### PR TITLE
Gate the UI on the ZoneMinder account's actual permissions

### DIFF
--- a/app/src/api/__tests__/client.test.ts
+++ b/app/src/api/__tests__/client.test.ts
@@ -297,6 +297,29 @@ describe('API Client', () => {
       expect(recoverFromAuthFailure).toHaveBeenCalledTimes(1);
       expect(vi.mocked(httpRequest)).toHaveBeenCalledTimes(1);
     });
+
+    // A permission refusal survives any number of fresh tokens, so refreshing
+    // one only spends two extra requests before failing anyway (refs #344).
+    it('does not refresh the token when ZoneMinder refused on privileges', async () => {
+      const recoverFromAuthFailure = vi.fn(async () => true);
+      const gates = mockGates({
+        auth: { isAuthenticated: () => true, recoverFromAuthFailure },
+      });
+
+      vi.mocked(httpRequest).mockRejectedValue({
+        status: 401,
+        statusText: 'Unauthorized',
+        message: 'Unauthorized',
+        data: { success: false, data: { name: 'Insufficient Privileges' } },
+      } as never);
+
+      const client = createApiClient('https://zm.example.com/api', gates);
+      await expect(client.postForm('/monitors/1.json', new URLSearchParams({ 'Monitor[MaxFPS]': '5' })))
+        .rejects.toMatchObject({ status: 401 });
+
+      expect(recoverFromAuthFailure).not.toHaveBeenCalled();
+      expect(vi.mocked(httpRequest)).toHaveBeenCalledTimes(1);
+    });
   });
 
   // End-to-end through the real auth store gates (api/store-gates.ts): the

--- a/app/src/api/__tests__/users.test.ts
+++ b/app/src/api/__tests__/users.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Reading the logged-in account's permissions off /users.json.
+ *
+ * The endpoint answers only for accounts with some system access, so the
+ * refusal is as much a result as the payload is.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createHttpError } from '../../lib/http/types';
+import { SYSTEM_NONE_PERMISSIONS, UNRESTRICTED_PERMISSIONS } from '../../lib/permissions/zm-permissions';
+import { fetchAccountPermissions } from '../users';
+import type { ApiClient } from '../client';
+
+/** One row as ZoneMinder 1.39 serializes it. */
+function row(username: string, overrides: Record<string, string> = {}) {
+  return {
+    User: {
+      Id: '2',
+      Username: username,
+      System: 'None',
+      Monitors: 'View',
+      Stream: 'View',
+      Events: 'View',
+      Control: 'None',
+      Groups: 'View',
+      ...overrides,
+    },
+  };
+}
+
+function clientReturning(data: unknown): ApiClient {
+  return { get: vi.fn().mockResolvedValue({ data }) } as unknown as ApiClient;
+}
+
+function clientRejecting(error: unknown): ApiClient {
+  return { get: vi.fn().mockRejectedValue(error) } as unknown as ApiClient;
+}
+
+const privilegeRefusal = createHttpError(
+  401,
+  'Unauthorized',
+  { success: false, data: { name: 'Insufficient Privileges' } },
+  {},
+);
+
+describe('fetchAccountPermissions', () => {
+  it('returns the columns of the row matching the username', async () => {
+    const client = clientReturning({
+      users: [row('admin', { System: 'Edit' }), row('viewer')],
+    });
+
+    await expect(fetchAccountPermissions(client, 'viewer')).resolves.toEqual({
+      system: 'None',
+      monitors: 'View',
+      stream: 'View',
+      events: 'View',
+      control: 'None',
+      groups: 'View',
+    });
+  });
+
+  it('matches the username case-insensitively', async () => {
+    const client = clientReturning({ users: [row('Admin', { System: 'Edit' })] });
+
+    await expect(fetchAccountPermissions(client, 'admin')).resolves.toMatchObject({ system: 'Edit' });
+  });
+
+  it('reports System None when the server refuses the list', async () => {
+    // UsersController gates on System() != 'None', so the refusal itself
+    // establishes the one column we could not read.
+    await expect(fetchAccountPermissions(clientRejecting(privilegeRefusal), 'viewer')).resolves.toEqual(
+      SYSTEM_NONE_PERMISSIONS,
+    );
+  });
+
+  it('treats a profile with no username as an unauthenticated server', async () => {
+    const client = clientReturning({ users: [] });
+
+    await expect(fetchAccountPermissions(client, undefined)).resolves.toEqual(UNRESTRICTED_PERMISSIONS);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('leaves a column unknown when ZoneMinder omits it', async () => {
+    const client = clientReturning({
+      users: [{ User: { Username: 'viewer', System: 'View' } }],
+    });
+
+    await expect(fetchAccountPermissions(client, 'viewer')).resolves.toEqual({
+      system: 'View',
+      monitors: undefined,
+      stream: undefined,
+      events: undefined,
+      control: undefined,
+      groups: undefined,
+    });
+  });
+
+  it('leaves System unknown when the value is not one ZoneMinder documents', async () => {
+    // Denying on a level we failed to parse would lock an administrator out of
+    // their own settings dialog.
+    const client = clientReturning({ users: [{ User: { Username: 'viewer', System: 'Superuser' } }] });
+
+    await expect(fetchAccountPermissions(client, 'viewer')).resolves.toMatchObject({ system: undefined });
+  });
+
+  it('gives up rather than guess when the account is not in the list', async () => {
+    // Reachable when ZoneMinder maps the token to a different name than the
+    // profile stores. Denying a surface on someone else's row would be worse
+    // than knowing nothing.
+    const client = clientReturning({ users: [row('someone-else')] });
+
+    await expect(fetchAccountPermissions(client, 'viewer')).resolves.toBeUndefined();
+  });
+
+  it('propagates a transport failure so the query can retry', async () => {
+    const offline = Object.assign(new Error('Failed to fetch'), { host: 'zm.local:443' });
+
+    await expect(fetchAccountPermissions(clientRejecting(offline), 'viewer')).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -2,6 +2,7 @@ import { httpRequest, type HttpError, type HttpOptions, type HttpResponse } from
 import { API_REQUEST } from '../lib/zmninja-ng-constants';
 import { log, LogLevel } from '../lib/logger';
 import { sanitizeObject } from '../lib/log-sanitizer';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
 
 export type ApiMethod = NonNullable<HttpOptions['method']>;
 
@@ -222,7 +223,18 @@ export function createApiClient(
       return response;
     } catch (error) {
       const httpError = error as HttpError;
-      if (httpError.status === 401 && !hasRetried && !skipAuth && !isLoginRequest) {
+      // ZoneMinder answers "you may not" and "log in again" with the same 401
+      // and separates them only in the body. Refreshing a token the server
+      // never objected to costs a refresh plus a retry and fails identically,
+      // so a privilege refusal skips recovery and reaches the caller intact
+      // (refs #344).
+      if (
+        httpError.status === 401 &&
+        !hasRetried &&
+        !skipAuth &&
+        !isLoginRequest &&
+        !isPermissionDenied(httpError)
+      ) {
         const recovered = await gates.auth.recoverFromAuthFailure(reLogin);
         if (recovered) {
           return request(method, url, data, config, true);

--- a/app/src/api/types.ts
+++ b/app/src/api/types.ts
@@ -537,6 +537,35 @@ export type ZMLog = z.infer<typeof ZMLogSchema>;
 export type ZMLogData = z.infer<typeof ZMLogDataSchema>;
 export type ZMLogsResponse = z.infer<typeof ZMLogsResponseSchema>;
 
+// User types
+//
+// Only `Username` is required: the permission columns are what this app came
+// for, but a ZoneMinder version that renames or drops one must degrade to
+// "unknown permission" rather than fail the whole response (refs #344).
+export const ZMUserSchema = z.object(
+  withFieldCatch({
+  Id: z.coerce.string().optional(),
+  Username: z.string(),
+  System: z.string().optional(),
+  Monitors: z.string().optional(),
+  Stream: z.string().optional(),
+  Events: z.string().optional(),
+  Control: z.string().optional(),
+  Groups: z.string().optional(),
+  }, ['Username']),
+);
+
+export const ZMUserDataSchema = z.object({
+  User: ZMUserSchema,
+});
+
+export const ZMUsersResponseSchema = z.object({
+  users: tolerantArray(ZMUserDataSchema, 'user').optional(),
+});
+
+export type ZMUser = z.infer<typeof ZMUserSchema>;
+export type ZMUsersResponse = z.infer<typeof ZMUsersResponseSchema>;
+
 // State types
 export const StateSchema = z.object(
   withFieldCatch({

--- a/app/src/api/users.ts
+++ b/app/src/api/users.ts
@@ -1,0 +1,74 @@
+/**
+ * Users API
+ *
+ * One call, for one purpose: finding out what the logged-in account may do.
+ * ZoneMinder has no endpoint for "my permissions", so the closest thing is the
+ * user list, which `UsersController` gates on `System() != 'None'`. An account
+ * with no system access gets a 401 - and that refusal is itself the answer to
+ * the only column it hides (refs #344).
+ */
+
+import type { ApiClient } from './client';
+import type { ZMUsersResponse } from './types';
+import { ZMUsersResponseSchema } from './types';
+import { validateApiResponse } from '../lib/zm/api-validator';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import {
+  parsePermissionLevel,
+  SYSTEM_NONE_PERMISSIONS,
+  UNRESTRICTED_PERMISSIONS,
+  type ZmPermissions,
+} from '../lib/permissions/zm-permissions';
+import { log, LogLevel } from '../lib/logger';
+
+/**
+ * Permissions for the account a profile logs in as.
+ *
+ * @param client - API client for the target profile
+ * @param username - The profile's username; absent means the server has
+ *   authentication turned off, where ZoneMinder allows everything
+ * @returns The account's columns, `SYSTEM_NONE_PERMISSIONS` when the server
+ *   refuses the list, or `undefined` when the list came back without a row for
+ *   this account. Transport failures reject so the caller can retry.
+ */
+export async function fetchAccountPermissions(
+  client: ApiClient,
+  username: string | undefined,
+): Promise<ZmPermissions | undefined> {
+  if (!username) return UNRESTRICTED_PERMISSIONS;
+
+  let response: ZMUsersResponse;
+  try {
+    const raw = await client.get<ZMUsersResponse>('/users.json', {
+      intent: 'Read account permissions',
+    });
+    response = validateApiResponse(ZMUsersResponseSchema, raw.data, {
+      endpoint: '/users.json',
+      method: 'GET',
+    });
+  } catch (error) {
+    if (isPermissionDenied(error)) {
+      log.api('Account has no system access; permissions beyond System are unknown', LogLevel.INFO);
+      return SYSTEM_NONE_PERMISSIONS;
+    }
+    throw error;
+  }
+
+  const wanted = username.toLowerCase();
+  const row = response.users?.find((entry) => entry.User.Username.toLowerCase() === wanted)?.User;
+  if (!row) {
+    // The token maps to a name the profile does not store. Better to know
+    // nothing than to gate this session on somebody else's row.
+    log.api('No users.json row matches this profile; permissions stay unknown', LogLevel.WARN);
+    return undefined;
+  }
+
+  return {
+    system: parsePermissionLevel(row.System),
+    monitors: parsePermissionLevel(row.Monitors),
+    stream: parsePermissionLevel(row.Stream),
+    events: parsePermissionLevel(row.Events),
+    control: parsePermissionLevel(row.Control),
+    groups: parsePermissionLevel(row.Groups),
+  };
+}

--- a/app/src/components/events/EventCard.tsx
+++ b/app/src/components/events/EventCard.tsx
@@ -27,6 +27,9 @@ import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { resolveOwnMonitorIds } from '../../hooks/useScopedEvents';
 import { queryKeys } from '../../lib/query/query-keys';
 import { setEventArchived } from '../../api/events';
+import { usePermissions } from '../../hooks/usePermissions';
+import { canEditEvents } from '../../lib/permissions/zm-permissions';
+import { useDeniedControl } from '../../hooks/useDeniedControl';
 import { getSession } from '../../services/sessions';
 import { log, LogLevel } from '../../lib/logger';
 import { TagChipList } from './TagChip';
@@ -104,6 +107,8 @@ function EventCardComponent({ event, monitorName, profileId, profileChip, thumbn
     }
   };
 
+  const { permissions } = usePermissions(ownerProfileId);
+
   const handleArchiveClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (isArchiving || !ownerProfileId) return;
@@ -123,6 +128,20 @@ function EventCardComponent({ event, monitorName, profileId, profileChip, thumbn
       setIsArchiving(false);
     }
   };
+
+  // Archiving needs Events: Edit. The control stays live and greyed so it can
+  // still say why it does nothing (refs #344).
+  const archiveProps = useDeniedControl({
+    denied: canEditEvents(permissions) === 'denied',
+    message: t('events.archive_permission_denied'),
+    onClick: handleArchiveClick,
+    title: isArchived ? t('events.unarchive') : t('events.archive'),
+    className: cn(
+      'p-1 rounded-full hover:bg-accent transition-colors',
+      'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+      'disabled:opacity-50 disabled:cursor-not-allowed'
+    ),
+  });
 
   return (
     <Card
@@ -223,15 +242,9 @@ function EventCardComponent({ event, monitorName, profileId, profileChip, thumbn
                   />
                 </HintButton>
                 <HintButton
-                  onClick={handleArchiveClick}
+                  {...archiveProps}
                   disabled={isArchiving}
-                  className={cn(
-                    "p-1 rounded-full hover:bg-accent transition-colors",
-                    "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-                    "disabled:opacity-50 disabled:cursor-not-allowed"
-                  )}
                   aria-label={isArchived ? t('events.unarchive') : t('events.archive')}
-                  title={isArchived ? t('events.unarchive') : t('events.archive')}
                   data-testid="event-archive-button"
                 >
                   <Archive

--- a/app/src/components/events/EventDeleteButton.tsx
+++ b/app/src/components/events/EventDeleteButton.tsx
@@ -9,6 +9,9 @@ import { cn } from '../../lib/utils';
 import { useDeleteSelectionStore, eventSelectionKey } from '../../stores/deleteSelection';
 import type { ProfileId } from '../../api/types';
 import { HintButton } from '../ui/button';
+import { usePermissions } from '../../hooks/usePermissions';
+import { canEditEvents } from '../../lib/permissions/zm-permissions';
+import { useDeniedControl } from '../../hooks/useDeniedControl';
 
 interface EventDeleteButtonProps {
   eventId: string;
@@ -26,21 +29,30 @@ export function EventDeleteButton({ eventId, profileId, size = 'md', className }
   const toggle = useDeleteSelectionStore((s) => s.toggle);
   const iconSize = size === 'sm' ? 'h-4 w-4' : 'h-4 w-4 sm:h-5 sm:w-5';
 
+  // Deleting needs Events: Edit. Greyed rather than hidden, so an
+  // administrator can see which permission their account is missing (refs #344).
+  const { permissions } = usePermissions(profileId);
+  const deniedProps = useDeniedControl({
+    denied: canEditEvents(permissions) === 'denied',
+    message: t('events.delete_permission_denied'),
+    onClick: (e) => {
+      e.stopPropagation();
+      toggle(selectionKey);
+    },
+    title: t('events.delete_toggle_aria'),
+    className: cn(
+      'p-1 rounded transition-colors',
+      'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+      className
+    ),
+  });
+
   return (
     <HintButton
       type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        toggle(selectionKey);
-      }}
-      className={cn(
-        'p-1 rounded transition-colors',
-        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        className
-      )}
+      {...deniedProps}
       aria-label={t('events.delete_toggle_aria')}
       aria-pressed={selected}
-      title={t('events.delete_toggle_aria')}
       data-testid="event-delete-button"
     >
       <Trash2

--- a/app/src/components/events/__tests__/CompactEventRow.test.tsx
+++ b/app/src/components/events/__tests__/CompactEventRow.test.tsx
@@ -8,6 +8,12 @@ import { asProfileId } from '../../../api/types';
 import { useProfileStore } from '../../../stores/profile';
 
 const navigate = vi.fn();
+// EventDeleteButton probes permissions through React Query; this suite renders
+// without a provider and is not about permissions (refs #344).
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: { events: 'Edit' }, isLoading: false }),
+}));
+
 vi.mock('react-router-dom', async (orig) => ({
   ...(await orig<typeof import('react-router-dom')>()),
   useNavigate: () => navigate,

--- a/app/src/components/events/__tests__/EventCard.test.tsx
+++ b/app/src/components/events/__tests__/EventCard.test.tsx
@@ -11,6 +11,15 @@ function renderWithClient(ui: ReactElement) {
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
 }
 
+// Permission probe (refs #344); tests set the verdict they need.
+let mockEventsPermission: string | undefined;
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    permissions: mockEventsPermission === undefined ? undefined : { events: mockEventsPermission },
+    isLoading: false,
+  }),
+}));
+
 vi.mock('react-router-dom', () => ({
   useNavigate: () => navigate,
 }));
@@ -303,5 +312,40 @@ describe('EventCard', () => {
     const start = `${old.getFullYear()}-${pad(old.getMonth() + 1)}-${pad(old.getDate())} ${pad(old.getHours())}:${pad(old.getMinutes())}:${pad(old.getSeconds())}`;
     renderEventCard({ StartDateTime: start });
     expect(screen.queryByTestId('event-relative-time')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Archiving needs Events: Edit (refs #344).
+ *
+ * One greyed button per card, not one note per card: the explanation belongs on
+ * the control that stopped working, and a note repeated down a scrolling list
+ * would be noise.
+ */
+describe('EventCard without permission to archive', () => {
+  beforeEach(() => {
+    mockEventsPermission = undefined;
+  });
+
+  it('greys the archive control when ZoneMinder denies editing', () => {
+    mockEventsPermission = 'View';
+
+    renderEventCard({});
+
+    expect(screen.getByTestId('event-archive-button')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('leaves it alone at Edit', () => {
+    mockEventsPermission = 'Edit';
+
+    renderEventCard({});
+
+    expect(screen.getByTestId('event-archive-button')).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('leaves it alone while the permission is unknown', () => {
+    renderEventCard({});
+
+    expect(screen.getByTestId('event-archive-button')).not.toHaveAttribute('aria-disabled');
   });
 });

--- a/app/src/components/events/__tests__/EventDeleteButton.test.tsx
+++ b/app/src/components/events/__tests__/EventDeleteButton.test.tsx
@@ -5,6 +5,17 @@ import { EventDeleteButton } from '../EventDeleteButton';
 import { useDeleteSelectionStore, eventSelectionKey } from '../../../stores/deleteSelection';
 import { asProfileId } from '../../../api/types';
 
+// Permission probe (refs #344); tests set the verdict they need.
+let mockEventsPermission: string | undefined;
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    permissions: mockEventsPermission === undefined ? undefined : { events: mockEventsPermission },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }));
+
 const P1 = asProfileId('p1');
 const P2 = asProfileId('p2');
 
@@ -48,5 +59,48 @@ describe('EventDeleteButton', () => {
     expect(first.getAttribute('aria-pressed')).toBe('true');
     expect(second.getAttribute('aria-pressed')).toBe('false');
     expect(useDeleteSelectionStore.getState().selectedKeys).toEqual([eventSelectionKey(P1, '1234')]);
+  });
+});
+
+/**
+ * Queueing an event for deletion needs Events: Edit (refs #344).
+ *
+ * Greying beats hiding here: the button is what tells an administrator their
+ * account is short a permission. It must still explain itself, which is why it
+ * is aria-disabled rather than disabled - a disabled button would receive no
+ * click and show no hint.
+ */
+describe('EventDeleteButton without permission to delete', () => {
+  beforeEach(() => {
+    mockEventsPermission = undefined;
+    useDeleteSelectionStore.getState().clear();
+  });
+
+  it('greys the control and refuses to queue the event', () => {
+    mockEventsPermission = 'View';
+
+    render(<EventDeleteButton eventId="42" profileId={P1} />);
+    const button = screen.getByTestId('event-delete-button');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(button);
+
+    expect(useDeleteSelectionStore.getState().selectedKeys).toEqual([]);
+  });
+
+  it('still queues when the account may delete', () => {
+    mockEventsPermission = 'Edit';
+
+    render(<EventDeleteButton eventId="42" profileId={P1} />);
+    fireEvent.click(screen.getByTestId('event-delete-button'));
+
+    expect(useDeleteSelectionStore.getState().selectedKeys).toEqual([eventSelectionKey(P1, '42')]);
+  });
+
+  it('still queues while the permission is unknown', () => {
+    render(<EventDeleteButton eventId="42" profileId={P1} />);
+    fireEvent.click(screen.getByTestId('event-delete-button'));
+
+    expect(useDeleteSelectionStore.getState().selectedKeys).toEqual([eventSelectionKey(P1, '42')]);
   });
 });

--- a/app/src/components/layout/SidebarContent.tsx
+++ b/app/src/components/layout/SidebarContent.tsx
@@ -9,6 +9,8 @@ import { useProfileStore } from '../../stores/profile';
 import { useNotificationStore } from '../../stores/notifications';
 import { useSettingsStore } from '../../stores/settings';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
+import { usePermissions } from '../../hooks/usePermissions';
+import { canViewSystem } from '../../lib/permissions/zm-permissions';
 import { Button } from '../ui/button';
 import { ModeToggle } from '../mode-toggle';
 import { ProfileSwitcher } from '../profile-switcher';
@@ -75,6 +77,8 @@ export function SidebarContent({ onMobileClose, isCollapsed }: SidebarContentPro
   // null. Their write target is currentProfileId, the same key that bucket
   // lives under, whichever aggregate it names (refs #337).
   const { currentProfile, settings: profileSettings } = useCurrentProfile();
+  const { permissions } = usePermissions(currentProfile?.id);
+  const logsDenied = canViewSystem(permissions) === 'denied';
   const currentProfileId = useProfileStore((state) => state.currentProfileId);
   const connectionState = useNotificationStore((state) => state.connections[currentProfile?.id ?? ''] ?? 'disconnected');
   const getProfileSettings = useNotificationStore((state) => state.getProfileSettings);
@@ -114,7 +118,12 @@ export function SidebarContent({ onMobileClose, isCollapsed }: SidebarContentPro
     { path: '/profiles', label: t('sidebar.profiles'), icon: Users },
     { path: '/settings', label: t('sidebar.settings'), icon: Settings },
     { path: '/server', label: t('sidebar.server'), icon: Server },
-    { path: '/logs', label: t('sidebar.logs'), icon: FileText },
+    // logs.json refuses an account below System View outright, so the entry
+    // would only ever lead to a permission error. Nothing to explain in a nav
+    // item, so it goes rather than greys (refs #344).
+    ...(logsDenied
+      ? []
+      : [{ path: '/logs', label: t('sidebar.logs'), icon: FileText }]),
     // The developer-notice entry hides entirely when notices are turned off.
     ...(showDeveloperNotices
       ? [{ path: '/developer-notice', label: t('sidebar.developer_notice'), icon: Megaphone }]
@@ -132,8 +141,11 @@ export function SidebarContent({ onMobileClose, isCollapsed }: SidebarContentPro
     });
     // `defaultNavItems` is rebuilt every render; `t` covers label refresh on language change.
     // `showDeveloperNotices` gates whether the developer-notice item is present.
+    // `logsDenied` does the same for Logs, and arrives after the permission
+    // probe settles - without it here the entry would linger until the next
+    // unrelated re-render (refs #344).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [savedOrder, t, showDeveloperNotices]);
+  }, [savedOrder, t, showDeveloperNotices, logsDenied]);
 
   const [isReordering, setIsReordering] = useState(false);
   const [dragIndex, setDragIndex] = useState<number | null>(null);

--- a/app/src/components/layout/__tests__/SidebarContent-all-mode.test.tsx
+++ b/app/src/components/layout/__tests__/SidebarContent-all-mode.test.tsx
@@ -16,6 +16,12 @@ import { useDeveloperNoticeStore } from '../../../stores/developerNotices';
 import { ALL_PROFILES_ID, asProfileId } from '../../../api/types';
 import type { Profile } from '../../../api/types';
 
+// The permission probe is a React Query call; these suites render without a
+// provider and are not about permissions (refs #344).
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: undefined, isLoading: false }),
+}));
+
 vi.mock('../../../../assets/logo.png', () => ({ default: 'logo.png' }));
 
 vi.mock('../../../hooks/useDeveloperNotices', () => ({

--- a/app/src/components/layout/__tests__/SidebarContent-developer-notice.test.tsx
+++ b/app/src/components/layout/__tests__/SidebarContent-developer-notice.test.tsx
@@ -5,6 +5,12 @@ import { SidebarContent } from '../SidebarContent';
 import { useDeveloperNoticeStore } from '../../../stores/developerNotices';
 
 // The logo is a png asset; give it a stub so the import resolves in jsdom.
+// The permission probe is a React Query call; these suites render without a
+// provider and are not about permissions (refs #344).
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: undefined, isLoading: false }),
+}));
+
 vi.mock('../../../../assets/logo.png', () => ({ default: 'logo.png' }));
 
 // Side-effecting hooks the sidebar pulls in; stub them to keep the render pure.

--- a/app/src/components/monitor-detail/MonitorRestrictedSettings.tsx
+++ b/app/src/components/monitor-detail/MonitorRestrictedSettings.tsx
@@ -47,7 +47,11 @@ export function MonitorRestrictedSettings({
   const isControllable = monitor.Controllable === '1' || monitor.Controllable === 'true';
 
   return (
-    <div className="mt-2 overflow-y-auto" data-testid="monitor-settings-readonly">
+    // px-1 -mx-1: a scroll container computes overflow-x to auto, and the
+    // switches sit flush right with a 4px focus ring outside their own box.
+    // The padding reserves room for it; the negative margin keeps the rows
+    // aligned where they were.
+    <div className="mt-2 overflow-y-auto px-1 -mx-1" data-testid="monitor-settings-readonly">
       <MonitorAppPreferences monitor={monitor} profileId={profileId} />
 
       {onCycleSecondsChange && cycleSeconds !== undefined && (

--- a/app/src/components/monitor-detail/MonitorRestrictedSettings.tsx
+++ b/app/src/components/monitor-detail/MonitorRestrictedSettings.tsx
@@ -1,0 +1,105 @@
+/**
+ * The settings dialog for an account that may not edit ZoneMinder fields.
+ *
+ * The gear stays on screen because most of what is behind it was never a
+ * ZoneMinder field: force-ZMS, the per-monitor Go2RTC override, and the cycle
+ * interval are app-local preferences, and they are exactly the knobs a
+ * restricted user reaches for when a stream will not play. What goes away is
+ * every writable ZM field, and with it the camera's address, username and
+ * password - which ZoneMinder hands to any account that can view the monitor,
+ * unstripped (refs #344).
+ *
+ * The read-only rows that survive are the ones a viewer is entitled to and can
+ * act on. Control address is not among them: it is another camera address, and
+ * of no use to someone who cannot change it.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Badge } from '../ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { SettingsRow } from './SettingsRow';
+import { MonitorAppPreferences } from './MonitorAppPreferences';
+import type { Monitor, ProfileId } from '../../api/types';
+
+/** Why the ZoneMinder fields are absent. Decides which note is shown. */
+export type RestrictedReason = 'account' | 'monitor';
+
+interface MonitorRestrictedSettingsProps {
+  monitor: Monitor;
+  profileId?: ProfileId;
+  reason: RestrictedReason;
+  cycleSeconds?: number;
+  onCycleSecondsChange?: (value: string) => void;
+  orientedResolution?: string;
+  monitorNames?: Record<string, string>;
+}
+
+export function MonitorRestrictedSettings({
+  monitor,
+  profileId,
+  reason,
+  cycleSeconds,
+  onCycleSecondsChange,
+  orientedResolution,
+  monitorNames,
+}: MonitorRestrictedSettingsProps) {
+  const { t } = useTranslation();
+  const isControllable = monitor.Controllable === '1' || monitor.Controllable === 'true';
+
+  return (
+    <div className="mt-2 overflow-y-auto" data-testid="monitor-settings-readonly">
+      <MonitorAppPreferences monitor={monitor} profileId={profileId} />
+
+      {onCycleSecondsChange && cycleSeconds !== undefined && (
+        <SettingsRow label={t('monitor_detail.cycle_label')} testId="settings-cycle-row" editable>
+          <Select value={String(cycleSeconds)} onValueChange={onCycleSecondsChange}>
+            <SelectTrigger className="w-32 h-8" data-testid="monitor-detail-cycle-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="0">{t('monitor_detail.cycle_off')}</SelectItem>
+              <SelectItem value="5">{t('monitor_detail.cycle_seconds', { seconds: 5 })}</SelectItem>
+              <SelectItem value="10">{t('monitor_detail.cycle_seconds', { seconds: 10 })}</SelectItem>
+              <SelectItem value="15">{t('monitor_detail.cycle_seconds', { seconds: 15 })}</SelectItem>
+              <SelectItem value="30">{t('monitor_detail.cycle_seconds', { seconds: 30 })}</SelectItem>
+              <SelectItem value="60">{t('monitor_detail.cycle_seconds', { seconds: 60 })}</SelectItem>
+            </SelectContent>
+          </Select>
+        </SettingsRow>
+      )}
+
+      <SettingsRow label={t('monitors.resolution')}>
+        {orientedResolution ?? `${monitor.Width}x${monitor.Height}`}
+      </SettingsRow>
+
+      <SettingsRow label={t('monitors.colours')}>{monitor.Colours}</SettingsRow>
+
+      <SettingsRow label={t('monitors.controllable')}>
+        <Badge variant={isControllable ? 'secondary' : 'outline'}>
+          {isControllable ? t('common.yes') : t('common.no')}
+        </Badge>
+      </SettingsRow>
+
+      {monitor.LinkedMonitors && (
+        <SettingsRow label={t('monitor_detail.linked_monitors')} testId="settings-linked-monitors">
+          <span className="text-xs">
+            {monitor.LinkedMonitors.split(',')
+              .map((id) => monitorNames?.[id.trim()] ?? `#${id.trim()}`)
+              .join(', ')}
+          </span>
+        </SettingsRow>
+      )}
+
+      {/* Muted, not a warning: a correctly restricted account is not an error
+          state, and colouring it like one makes the app look broken. */}
+      <p
+        className="pt-4 text-xs text-muted-foreground"
+        data-testid="monitor-settings-restricted-note"
+      >
+        {reason === 'monitor'
+          ? t('monitor_detail.settings_restricted_monitor')
+          : t('monitor_detail.settings_restricted_account')}
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/monitor-detail/MonitorSettingsDialog.tsx
+++ b/app/src/components/monitor-detail/MonitorSettingsDialog.tsx
@@ -210,7 +210,7 @@ export function MonitorSettingsDialog({
           </TabsList>
 
           {/* Tab: Capture & Recording */}
-          <TabsContent value="capture" className="mt-4 space-y-0 overflow-y-auto">
+          <TabsContent value="capture" className="mt-4 space-y-0 overflow-y-auto px-1 -mx-1">
             {is138Plus ? (
               <>
                 <SettingsRow label={t('monitor_detail.capturing_label')} testId="settings-capturing-row" editable>
@@ -365,7 +365,7 @@ export function MonitorSettingsDialog({
           </TabsContent>
 
           {/* Tab: Video */}
-          <TabsContent value="video" className="mt-4 space-y-0 overflow-y-auto">
+          <TabsContent value="video" className="mt-4 space-y-0 overflow-y-auto px-1 -mx-1">
             {/* App-local per-monitor preferences. Applied on toggle, never part
                 of the ZM save payload below. */}
             <MonitorAppPreferences monitor={monitor} profileId={profileId} />

--- a/app/src/components/monitor-detail/MonitorSettingsDialog.tsx
+++ b/app/src/components/monitor-detail/MonitorSettingsDialog.tsx
@@ -25,6 +25,7 @@ import { useSettingsStore } from '../../stores/settings';
 import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { SettingsRow } from './SettingsRow';
 import { MonitorAppPreferences } from './MonitorAppPreferences';
+import { MonitorRestrictedSettings, type RestrictedReason } from './MonitorRestrictedSettings';
 
 interface MonitorSettingsDialogProps {
   open: boolean;
@@ -44,6 +45,11 @@ interface MonitorSettingsDialogProps {
   monitorNames?: Record<string, string>;
   /** Owning profile for an /all/ deep route or All-mode monitor grid; defaults to the current profile. */
   profileId?: ProfileId;
+  /**
+   * Why `onSave` is absent, when it is absent because ZoneMinder said no
+   * rather than because the caller never offered saving (refs #344).
+   */
+  restrictedReason?: RestrictedReason;
 }
 
 export function MonitorSettingsDialog({
@@ -58,6 +64,7 @@ export function MonitorSettingsDialog({
   orientedResolution,
   monitorNames,
   profileId,
+  restrictedReason = 'account',
 }: MonitorSettingsDialogProps) {
   const { t } = useTranslation();
   const editable = !!onSave;
@@ -181,6 +188,17 @@ export function MonitorSettingsDialog({
           </DialogDescription>
         </DialogHeader>
 
+        {!editable ? (
+          <MonitorRestrictedSettings
+            monitor={monitor}
+            profileId={profileId}
+            reason={restrictedReason}
+            cycleSeconds={cycleSeconds}
+            onCycleSecondsChange={onCycleSecondsChange}
+            orientedResolution={orientedResolution}
+            monitorNames={monitorNames}
+          />
+        ) : (
         <Tabs defaultValue="video" className="mt-2 flex flex-col min-h-0 flex-1">
           <TabsList className="w-full shrink-0">
             <TabsTrigger value="video" className="flex-1" data-testid="settings-tab-video">
@@ -533,6 +551,7 @@ export function MonitorSettingsDialog({
             )}
           </TabsContent>
         </Tabs>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/src/components/monitor-detail/__tests__/MonitorSettingsDialog.test.tsx
+++ b/app/src/components/monitor-detail/__tests__/MonitorSettingsDialog.test.tsx
@@ -359,3 +359,92 @@ describe('MonitorSettingsDialog owning-profile scoping (refs #337)', () => {
     });
   });
 });
+
+/**
+ * The restricted dialog (refs #344).
+ *
+ * A ZoneMinder account without System Edit gets no editor. The gear stays,
+ * because the app-local preferences behind it - force-ZMS, per-monitor Go2RTC,
+ * cycle - are the stream troubleshooting knobs a restricted user most needs,
+ * and they are not ZoneMinder fields at all. What goes away is every ZM field,
+ * and with it the camera's address and password.
+ */
+describe('MonitorSettingsDialog without permission to edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    disableLogRedaction = false;
+    forceZmsMonitorIds = [];
+    profileSettingsById = {};
+  });
+
+  const credentialed = {
+    ...baseMonitor,
+    Path: 'rtsp://192.168.1.10:554/h264',
+    User: 'admin',
+    Pass: 'hunter2',
+  } as unknown as Monitor;
+
+  function renderRestricted(props: Record<string, unknown> = {}) {
+    return render(
+      <MonitorSettingsDialog
+        open
+        onOpenChange={vi.fn()}
+        monitor={credentialed}
+        zmVersion="1.38.0"
+        profileId={asProfileId('p1')}
+        {...props}
+      />
+    );
+  }
+
+  it('shows no camera address, username, or password', () => {
+    renderRestricted();
+
+    expect(screen.queryByTestId('settings-source-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('settings-username-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('settings-password-row')).not.toBeInTheDocument();
+    // The password must not reach the DOM at all, masked or otherwise.
+    expect(document.body.innerHTML).not.toContain('hunter2');
+    expect(document.body.innerHTML).not.toContain('192.168.1.10');
+  });
+
+  it('offers no way to write a ZoneMinder field', () => {
+    renderRestricted();
+
+    expect(screen.queryByTestId('settings-video-save-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('settings-save-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('settings-capturing-select')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('settings-orientation-select')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('settings-event-start-cmd-row')).not.toBeInTheDocument();
+  });
+
+  it('keeps the app-local preferences usable', () => {
+    renderRestricted();
+
+    expect(screen.getByTestId('settings-monitor-force-zms-switch')).toBeInTheDocument();
+  });
+
+  it('keeps the read-only facts a viewer is entitled to', () => {
+    renderRestricted({ orientedResolution: '640x480' });
+
+    expect(screen.getByTestId('monitor-settings-readonly')).toHaveTextContent('640x480');
+  });
+
+  it('says why the fields are gone, naming the ZoneMinder permission', () => {
+    renderRestricted();
+
+    expect(screen.getByTestId('monitor-settings-restricted-note')).toHaveTextContent(
+      'monitor_detail.settings_restricted_account'
+    );
+  });
+
+  it('names the monitor, not the account, when ZoneMinder refused this one monitor', () => {
+    // Per-monitor permission rows override the account columns and are not in
+    // the API, so an account with System Edit can still be refused here.
+    renderRestricted({ restrictedReason: 'monitor' });
+
+    expect(screen.getByTestId('monitor-settings-restricted-note')).toHaveTextContent(
+      'monitor_detail.settings_restricted_monitor'
+    );
+  });
+});

--- a/app/src/components/monitors/LiveMonitorPlayer.tsx
+++ b/app/src/components/monitors/LiveMonitorPlayer.tsx
@@ -33,7 +33,9 @@ import {
   GO2RTC_RETRY_INTERVAL_MIN,
 } from '../../lib/zmninja-ng-constants';
 import { Button } from '../ui/button';
-import { VideoOff } from 'lucide-react';
+import { VideoOff, ShieldOff } from 'lucide-react';
+import { usePermissions } from '../../hooks/usePermissions';
+import { canViewStream } from '../../lib/permissions/zm-permissions';
 
 /**
  * Cache of monitors where Go2RTC failed: skip straight to MJPEG until TTL
@@ -189,6 +191,13 @@ export function LiveMonitorPlayer({
   const monitorOverride = rawSettings?.monitorStreamingOverrides?.[monitor.Id];
   const userStreamingPreference = monitorOverride ?? globalStreamingMethod;
 
+  // Streaming is a ZoneMinder permission of its own: zms.cpp checks Stream for
+  // a live monitor, independently of Monitors. Denied, the stream is an image
+  // that never loads - there is no failing request to catch - so the probe is
+  // the only thing that can tell the user why (refs #344).
+  const { permissions: accountPermissions } = usePermissions(profileId ?? profile?.id);
+  const streamDenied = canViewStream(accountPermissions) === 'denied';
+
   // Determine streaming method: WebRTC if supported and enabled, otherwise MJPEG
   const lastLoggedRef = useRef<string>('');
   const streamingMethod = useMemo(() => {
@@ -282,7 +291,7 @@ export function LiveMonitorPlayer({
     containerRef,
     protocols: rawSettings?.webrtcProtocols,
     expectedHost: portalHost,
-    enabled: streamingMethod === 'webrtc' && !!profile?.go2rtcUrl && !go2rtcFailed && !paused,
+    enabled: streamingMethod === 'webrtc' && !!profile?.go2rtcUrl && !go2rtcFailed && !paused && !streamDenied,
     muted,
     controls: showControls,
     useStun: rawSettings?.webrtcUseStun ?? false,
@@ -514,7 +523,7 @@ export function LiveMonitorPlayer({
       { maxfps: rawSettings?.streamMaxFps, scale: rawSettings?.streamScale },
       reduceStream,
     ),
-    enabled: (effectiveStreamingMethod === 'mjpeg' || showMjpegPlaceholder) && !paused,
+    enabled: (effectiveStreamingMethod === 'mjpeg' || showMjpegPlaceholder) && !paused && !streamDenied,
     viewModeOverride: forceViewMode,
     profileId,
   });
@@ -659,6 +668,18 @@ export function LiveMonitorPlayer({
     hasVideoFrames: hasLiveVideoFrames,
     hasMjpegFrame,
   });
+
+  if (streamDenied) {
+    return (
+      <div
+        className="relative w-full h-full flex flex-col items-center justify-center gap-2 bg-muted/30 p-3 text-center"
+        data-testid="video-player-no-permission"
+      >
+        <ShieldOff className="h-8 w-8 text-muted-foreground/40" aria-hidden="true" />
+        <p className="text-xs text-muted-foreground">{t('monitors.stream_permission_denied')}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="relative w-full h-full" data-testid="video-player">

--- a/app/src/components/monitors/PTZControls.tsx
+++ b/app/src/components/monitors/PTZControls.tsx
@@ -3,11 +3,19 @@ import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight, ZoomIn, ZoomOut, Home, Squar
 import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
 import { useTranslation } from 'react-i18next';
-import type { ZMControl } from '../../api/types';
+import type { ProfileId, ZMControl } from '../../api/types';
+import { usePermissions } from '../../hooks/usePermissions';
+import { canUseControl } from '../../lib/permissions/zm-permissions';
+import { useCurrentProfile } from '../../hooks/useCurrentProfile';
 import { UI_INTERACTIONS } from '../../lib/zmninja-ng-constants';
 
 interface PTZControlsProps {
   onCommand: (command: string) => void;
+  /**
+   * Profile whose ZoneMinder account these commands run as. Defaults to the
+   * current profile; an All-mode caller must pass the monitor's owner.
+   */
+  profileId?: ProfileId | null;
   className?: string;
   disabled?: boolean;
   control?: ZMControl;
@@ -127,8 +135,15 @@ function HoldButton({
   );
 }
 
-export function PTZControls({ onCommand, className, disabled, control }: PTZControlsProps) {
+export function PTZControls({ onCommand, profileId, className, disabled, control }: PTZControlsProps) {
   const { t } = useTranslation();
+
+  // Controllable is what the camera can do; Control is what this account may
+  // ask of it. ZoneMinder checks the second in ajax/control.php, so a denied
+  // account gets no pad rather than buttons that always fail (refs #344).
+  const { currentProfile } = useCurrentProfile();
+  const { permissions } = usePermissions(profileId ?? currentProfile?.id);
+  const controlDenied = canUseControl(permissions) === 'denied';
 
   const canMove = control?.CanMove === '1';
   const canMoveDiag = control?.CanMoveDiag === '1';
@@ -161,6 +176,8 @@ export function PTZControls({ onCommand, className, disabled, control }: PTZCont
 
   const moveModeKey = canMoveCon ? 'ptz.mode_continuous' : (canMoveRel ? 'ptz.mode_relative' : (canMoveAbs ? 'ptz.mode_absolute' : null));
   const zoomModeKey = canZoomCon ? 'ptz.mode_continuous' : (canZoomRel ? 'ptz.mode_relative' : (canZoomAbs ? 'ptz.mode_absolute' : null));
+
+  if (controlDenied) return null;
 
   return (
     <div className={cn("flex flex-col items-center gap-4 p-4 bg-card/50 rounded-xl border shadow-sm backdrop-blur-sm", className)} data-testid="ptz-controls">

--- a/app/src/components/monitors/__tests__/LiveMonitorPlayer.test.tsx
+++ b/app/src/components/monitors/__tests__/LiveMonitorPlayer.test.tsx
@@ -83,6 +83,15 @@ vi.mock('../../../lib/logger', () => ({
 // are set; every other read is optional-chained in the player.
 let mockSettings: { streamMaxFps?: number; streamScale?: number } | undefined;
 
+// Permission probe (refs #344). Individual tests override the verdict.
+let mockStreamPermission: string | undefined;
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    permissions: mockStreamPermission === undefined ? undefined : { stream: mockStreamPermission },
+    isLoading: false,
+  }),
+}));
+
 vi.mock('../../../stores/settings', () => ({
   useSettingsStore: () => mockSettings,
 }));
@@ -458,5 +467,68 @@ describe('LiveMonitorPlayer paused WebRTC frames', () => {
     // start the freeze watchdog against a stream that has not connected yet,
     // and its retries would fire before the first frame could arrive.
     expect(isShowingPlaceholder()).toBe(true);
+  });
+});
+
+/**
+ * Streaming is its own ZoneMinder permission (refs #344).
+ *
+ * `zms.cpp` checks Stream for a live monitor, independently of Monitors. An
+ * account with Monitors View and Stream None sees every camera listed and gets
+ * a stream that 403s - and because a denied stream is just an image that never
+ * loads, no failing request exists for the app to notice. Without the probe
+ * this is a permanently broken tile with no explanation.
+ */
+describe('LiveMonitorPlayer without streaming permission', () => {
+  beforeEach(() => {
+    mockStreamPermission = undefined;
+    mockMjpegReturn = {
+      streamUrl: 'https://t/stream?connkey=1',
+      imageSrc: 'https://t/stream?connkey=1',
+      imgRef: { current: null },
+      regenerateConnection: vi.fn(),
+      reportStreamError: vi.fn(),
+      reportStreamLoad: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    mockStreamPermission = undefined;
+  });
+
+  it('explains the refusal instead of showing a tile that can never load', () => {
+    mockStreamPermission = 'None';
+
+    render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(screen.getByTestId('video-player-no-permission')).toBeInTheDocument();
+    expect(screen.queryByTestId('video-player-mjpeg')).not.toBeInTheDocument();
+  });
+
+  it('does not ask ZoneMinder for a stream it will refuse', () => {
+    mockStreamPermission = 'None';
+    streamCalls.length = 0;
+
+    render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(streamCalls.every((call) => call.enabled === false)).toBe(true);
+  });
+
+  it('streams normally when the account may stream', () => {
+    mockStreamPermission = 'View';
+
+    render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(screen.queryByTestId('video-player-no-permission')).not.toBeInTheDocument();
+    expect(screen.getByTestId('video-player-mjpeg')).toBeInTheDocument();
+  });
+
+  it('streams while the permission is still unknown', () => {
+    // Unknown must never withhold video: an account that can stream would lose
+    // it for no reason.
+    render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(screen.queryByTestId('video-player-no-permission')).not.toBeInTheDocument();
+    expect(screen.getByTestId('video-player-mjpeg')).toBeInTheDocument();
   });
 });

--- a/app/src/components/monitors/__tests__/PTZControls.test.tsx
+++ b/app/src/components/monitors/__tests__/PTZControls.test.tsx
@@ -10,6 +10,15 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+// Permission probe (refs #344). Tests set the verdict they need.
+let mockControlPermission: string | undefined;
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    permissions: mockControlPermission === undefined ? undefined : { control: mockControlPermission },
+    isLoading: false,
+  }),
+}));
+
 // jsdom does not implement pointer capture; the pointerdown handler calls it.
 beforeEach(() => {
   HTMLElement.prototype.setPointerCapture = vi.fn();
@@ -123,5 +132,43 @@ describe('PTZControls hold button', () => {
 
     vi.advanceTimersByTime(UI_INTERACTIONS.ptzHoldRepeatMs * 5);
     expect(onCommand).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * PTZ needs its own ZoneMinder permission (refs #344).
+ *
+ * `ajax/control.php` gates on canView('Control', id): a camera being
+ * controllable is a property of the hardware, and Control is the user's right
+ * to use it. Those are different questions, and only the second one decides
+ * whether these buttons can do anything.
+ */
+describe('PTZControls without control permission', () => {
+  const control = { CanMove: '1', CanMoveCon: '1', CanZoom: '1' } as unknown as ZMControl;
+
+  afterEach(() => {
+    mockControlPermission = undefined;
+  });
+
+  it('renders nothing when ZoneMinder denies control', () => {
+    mockControlPermission = 'None';
+
+    render(<PTZControls onCommand={vi.fn()} control={control} />);
+
+    expect(screen.queryByTestId('ptz-controls')).not.toBeInTheDocument();
+  });
+
+  it('renders at View, which is all ZoneMinder asks for', () => {
+    mockControlPermission = 'View';
+
+    render(<PTZControls onCommand={vi.fn()} control={control} />);
+
+    expect(screen.getByTestId('ptz-controls')).toBeInTheDocument();
+  });
+
+  it('renders while the permission is unknown', () => {
+    render(<PTZControls onCommand={vi.fn()} control={control} />);
+
+    expect(screen.getByTestId('ptz-controls')).toBeInTheDocument();
   });
 });

--- a/app/src/components/settings/AccountPermissionsCard.tsx
+++ b/app/src/components/settings/AccountPermissionsCard.tsx
@@ -1,0 +1,82 @@
+/**
+ * What this ZoneMinder account may do, in one place.
+ *
+ * The rest of the app explains a refusal where it happens - a greyed button,
+ * a read-only dialog - and deliberately keeps those to one short sentence
+ * each. This is where the whole picture lives, so those sentences do not have
+ * to grow into a lecture, and so a hidden nav entry has somewhere to be
+ * accounted for (refs #344).
+ *
+ * "Not determined" is a real answer, not a failure: ZoneMinder only lets an
+ * account read its own permissions at System View or above, so an account with
+ * less than that can be told what the app knows, which is that it has no
+ * system access and nothing more.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { ShieldCheck } from 'lucide-react';
+import type { ProfileId } from '../../api/types';
+import { usePermissions } from '../../hooks/usePermissions';
+import type { ZmPermissionLevel, ZmPermissions } from '../../lib/permissions/zm-permissions';
+
+interface AccountPermissionsCardProps {
+  profileId: ProfileId | null | undefined;
+}
+
+/** The columns worth showing, in the order a ZoneMinder admin screen lists them. */
+const COLUMNS: Array<{ key: keyof ZmPermissions; labelKey: string }> = [
+  { key: 'system', labelKey: 'server.permission_system' },
+  { key: 'monitors', labelKey: 'server.permission_monitors' },
+  { key: 'stream', labelKey: 'server.permission_stream' },
+  { key: 'events', labelKey: 'server.permission_events' },
+  { key: 'control', labelKey: 'server.permission_control' },
+  { key: 'groups', labelKey: 'server.permission_groups' },
+];
+
+/** `None` is the one level worth calling out; the rest are unremarkable. */
+function levelVariant(level: ZmPermissionLevel | undefined) {
+  if (level === undefined) return 'outline' as const;
+  return level === 'None' ? 'outline' as const : 'secondary' as const;
+}
+
+export function AccountPermissionsCard({ profileId }: AccountPermissionsCardProps) {
+  const { t } = useTranslation();
+  const { permissions, isLoading } = usePermissions(profileId);
+
+  if (isLoading || !permissions) return null;
+
+  return (
+    <Card data-testid="account-permissions-card">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5" />
+          <CardTitle>{t('server.permissions_title')}</CardTitle>
+        </div>
+        <CardDescription>{t('server.permissions_desc')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {COLUMNS.map(({ key, labelKey }) => {
+            const level = permissions[key];
+            return (
+              <div
+                key={key}
+                className="flex items-center justify-between gap-2 border-b border-border/40 py-1.5 last:border-0"
+                data-testid={`account-permission-${key}`}
+              >
+                <span className="min-w-0 truncate text-sm text-muted-foreground" title={t(labelKey)}>
+                  {t(labelKey)}
+                </span>
+                <Badge variant={levelVariant(level)} className="whitespace-nowrap">
+                  {level ?? t('server.permission_unknown')}
+                </Badge>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/components/settings/__tests__/AccountPermissionsCard.test.tsx
+++ b/app/src/components/settings/__tests__/AccountPermissionsCard.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * The one place that shows the whole permission picture.
+ *
+ * Every other surface explains its own refusal in a sentence; this card is
+ * where a user goes to find out why, including for the surfaces that vanish
+ * entirely and have nowhere to put a note.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AccountPermissionsCard } from '../AccountPermissionsCard';
+import { asProfileId } from '../../../api/types';
+import { SYSTEM_NONE_PERMISSIONS } from '../../../lib/permissions/zm-permissions';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+let mockPermissions: unknown;
+let mockLoading = false;
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: mockPermissions, isLoading: mockLoading }),
+}));
+
+const profileId = asProfileId('p1');
+
+describe('AccountPermissionsCard', () => {
+  it('lists the level ZoneMinder reported for each column', () => {
+    mockPermissions = {
+      system: 'View',
+      monitors: 'Edit',
+      stream: 'None',
+      events: 'View',
+      control: 'None',
+      groups: 'View',
+    };
+
+    render(<AccountPermissionsCard profileId={profileId} />);
+
+    expect(screen.getByTestId('account-permission-system')).toHaveTextContent('View');
+    expect(screen.getByTestId('account-permission-monitors')).toHaveTextContent('Edit');
+    expect(screen.getByTestId('account-permission-stream')).toHaveTextContent('None');
+  });
+
+  it('says a column is undetermined rather than inventing a level', () => {
+    // An account below System View cannot read its own row, so everything but
+    // System stays genuinely unknown.
+    mockPermissions = SYSTEM_NONE_PERMISSIONS;
+
+    render(<AccountPermissionsCard profileId={profileId} />);
+
+    expect(screen.getByTestId('account-permission-system')).toHaveTextContent('None');
+    expect(screen.getByTestId('account-permission-events')).toHaveTextContent(
+      'server.permission_unknown',
+    );
+  });
+
+  it('shows nothing until the probe settles', () => {
+    mockPermissions = undefined;
+    mockLoading = true;
+
+    render(<AccountPermissionsCard profileId={profileId} />);
+
+    expect(screen.queryByTestId('account-permissions-card')).not.toBeInTheDocument();
+    mockLoading = false;
+  });
+});

--- a/app/src/hooks/__tests__/useDeniedControl.test.tsx
+++ b/app/src/hooks/__tests__/useDeniedControl.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * The props that turn a control into a refusal that explains itself.
+ *
+ * The key constraint is that a greyed control must still be reachable: a
+ * `disabled` button dispatches no pointer events, so the long-press hint never
+ * fires and browsers suppress `title` too - it would grey out and explain
+ * nothing, which is the failure this whole change exists to fix.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { toast } from 'sonner';
+import { useDeniedControl } from '../useDeniedControl';
+
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }));
+
+function Probe({ denied, onClick }: { denied: boolean; onClick: () => void }) {
+  const props = useDeniedControl({
+    denied,
+    message: 'needs Events: Edit',
+    onClick,
+    title: 'Archive',
+    className: 'p-1',
+  });
+  return <button data-testid="control" {...props}>Archive</button>;
+}
+
+describe('useDeniedControl', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('leaves an allowed control completely alone', () => {
+    const onClick = vi.fn();
+    render(<Probe denied={false} onClick={onClick} />);
+
+    const button = screen.getByTestId('control');
+    expect(button).not.toHaveAttribute('aria-disabled');
+    expect(button).toHaveAttribute('title', 'Archive');
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a refused control aria-disabled rather than disabled', () => {
+    render(<Probe denied onClick={vi.fn()} />);
+
+    const button = screen.getByTestId('control');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    // Still in the tab order and still receiving events, so a screen reader
+    // announces it and the hint can fire.
+    expect(button).not.toBeDisabled();
+  });
+
+  it('explains instead of acting when clicked', () => {
+    const onClick = vi.fn();
+    render(<Probe denied onClick={onClick} />);
+
+    fireEvent.click(screen.getByTestId('control'));
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(vi.mocked(toast)).toHaveBeenCalledWith('needs Events: Edit');
+  });
+
+  it('carries the reason in title, which is what hover and long-press show', () => {
+    render(<Probe denied onClick={vi.fn()} />);
+
+    expect(screen.getByTestId('control')).toHaveAttribute('title', 'needs Events: Edit');
+  });
+
+  it('keeps the caller classes and adds the muted treatment', () => {
+    render(<Probe denied onClick={vi.fn()} />);
+
+    const className = screen.getByTestId('control').className;
+    expect(className).toContain('p-1');
+    expect(className).toContain('opacity-50');
+  });
+});

--- a/app/src/hooks/__tests__/useGroups.test.ts
+++ b/app/src/hooks/__tests__/useGroups.test.ts
@@ -9,6 +9,13 @@ import type { GroupData } from '../../api/types';
 import { asProfileId } from '../../api/types';
 
 // Mock dependencies
+// The permission probe reaches the profile store through the sessions module
+// this suite stubs; groups permissions are covered in the permission model
+// tests (refs #344).
+vi.mock('../usePermissions', () => ({
+  usePermissions: () => ({ permissions: { groups: 'View' }, isLoading: false }),
+}));
+
 vi.mock('../../api/groups', () => ({
   getGroups: vi.fn(),
 }));

--- a/app/src/hooks/__tests__/usePermissions.test.tsx
+++ b/app/src/hooks/__tests__/usePermissions.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * usePermissions against the real profile store.
+ *
+ * The hook subscribes to the profile store for the account name, so it is
+ * exercised against the actual store rather than a `(selector) => selector(state)`
+ * stub: that stub cannot reproduce the re-render loop a selector minting a new
+ * object would cause in production (testing playbook).
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { usePermissions } from '../usePermissions';
+import { fetchAccountPermissions } from '../../api/users';
+import { useProfileStore } from '../../stores/profile';
+import { asProfileId, VIRTUAL_PROFILE_ID_PREFIX, type Profile } from '../../api/types';
+import { SYSTEM_NONE_PERMISSIONS } from '../../lib/permissions/zm-permissions';
+
+vi.mock('../../api/users', () => ({ fetchAccountPermissions: vi.fn() }));
+
+// Partial for the same reason as sessions below: the real profile store wires
+// itself to this module's registration functions at import time.
+vi.mock('../../stores/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../stores/auth')>()),
+  useAuthSlice: () => ({ isAuthenticated: true }),
+}));
+
+// Partial: the profile store registers its own gate against this module on
+// import, so the real exports have to survive the mock.
+vi.mock('../../services/sessions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/sessions')>()),
+  getSession: vi.fn(() => ({ client: {} })),
+}));
+
+const profileId = asProfileId('profile-1');
+
+const profile: Profile = {
+  id: profileId,
+  name: 'Home',
+  portalUrl: 'https://zm.test/zm',
+  apiUrl: 'https://zm.test/zm/api',
+  cgiUrl: 'https://zm.test/zm/cgi-bin',
+  username: 'viewer',
+  isDefault: true,
+  createdAt: 0,
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('usePermissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProfileStore.setState({ profiles: [profile], currentProfileId: profileId });
+  });
+
+  it('reports the account permissions for the requested profile', async () => {
+    vi.mocked(fetchAccountPermissions).mockResolvedValue({ system: 'View', stream: 'None' });
+
+    const { result } = renderHook(() => usePermissions(profileId), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.permissions).toEqual({ system: 'View', stream: 'None' }));
+    expect(fetchAccountPermissions).toHaveBeenCalledWith(expect.anything(), 'viewer');
+  });
+
+  it('keeps everything unknown until the probe resolves', async () => {
+    let release: (value: typeof SYSTEM_NONE_PERMISSIONS) => void = () => {};
+    vi.mocked(fetchAccountPermissions).mockReturnValue(
+      new Promise((resolve) => { release = resolve; }),
+    );
+
+    const { result } = renderHook(() => usePermissions(profileId), { wrapper: createWrapper() });
+
+    expect(result.current.permissions).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+
+    release(SYSTEM_NONE_PERMISSIONS);
+    await waitFor(() => expect(result.current.permissions).toEqual(SYSTEM_NONE_PERMISSIONS));
+  });
+
+  it('does not probe an aggregate, which has no account of its own', () => {
+    const { result } = renderHook(() => usePermissions(asProfileId(`${VIRTUAL_PROFILE_ID_PREFIX}all-cameras`)), {
+      wrapper: createWrapper(),
+    });
+
+    expect(fetchAccountPermissions).not.toHaveBeenCalled();
+    expect(result.current.permissions).toBeUndefined();
+  });
+
+  it('re-renders without looping when the store updates', async () => {
+    vi.mocked(fetchAccountPermissions).mockResolvedValue({ system: 'Edit' });
+
+    const { result, rerender } = renderHook(() => usePermissions(profileId), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.permissions).toEqual({ system: 'Edit' }));
+
+    // An unrelated store write must not churn this subscription.
+    useProfileStore.setState({ profiles: [{ ...profile, lastUsed: 1 }] });
+    rerender();
+
+    expect(result.current.permissions).toEqual({ system: 'Edit' });
+  });
+});

--- a/app/src/hooks/useDeniedControl.ts
+++ b/app/src/hooks/useDeniedControl.ts
@@ -1,0 +1,68 @@
+/**
+ * useDeniedControl
+ *
+ * Turns a control ZoneMinder will refuse into one that says so. Greying alone
+ * is not enough - an absent explanation is what makes a restricted account feel
+ * like a broken app - and the obvious implementation is the one that cannot
+ * work: a `disabled` button dispatches no pointer events, so `useLongPressHint`
+ * never fires and browsers suppress its `title` too. It would grey out and
+ * explain nothing (refs #344).
+ *
+ * So the control stays live and loses only its action. Three ways in, all from
+ * the same string: hover shows `title`, hold shows the long-press toast that
+ * `Button` and `HintButton` already wire from `title`, and a tap explains
+ * instead of acting - which matters most, because tapping is what a phone user
+ * does first and a hold they never think to try teaches them nothing.
+ *
+ * `aria-disabled` rather than `disabled` also keeps the control focusable, so a
+ * screen reader announces it as unavailable instead of skipping it (I3).
+ */
+
+import { useCallback, type MouseEvent } from 'react';
+import { toast } from 'sonner';
+import { cn } from '../lib/utils';
+
+export interface DeniedControlOptions {
+  /** True only when ZoneMinder has actually refused. Never on `unknown`. */
+  denied: boolean;
+  /** Why, naming the ZoneMinder permission. Shown on hover, hold, and tap. */
+  message: string;
+  onClick: (event: MouseEvent<HTMLElement>) => void;
+  title?: string;
+  className?: string;
+}
+
+export interface DeniedControlProps {
+  onClick: (event: MouseEvent<HTMLElement>) => void;
+  title?: string;
+  className?: string;
+  'aria-disabled'?: true;
+}
+
+export function useDeniedControl({
+  denied,
+  message,
+  onClick,
+  title,
+  className,
+}: DeniedControlOptions): DeniedControlProps {
+  const explain = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      // Cards and rows are clickable underneath these buttons; explaining must
+      // not also navigate.
+      event.preventDefault();
+      event.stopPropagation();
+      toast(message);
+    },
+    [message],
+  );
+
+  if (!denied) return { onClick, title, className };
+
+  return {
+    onClick: explain,
+    title: message,
+    className: cn(className, 'opacity-50'),
+    'aria-disabled': true,
+  };
+}

--- a/app/src/hooks/useGroups.ts
+++ b/app/src/hooks/useGroups.ts
@@ -18,6 +18,8 @@ import { getCurrentSession } from '../services/sessions';
 import { useCurrentProfile } from './useCurrentProfile';
 import { useAuthSlice } from '../stores/auth';
 import { queryKeys } from '../lib/query/query-keys';
+import { usePermissions } from './usePermissions';
+import { canViewGroups } from '../lib/permissions/zm-permissions';
 import type { GroupData } from '../api/types';
 
 export interface UseGroupsReturn {
@@ -70,10 +72,17 @@ export function useGroups(): UseGroupsReturn {
   const { currentProfile } = useCurrentProfile();
   const isAuthenticated = useAuthSlice(currentProfile?.id ?? null).isAuthenticated;
 
+  // Groups is its own ZoneMinder column: full monitor access with Groups='None'
+  // is a real account, and groups.json refuses it outright. The filter already
+  // hides itself when no groups come back, so all this saves is a request that
+  // can only 401 - and the retries behind it (refs #344).
+  const { permissions } = usePermissions(currentProfile?.id);
+
   const { data, isLoading, isSuccess, error, refetch } = useQuery({
     queryKey: queryKeys.groups(currentProfile?.id),
     queryFn: () => getGroups(getCurrentSession().client),
-    enabled: !!currentProfile?.id && isAuthenticated,
+    enabled:
+      !!currentProfile?.id && isAuthenticated && canViewGroups(permissions) !== 'denied',
     // Groups rarely change, so we can use a longer stale time
     staleTime: 5 * 60 * 1000, // 5 minutes
   });

--- a/app/src/hooks/usePermissions.ts
+++ b/app/src/hooks/usePermissions.ts
@@ -1,0 +1,60 @@
+/**
+ * usePermissions Hook
+ *
+ * What the given profile's ZoneMinder account may do, probed once per profile
+ * and cached for the session. Surfaces read a verdict from
+ * `lib/permissions/zm-permissions.ts` rather than the raw columns.
+ *
+ * Takes an explicit profile id because an aggregate has no account of its own:
+ * in All mode each monitor, event, and stream belongs to a real profile, and
+ * that owner's permissions are the ones that decide what its controls can do.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchAccountPermissions } from '../api/users';
+import { getSession } from '../services/sessions';
+import { useProfileStore } from '../stores/profile';
+import { useAuthSlice } from '../stores/auth';
+import { queryKeys } from '../lib/query/query-keys';
+import { isAggregateProfileId } from '../api/types';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import type { ProfileId } from '../api/types';
+import type { ZmPermissions } from '../lib/permissions/zm-permissions';
+
+export interface UsePermissionsReturn {
+  /** The account's columns, or undefined while unknown. */
+  permissions: ZmPermissions | undefined;
+  /** True until the probe settles. Surfaces stay optimistic meanwhile. */
+  isLoading: boolean;
+}
+
+/**
+ * @param profileId - A real profile id. An aggregate id yields no permissions:
+ *   ask for the owning profile of whatever is on screen instead.
+ */
+export function usePermissions(profileId: ProfileId | null | undefined): UsePermissionsReturn {
+  const isReal = !!profileId && !isAggregateProfileId(profileId);
+  const isAuthenticated = useAuthSlice(isReal ? profileId : null).isAuthenticated;
+  // A primitive, so this subscription re-renders on a credential change and
+  // on nothing else.
+  const username = useProfileStore((state) =>
+    isReal ? state.profiles.find((p) => p.id === profileId)?.username : undefined,
+  );
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.accountPermissions(profileId),
+    queryFn: () => fetchAccountPermissions(getSession(profileId!).client, username),
+    enabled: isReal && isAuthenticated,
+    // Permissions change when an administrator edits the account, which this
+    // app cannot observe and the user cannot do from here. One probe per
+    // session is the whole budget.
+    staleTime: Infinity,
+    gcTime: Infinity,
+    // A refusal is an answer, not a failure; retrying it would spend requests
+    // to be told the same thing. Transport failures still get the default
+    // retry, and leave every verdict at "unknown" until one succeeds.
+    retry: (failureCount, error) => !isPermissionDenied(error) && failureCount < 2,
+  });
+
+  return { permissions: data, isLoading };
+}

--- a/app/src/lib/__tests__/time.test.ts
+++ b/app/src/lib/__tests__/time.test.ts
@@ -96,8 +96,10 @@ describe('formatForServer', () => {
   });
 
   it('falls back gracefully on timezone error', () => {
-    // Mock a timezone that might cause issues
-    vi.mocked(useProfileStore.getState).mockReturnValue({
+    // Once, not permanently: mockReturnValue would outlive this test, and
+    // vi.clearAllMocks() clears calls rather than implementations, so the
+    // override would still be in place for every later describe.
+    vi.mocked(useProfileStore.getState).mockReturnValueOnce({
       profiles: [{ id: 'profile-1', timezone: 'Invalid/Timezone' }],
       currentProfileId: 'profile-1',
     } as any);
@@ -110,7 +112,7 @@ describe('formatForServer', () => {
   });
 
   it('uses browser timezone when profile has no timezone', () => {
-    vi.mocked(useProfileStore.getState).mockReturnValue({
+    vi.mocked(useProfileStore.getState).mockReturnValueOnce({
       profiles: [],
       currentProfileId: null,
     } as any);

--- a/app/src/lib/permissions/__tests__/permission-error.test.ts
+++ b/app/src/lib/permissions/__tests__/permission-error.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Telling "you may not" apart from "log in again".
+ *
+ * Both arrive as HTTP 401. Treating a permission refusal as an expired session
+ * costs a token refresh and a retry per attempt, and ends in a message about
+ * the server failing rather than about the account.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHttpError } from '../../http/types';
+import { isPermissionDenied } from '../permission-error';
+
+/** Verbatim body from ZoneMinder 1.39.18 for a refused write. */
+const insufficientPrivileges = {
+  success: false,
+  data: {
+    name: 'Insufficient Privileges',
+    message: 'Insufficient Privileges',
+    url: '/zm/api/monitors/1.json',
+    exception: { class: 'UnauthorizedException', code: 401, message: 'Insufficient Privileges' },
+  },
+};
+
+/** Verbatim body from the same server when the token is missing or stale. */
+const notAuthenticated = {
+  success: false,
+  data: {
+    name: 'Not Authenticated',
+    message: 'Not Authenticated',
+    url: '/zm/api/users.json',
+    exception: { class: 'UnauthorizedException', code: 401, message: 'Not Authenticated' },
+  },
+};
+
+describe('isPermissionDenied', () => {
+  it('recognizes a ZoneMinder privilege refusal', () => {
+    expect(isPermissionDenied(createHttpError(401, 'Unauthorized', insufficientPrivileges, {}))).toBe(true);
+  });
+
+  it('does not claim an unauthenticated 401 is a permission problem', () => {
+    // This one MUST still reach the token-refresh path or a stale session
+    // never recovers.
+    expect(isPermissionDenied(createHttpError(401, 'Unauthorized', notAuthenticated, {}))).toBe(false);
+  });
+
+  it('ignores a 401 with no ZoneMinder body to read', () => {
+    expect(isPermissionDenied(createHttpError(401, 'Unauthorized', undefined, {}))).toBe(false);
+    expect(isPermissionDenied(createHttpError(401, 'Unauthorized', 'Unauthorized', {}))).toBe(false);
+  });
+
+  it('ignores other statuses and non-errors', () => {
+    expect(isPermissionDenied(createHttpError(500, 'Server Error', insufficientPrivileges, {}))).toBe(false);
+    expect(isPermissionDenied(new Error('boom'))).toBe(false);
+    expect(isPermissionDenied(null)).toBe(false);
+    expect(isPermissionDenied(undefined)).toBe(false);
+  });
+
+  it('reads the message off the exception when the name is missing', () => {
+    const body = { success: false, data: { exception: { message: 'Insufficient privileges' } } };
+    expect(isPermissionDenied(createHttpError(401, 'Unauthorized', body, {}))).toBe(true);
+  });
+});

--- a/app/src/lib/permissions/__tests__/zm-permissions.test.ts
+++ b/app/src/lib/permissions/__tests__/zm-permissions.test.ts
@@ -16,7 +16,7 @@ import {
   canViewEvents,
   canUseControl,
   canViewGroups,
-  canViewLogs,
+  canViewSystem,
   canChangeRunState,
   parsePermissionLevel,
   type ZmPermissions,
@@ -66,7 +66,7 @@ describe('verdicts before the probe lands', () => {
     expect(canEditEvents(undefined)).toBe('unknown');
     expect(canUseControl(undefined)).toBe('unknown');
     expect(canViewGroups(undefined)).toBe('unknown');
-    expect(canViewLogs(undefined)).toBe('unknown');
+    expect(canViewSystem(undefined)).toBe('unknown');
     expect(canChangeRunState(undefined)).toBe('unknown');
   });
 });
@@ -119,9 +119,9 @@ describe('PTZ control', () => {
 
 describe('system surfaces', () => {
   it('lets a View user read logs but not change the run state', () => {
-    expect(canViewLogs(viewer)).toBe('allowed');
+    expect(canViewSystem(viewer)).toBe('allowed');
     expect(canChangeRunState(viewer)).toBe('denied');
-    expect(canViewLogs(SYSTEM_NONE_PERMISSIONS)).toBe('denied');
+    expect(canViewSystem(SYSTEM_NONE_PERMISSIONS)).toBe('denied');
     expect(canChangeRunState(admin)).toBe('allowed');
   });
 });

--- a/app/src/lib/permissions/__tests__/zm-permissions.test.ts
+++ b/app/src/lib/permissions/__tests__/zm-permissions.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Permission verdicts.
+ *
+ * The three-state model is the whole point: a surface must be able to tell
+ * "ZoneMinder says no" from "we never found out", because only the first one
+ * may hide or grey anything.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  UNRESTRICTED_PERMISSIONS,
+  SYSTEM_NONE_PERMISSIONS,
+  canEditMonitorSettings,
+  canViewStream,
+  canEditEvents,
+  canViewEvents,
+  canUseControl,
+  canViewGroups,
+  canViewLogs,
+  canChangeRunState,
+  parsePermissionLevel,
+  type ZmPermissions,
+} from '../zm-permissions';
+
+/** A user with every permission ZoneMinder grants. */
+const admin: ZmPermissions = {
+  system: 'Edit',
+  monitors: 'Edit',
+  stream: 'Edit',
+  events: 'Edit',
+  control: 'Edit',
+  groups: 'Edit',
+};
+
+/** Can watch cameras, change nothing. */
+const viewer: ZmPermissions = {
+  system: 'View',
+  monitors: 'View',
+  stream: 'View',
+  events: 'View',
+  control: 'None',
+  groups: 'View',
+};
+
+describe('parsePermissionLevel', () => {
+  it('accepts the levels ZoneMinder stores', () => {
+    expect(parsePermissionLevel('None')).toBe('None');
+    expect(parsePermissionLevel('View')).toBe('View');
+    expect(parsePermissionLevel('Edit')).toBe('Edit');
+    expect(parsePermissionLevel('Create')).toBe('Create');
+  });
+
+  it('reports an unrecognized level as unknown rather than denying', () => {
+    // A level this app has not heard of must not lock a user out of a surface
+    // they may well be entitled to.
+    expect(parsePermissionLevel('Superuser')).toBeUndefined();
+    expect(parsePermissionLevel(undefined)).toBeUndefined();
+    expect(parsePermissionLevel('')).toBeUndefined();
+  });
+});
+
+describe('verdicts before the probe lands', () => {
+  it('is unknown for every capability', () => {
+    expect(canEditMonitorSettings(undefined)).toBe('unknown');
+    expect(canViewStream(undefined)).toBe('unknown');
+    expect(canEditEvents(undefined)).toBe('unknown');
+    expect(canUseControl(undefined)).toBe('unknown');
+    expect(canViewGroups(undefined)).toBe('unknown');
+    expect(canViewLogs(undefined)).toBe('unknown');
+    expect(canChangeRunState(undefined)).toBe('unknown');
+  });
+});
+
+describe('monitor settings', () => {
+  it('allows editing only at System Edit', () => {
+    expect(canEditMonitorSettings(admin)).toBe('allowed');
+    expect(canEditMonitorSettings(viewer)).toBe('denied');
+  });
+
+  it('denies editing when users.json refused the probe', () => {
+    // A 401 on users.json proves System is 'None' (UsersController gates on
+    // System() != 'None'), so this branch is knowledge, not a guess.
+    expect(canEditMonitorSettings(SYSTEM_NONE_PERMISSIONS)).toBe('denied');
+  });
+
+  it('leaves the other capabilities unknown after a refused probe', () => {
+    expect(canViewStream(SYSTEM_NONE_PERMISSIONS)).toBe('unknown');
+    expect(canEditEvents(SYSTEM_NONE_PERMISSIONS)).toBe('unknown');
+    expect(canUseControl(SYSTEM_NONE_PERMISSIONS)).toBe('unknown');
+    expect(canViewGroups(SYSTEM_NONE_PERMISSIONS)).toBe('unknown');
+  });
+});
+
+describe('streaming', () => {
+  it('separates watching a camera from listing it', () => {
+    // Monitors View with Stream None is the case no failing request can catch:
+    // the monitor appears everywhere and every stream 403s.
+    expect(canViewStream({ system: 'None', monitors: 'View', stream: 'None' })).toBe('denied');
+    expect(canViewStream({ system: 'None', monitors: 'View', stream: 'View' })).toBe('allowed');
+  });
+});
+
+describe('events', () => {
+  it('requires Edit to archive or delete, View to read', () => {
+    expect(canEditEvents(admin)).toBe('allowed');
+    expect(canEditEvents(viewer)).toBe('denied');
+    expect(canViewEvents(viewer)).toBe('allowed');
+    expect(canViewEvents({ system: 'None', events: 'None' })).toBe('denied');
+  });
+});
+
+describe('PTZ control', () => {
+  it('denies at None and allows from View up', () => {
+    // ajax/control.php gates on canView('Control', id), not canEdit.
+    expect(canUseControl(viewer)).toBe('denied');
+    expect(canUseControl({ system: 'None', control: 'View' })).toBe('allowed');
+  });
+});
+
+describe('system surfaces', () => {
+  it('lets a View user read logs but not change the run state', () => {
+    expect(canViewLogs(viewer)).toBe('allowed');
+    expect(canChangeRunState(viewer)).toBe('denied');
+    expect(canViewLogs(SYSTEM_NONE_PERMISSIONS)).toBe('denied');
+    expect(canChangeRunState(admin)).toBe('allowed');
+  });
+});
+
+describe('groups', () => {
+  it('is its own column, independent of monitor access', () => {
+    expect(canViewGroups({ system: 'None', monitors: 'Edit', groups: 'None' })).toBe('denied');
+    expect(canViewGroups(admin)).toBe('allowed');
+  });
+});
+
+describe('a server with authentication disabled', () => {
+  it('allows everything', () => {
+    // ZoneMinder short-circuits every check with `!$user`, so a profile with
+    // no username is unrestricted rather than unknown.
+    expect(canEditMonitorSettings(UNRESTRICTED_PERMISSIONS)).toBe('allowed');
+    expect(canViewStream(UNRESTRICTED_PERMISSIONS)).toBe('allowed');
+    expect(canEditEvents(UNRESTRICTED_PERMISSIONS)).toBe('allowed');
+    expect(canUseControl(UNRESTRICTED_PERMISSIONS)).toBe('allowed');
+    expect(canChangeRunState(UNRESTRICTED_PERMISSIONS)).toBe('allowed');
+  });
+});
+
+describe('Create outranks Edit', () => {
+  it('treats a monitor-creating user as able to edit', () => {
+    expect(canEditEvents({ system: 'None', events: 'Create' })).toBe('allowed');
+  });
+});

--- a/app/src/lib/permissions/permission-error.ts
+++ b/app/src/lib/permissions/permission-error.ts
@@ -1,0 +1,43 @@
+/**
+ * Separating a permission refusal from an expired session.
+ *
+ * ZoneMinder answers both with HTTP 401 and distinguishes them only in the
+ * body: `Insufficient Privileges` when the account may not do the thing,
+ * `Not Authenticated` when the token is missing or stale. The client retries
+ * 401s through a token refresh, which is right for the second and useless for
+ * the first - a refusal survives any number of fresh tokens, so the retry only
+ * spends requests before failing with a message about the server rather than
+ * about the account.
+ *
+ * The match is deliberately narrow. Anything that is not an explicit privilege
+ * refusal keeps the old recovery path, because misreading a stale session as a
+ * permission problem would strand a user who only needed a new token.
+ */
+
+/** Body ZoneMinder serializes for an `UnauthorizedException`. */
+interface ZmErrorBody {
+  data?: {
+    name?: unknown;
+    message?: unknown;
+    exception?: { message?: unknown };
+  };
+}
+
+const PRIVILEGE_REFUSAL = /insufficient privileges?/i;
+
+/**
+ * Whether this error is ZoneMinder refusing on permissions rather than on
+ * authentication. False for everything it cannot positively identify.
+ */
+export function isPermissionDenied(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  if ((error as { status?: number }).status !== 401) return false;
+
+  const body = (error as { data?: unknown }).data as ZmErrorBody | undefined;
+  const payload = body && typeof body === 'object' ? body.data : undefined;
+  if (!payload || typeof payload !== 'object') return false;
+
+  return [payload.name, payload.message, payload.exception?.message].some(
+    (value) => typeof value === 'string' && PRIVILEGE_REFUSAL.test(value),
+  );
+}

--- a/app/src/lib/permissions/zm-permissions.ts
+++ b/app/src/lib/permissions/zm-permissions.ts
@@ -140,8 +140,8 @@ export function canViewGroups(permissions: ZmPermissions | undefined): Permissio
   return atLeast(permissions?.groups, 'View');
 }
 
-/** Whether `logs.json` and `states.json` will answer. */
-export function canViewLogs(permissions: ZmPermissions | undefined): PermissionVerdict {
+/** Whether the system endpoints answer: `logs.json`, `states.json`, `servers.json`. */
+export function canViewSystem(permissions: ZmPermissions | undefined): PermissionVerdict {
   return atLeast(permissions?.system, 'View');
 }
 

--- a/app/src/lib/permissions/zm-permissions.ts
+++ b/app/src/lib/permissions/zm-permissions.ts
@@ -1,0 +1,151 @@
+/**
+ * What the logged-in ZoneMinder account is allowed to do.
+ *
+ * ZoneMinder has no "current user permissions" endpoint. `/host/login.json`
+ * returns tokens only, and the JWT payload carries the username and nothing
+ * else. The permission columns live on the Users row, and `UsersController`
+ * gates `users.json` on `System() != 'None'` - so an account can read its own
+ * permissions only when it has some system access to begin with.
+ *
+ * That is why every capability here answers with three states instead of a
+ * boolean. `denied` means ZoneMinder told us no and a surface may hide or grey
+ * itself; `unknown` means we never found out and the surface must behave as it
+ * always has, leaving the write to fail honestly. Guessing in the `unknown`
+ * case is how you take a feature away from someone who has it: `System='None'`
+ * with `Monitors='Edit'` is a legal ZoneMinder account.
+ *
+ * A refused probe is still knowledge: a 401 from `users.json` proves `System`
+ * is `'None'`, which is why {@link SYSTEM_NONE_PERMISSIONS} fills that one
+ * field in and leaves the rest unknown.
+ */
+
+/** The levels ZoneMinder stores in a permission column. */
+export const ZM_PERMISSION_LEVELS = ['None', 'View', 'Edit', 'Create'] as const;
+
+export type ZmPermissionLevel = (typeof ZM_PERMISSION_LEVELS)[number];
+
+/**
+ * One account's permission columns. Every field but `system` is optional
+ * because a refused probe leaves them unknown, and `undefined` has to stay
+ * distinguishable from `'None'`.
+ */
+export interface ZmPermissions {
+  /**
+   * Known in the two cases that matter: read from the row, or proven `'None'`
+   * by a 401. Still optional, because a ZoneMinder that omits or renames the
+   * column has to read as unknown rather than as a denial.
+   */
+  system?: ZmPermissionLevel;
+  monitors?: ZmPermissionLevel;
+  stream?: ZmPermissionLevel;
+  events?: ZmPermissionLevel;
+  control?: ZmPermissionLevel;
+  groups?: ZmPermissionLevel;
+}
+
+/**
+ * `allowed` and `denied` are answers; `unknown` is the absence of one. Only
+ * `denied` may drive hiding or greying.
+ */
+export type PermissionVerdict = 'allowed' | 'denied' | 'unknown';
+
+/**
+ * A profile with no username talks to a server with `ZM_OPT_USE_AUTH` off,
+ * where every check short-circuits on `!$user`. Unrestricted, not unknown.
+ */
+export const UNRESTRICTED_PERMISSIONS: ZmPermissions = {
+  system: 'Edit',
+  monitors: 'Edit',
+  stream: 'Edit',
+  events: 'Edit',
+  control: 'Edit',
+  groups: 'Edit',
+};
+
+/** What a 401 from `users.json` tells us, and no more. */
+export const SYSTEM_NONE_PERMISSIONS: ZmPermissions = { system: 'None' };
+
+const LEVEL_RANK: Record<ZmPermissionLevel, number> = {
+  None: 0,
+  View: 1,
+  Edit: 2,
+  Create: 3,
+};
+
+/**
+ * Reads a permission column, reporting anything unrecognized as unknown.
+ *
+ * A level this app has not heard of must not read as a denial: the safe
+ * failure is to leave the surface alone and let the write speak for itself.
+ */
+export function parsePermissionLevel(value: unknown): ZmPermissionLevel | undefined {
+  return ZM_PERMISSION_LEVELS.find((level) => level === value);
+}
+
+function atLeast(
+  level: ZmPermissionLevel | undefined,
+  minimum: ZmPermissionLevel,
+): PermissionVerdict {
+  if (level === undefined) return 'unknown';
+  return LEVEL_RANK[level] >= LEVEL_RANK[minimum] ? 'allowed' : 'denied';
+}
+
+/**
+ * Whether the monitor settings dialog may edit ZoneMinder fields.
+ *
+ * Keyed on `System` rather than `Monitors` by product decision (refs #344):
+ * the dialog carries camera credentials, so it opens for administrators only.
+ * `Monitors` still decides whether a save succeeds, which is what the
+ * permission-denied latch is for.
+ */
+export function canEditMonitorSettings(
+  permissions: ZmPermissions | undefined,
+): PermissionVerdict {
+  return atLeast(permissions?.system, 'Edit');
+}
+
+/**
+ * Whether live streams will play.
+ *
+ * `zms.cpp` checks `Stream` for a monitor source, independently of `Monitors`.
+ * A denied stream is an image that never loads, with no request to catch
+ * failing, so this is the one capability nothing but the probe can report.
+ */
+export function canViewStream(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.stream, 'View');
+}
+
+/** Whether events can be archived, edited, or deleted. */
+export function canEditEvents(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.events, 'Edit');
+}
+
+/** Whether events can be listed and replayed at all. */
+export function canViewEvents(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.events, 'View');
+}
+
+/**
+ * Whether PTZ commands will be accepted.
+ *
+ * `ajax/control.php` gates on `canView('Control', id)`, so View is enough -
+ * this is not an Edit-level capability despite being a write.
+ */
+export function canUseControl(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.control, 'View');
+}
+
+/** Whether `groups.json` will answer. Independent of monitor access. */
+export function canViewGroups(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.groups, 'View');
+}
+
+/** Whether `logs.json` and `states.json` will answer. */
+export function canViewLogs(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.system, 'View');
+}
+
+/** Whether the run state can be changed. `StatesController` wants System Edit. */
+export function canChangeRunState(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.system, 'Edit');
+}

--- a/app/src/lib/permissions/zm-permissions.ts
+++ b/app/src/lib/permissions/zm-permissions.ts
@@ -135,6 +135,16 @@ export function canUseControl(permissions: ZmPermissions | undefined): Permissio
   return atLeast(permissions?.control, 'View');
 }
 
+/**
+ * Whether any monitor is visible at all.
+ *
+ * At `'None'` ZoneMinder returns an empty list rather than an error, so without
+ * this the app would report a server with no cameras on it.
+ */
+export function canViewMonitors(permissions: ZmPermissions | undefined): PermissionVerdict {
+  return atLeast(permissions?.monitors, 'View');
+}
+
 /** Whether `groups.json` will answer. Independent of monitor access. */
 export function canViewGroups(permissions: ZmPermissions | undefined): PermissionVerdict {
   return atLeast(permissions?.groups, 'View');

--- a/app/src/lib/query/__tests__/query-error.test.ts
+++ b/app/src/lib/query/__tests__/query-error.test.ts
@@ -23,6 +23,16 @@ describe('resolveQueryError', () => {
     expect(resolveQueryError(err, t)).toBe('common.auth_required');
   });
 
+  // "Log in again" is useless advice when the session is fine and the account
+  // simply may not do this (refs #344).
+  it('distinguishes a privilege refusal from an expired session', () => {
+    const err = createHttpError(401, 'Unauthorized', {
+      success: false,
+      data: { name: 'Insufficient Privileges' },
+    }, {});
+    expect(resolveQueryError(err, t)).toBe('common.permission_denied');
+  });
+
   it('returns the auth_required key when the message says unauthorized', () => {
     const err = new Error('Unauthorized: token expired');
     expect(resolveQueryError(err, t)).toBe('common.auth_required');

--- a/app/src/lib/query/query-error.ts
+++ b/app/src/lib/query/query-error.ts
@@ -8,6 +8,7 @@
 
 import type { TFunction } from 'i18next';
 import { isAbortError } from '../is-abort-error';
+import { isPermissionDenied } from '../permissions/permission-error';
 
 export interface ResolveQueryErrorOptions {
   /**
@@ -26,6 +27,11 @@ export function resolveQueryError(
   // `createHttpError` (lib/http/types.ts) puts the code on a flat `status`.
   // Nothing here produces an axios-shaped `.response.status` envelope.
   const status = (err as { status?: number })?.status;
+  // A privilege refusal is also a 401, and telling that user to authenticate
+  // sends them to re-enter credentials that were never the problem (refs #344).
+  if (isPermissionDenied(err)) {
+    return t('common.permission_denied');
+  }
   if (status === 401 || /unauthorized/i.test(message)) {
     return t('common.auth_required');
   }

--- a/app/src/lib/query/query-keys.ts
+++ b/app/src/lib/query/query-keys.ts
@@ -149,6 +149,8 @@ export const queryKeys = {
   states: (profileId: MaybeProfileId) => ['states', profileId] as const,
   timezone: (profileId: MaybeProfileId) => ['timezone', profileId] as const,
   storages: (profileId: MaybeProfileId) => ['storages', profileId] as const,
+  /** What the profile's ZoneMinder account is allowed to do (refs #344). */
+  accountPermissions: (profileId: MaybeProfileId) => ['account-permissions', profileId] as const,
 
   // --- Assistant ----------------------------------------------------------
   /** Ollama backend reachability probe, keyed by base URL so a URL change

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -152,7 +152,8 @@
     "fit_none": "Keine",
     "fit_scale_down": "Verkleinern",
     "view_events": "Ereignisse",
-    "group_by_server": "Nach Server gruppieren"
+    "group_by_server": "Nach Server gruppieren",
+    "stream_permission_denied": "Dieses Konto hat keine Streaming-Berechtigung."
   },
   "events": {
     "title": "Ereignisse",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -41,6 +41,7 @@
     "selected": "Ausgewählt",
     "unknown_error": "Unbekannter Fehler",
     "auth_required": "Authentifizierung erforderlich",
+    "permission_denied": "Dein ZoneMinder-Konto hat dafür keine Berechtigung.",
     "cannot_reach_host": "Keine Verbindung zu {{host}}. Adresse in den Einstellungen prüfen oder ob der Server läuft.",
     "running": "Läuft",
     "stopped": "Gestoppt",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -153,7 +153,8 @@
     "fit_scale_down": "Verkleinern",
     "view_events": "Ereignisse",
     "group_by_server": "Nach Server gruppieren",
-    "stream_permission_denied": "Dieses Konto hat keine Streaming-Berechtigung."
+    "stream_permission_denied": "Dieses Konto hat keine Streaming-Berechtigung.",
+    "no_monitor_permission": "Dieses Konto hat keine Monitor-Berechtigungen."
   },
   "events": {
     "title": "Ereignisse",
@@ -255,7 +256,8 @@
     "show_all_servers": "Alle Server anzeigen",
     "failed_to_load": "Ereignisse konnten nicht geladen werden: {{error}}",
     "delete_permission_denied": "Zum Löschen von Ereignissen wird Events: Edit benötigt.",
-    "archive_permission_denied": "Zum Archivieren von Ereignissen wird Events: Edit benötigt."
+    "archive_permission_denied": "Zum Archivieren von Ereignissen wird Events: Edit benötigt.",
+    "no_event_permission": "Dieses Konto hat keine Ereignis-Berechtigungen."
   },
   "event_detail": {
     "event_id": "Ereignis ID",
@@ -1238,7 +1240,16 @@
     "storage_used": "Belegt",
     "storage_total": "Gesamt",
     "no_storage": "Kein Speicherinfo",
-    "run_state_permission_denied": "Zum Ändern des Laufzustands wird System: Edit benötigt."
+    "run_state_permission_denied": "Zum Ändern des Laufzustands wird System: Edit benötigt.",
+    "permissions_title": "Kontoberechtigungen",
+    "permissions_desc": "Was dieses ZoneMinder-Konto darf.",
+    "permission_system": "System",
+    "permission_monitors": "Monitore",
+    "permission_stream": "Stream",
+    "permission_events": "Ereignisse",
+    "permission_control": "Steuerung",
+    "permission_groups": "Gruppen",
+    "permission_unknown": "Nicht ermittelt"
   },
   "eventMontage": {
     "grid_layout_applied": "Rasterlayout angewendet: {{cols}} Spalten",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -253,7 +253,9 @@
     "filter_by_server": "Nach Server filtern",
     "filter_hides_everything": "Alle Server sind durch den Filter oben ausgeblendet",
     "show_all_servers": "Alle Server anzeigen",
-    "failed_to_load": "Ereignisse konnten nicht geladen werden: {{error}}"
+    "failed_to_load": "Ereignisse konnten nicht geladen werden: {{error}}",
+    "delete_permission_denied": "Zum Löschen von Ereignissen wird Events: Edit benötigt.",
+    "archive_permission_denied": "Zum Archivieren von Ereignissen wird Events: Edit benötigt."
   },
   "event_detail": {
     "event_id": "Ereignis ID",
@@ -1235,7 +1237,8 @@
     "storage_server": "Server",
     "storage_used": "Belegt",
     "storage_total": "Gesamt",
-    "no_storage": "Kein Speicherinfo"
+    "no_storage": "Kein Speicherinfo",
+    "run_state_permission_denied": "Zum Ändern des Laufzustands wird System: Edit benötigt."
   },
   "eventMontage": {
     "grid_layout_applied": "Rasterlayout angewendet: {{cols}} Spalten",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -790,7 +790,9 @@
     "orientation_90": "Rechts drehen (90°)",
     "orientation_180": "Invertiert (180°)",
     "orientation_270": "Links drehen (270°)",
-    "settings_description": "Monitor #{{id}} · {{type}}"
+    "settings_description": "Monitor #{{id}} · {{type}}",
+    "settings_restricted_account": "Kamera-Einstellungen sind schreibgeschützt. Zum Bearbeiten braucht dein ZoneMinder-Konto System: Edit.",
+    "settings_restricted_monitor": "Kamera-Einstellungen sind schreibgeschützt. ZoneMinder sperrt diesen Monitor für dein Konto."
   },
   "montage": {
     "title": "Montage",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -153,7 +153,8 @@
     "fit_scale_down": "Scale down",
     "view_events": "Events",
     "group_by_server": "Group by server",
-    "stream_permission_denied": "No streaming permission for this account."
+    "stream_permission_denied": "No streaming permission for this account.",
+    "no_monitor_permission": "This account has no monitor permissions."
   },
   "events": {
     "title": "Events",
@@ -255,7 +256,8 @@
     "show_all_servers": "Show all servers",
     "failed_to_load": "Failed to load events: {{error}}",
     "delete_permission_denied": "Deleting events needs Events: Edit permission.",
-    "archive_permission_denied": "Archiving events needs Events: Edit permission."
+    "archive_permission_denied": "Archiving events needs Events: Edit permission.",
+    "no_event_permission": "This account has no event permissions."
   },
   "event_detail": {
     "event_id": "Event ID",
@@ -1238,7 +1240,16 @@
     "storage_used": "Used",
     "storage_total": "Total",
     "no_storage": "No storage info",
-    "run_state_permission_denied": "Changing the run state needs System: Edit permission."
+    "run_state_permission_denied": "Changing the run state needs System: Edit permission.",
+    "permissions_title": "Account permissions",
+    "permissions_desc": "What this ZoneMinder account is allowed to do.",
+    "permission_system": "System",
+    "permission_monitors": "Monitors",
+    "permission_stream": "Stream",
+    "permission_events": "Events",
+    "permission_control": "Control",
+    "permission_groups": "Groups",
+    "permission_unknown": "Not determined"
   },
   "eventMontage": {
     "grid_layout_applied": "Grid layout applied: {{cols}} columns",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -41,6 +41,7 @@
     "selected": "Selected",
     "unknown_error": "Unknown error",
     "auth_required": "Authentication required",
+    "permission_denied": "Your ZoneMinder account doesn't have permission for this.",
     "cannot_reach_host": "Can't reach {{host}}. Check the address in Settings, or that the server is running.",
     "done": "Done",
     "default": "Default",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -253,7 +253,9 @@
     "filter_by_server": "Filter by server",
     "filter_hides_everything": "Every server is hidden by the filter above",
     "show_all_servers": "Show all servers",
-    "failed_to_load": "Failed to load events: {{error}}"
+    "failed_to_load": "Failed to load events: {{error}}",
+    "delete_permission_denied": "Deleting events needs Events: Edit permission.",
+    "archive_permission_denied": "Archiving events needs Events: Edit permission."
   },
   "event_detail": {
     "event_id": "Event ID",
@@ -1235,7 +1237,8 @@
     "storage_server": "Server",
     "storage_used": "Used",
     "storage_total": "Total",
-    "no_storage": "No storage info"
+    "no_storage": "No storage info",
+    "run_state_permission_denied": "Changing the run state needs System: Edit permission."
   },
   "eventMontage": {
     "grid_layout_applied": "Grid layout applied: {{cols}} columns",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -790,7 +790,9 @@
     "orientation_90": "Rotate Right (90°)",
     "orientation_180": "Inverted (180°)",
     "orientation_270": "Rotate Left (270°)",
-    "settings_description": "Monitor #{{id}} · {{type}}"
+    "settings_description": "Monitor #{{id}} · {{type}}",
+    "settings_restricted_account": "Camera settings are read-only. Editing needs System: Edit permission on your ZoneMinder account.",
+    "settings_restricted_monitor": "Camera settings are read-only. ZoneMinder restricts this monitor for your account."
   },
   "montage": {
     "title": "Montage",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -152,7 +152,8 @@
     "fit_none": "None",
     "fit_scale_down": "Scale down",
     "view_events": "Events",
-    "group_by_server": "Group by server"
+    "group_by_server": "Group by server",
+    "stream_permission_denied": "No streaming permission for this account."
   },
   "events": {
     "title": "Events",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -153,7 +153,8 @@
     "fit_scale_down": "Reducir",
     "view_events": "Eventos",
     "group_by_server": "Agrupar por servidor",
-    "stream_permission_denied": "Esta cuenta no tiene permiso de streaming."
+    "stream_permission_denied": "Esta cuenta no tiene permiso de streaming.",
+    "no_monitor_permission": "Esta cuenta no tiene permisos de monitores."
   },
   "events": {
     "title": "Eventos",
@@ -255,7 +256,8 @@
     "show_all_servers": "Mostrar todos los servidores",
     "failed_to_load": "No se pudieron cargar los eventos: {{error}}",
     "delete_permission_denied": "Eliminar eventos requiere el permiso Events: Edit.",
-    "archive_permission_denied": "Archivar eventos requiere el permiso Events: Edit."
+    "archive_permission_denied": "Archivar eventos requiere el permiso Events: Edit.",
+    "no_event_permission": "Esta cuenta no tiene permisos de eventos."
   },
   "event_detail": {
     "event_id": "ID de Evento",
@@ -1238,7 +1240,16 @@
     "storage_used": "Usado",
     "storage_total": "Total",
     "no_storage": "Sin almacenamiento",
-    "run_state_permission_denied": "Cambiar el estado de ejecución requiere el permiso System: Edit."
+    "run_state_permission_denied": "Cambiar el estado de ejecución requiere el permiso System: Edit.",
+    "permissions_title": "Permisos de la cuenta",
+    "permissions_desc": "Lo que esta cuenta de ZoneMinder puede hacer.",
+    "permission_system": "Sistema",
+    "permission_monitors": "Monitores",
+    "permission_stream": "Streaming",
+    "permission_events": "Eventos",
+    "permission_control": "Control",
+    "permission_groups": "Grupos",
+    "permission_unknown": "Sin determinar"
   },
   "eventMontage": {
     "grid_layout_applied": "Diseño de cuadrícula aplicado: {{cols}} columnas",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -41,6 +41,7 @@
     "selected": "Seleccionado",
     "unknown_error": "Error desconocido",
     "auth_required": "Autenticación requerida",
+    "permission_denied": "Tu cuenta de ZoneMinder no tiene permiso para esto.",
     "cannot_reach_host": "No se puede conectar con {{host}}. Comprueba la dirección en Ajustes o que el servidor esté funcionando.",
     "running": "En ejecución",
     "stopped": "Detenido",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -152,7 +152,8 @@
     "fit_none": "Ninguno",
     "fit_scale_down": "Reducir",
     "view_events": "Eventos",
-    "group_by_server": "Agrupar por servidor"
+    "group_by_server": "Agrupar por servidor",
+    "stream_permission_denied": "Esta cuenta no tiene permiso de streaming."
   },
   "events": {
     "title": "Eventos",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -253,7 +253,9 @@
     "filter_by_server": "Filtrar por servidor",
     "filter_hides_everything": "El filtro anterior oculta todos los servidores",
     "show_all_servers": "Mostrar todos los servidores",
-    "failed_to_load": "No se pudieron cargar los eventos: {{error}}"
+    "failed_to_load": "No se pudieron cargar los eventos: {{error}}",
+    "delete_permission_denied": "Eliminar eventos requiere el permiso Events: Edit.",
+    "archive_permission_denied": "Archivar eventos requiere el permiso Events: Edit."
   },
   "event_detail": {
     "event_id": "ID de Evento",
@@ -1235,7 +1237,8 @@
     "storage_server": "Servidor",
     "storage_used": "Usado",
     "storage_total": "Total",
-    "no_storage": "Sin almacenamiento"
+    "no_storage": "Sin almacenamiento",
+    "run_state_permission_denied": "Cambiar el estado de ejecución requiere el permiso System: Edit."
   },
   "eventMontage": {
     "grid_layout_applied": "Diseño de cuadrícula aplicado: {{cols}} columnas",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -790,7 +790,9 @@
     "orientation_90": "Rotar derecha (90°)",
     "orientation_180": "Invertido (180°)",
     "orientation_270": "Rotar izquierda (270°)",
-    "settings_description": "Monitor #{{id}} · {{type}}"
+    "settings_description": "Monitor #{{id}} · {{type}}",
+    "settings_restricted_account": "Los ajustes de la cámara son de solo lectura. Editar requiere el permiso System: Edit en tu cuenta de ZoneMinder.",
+    "settings_restricted_monitor": "Los ajustes de la cámara son de solo lectura. ZoneMinder restringe este monitor para tu cuenta."
   },
   "montage": {
     "title": "Montaje",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -790,7 +790,9 @@
     "orientation_90": "Rotation droite (90°)",
     "orientation_180": "Inversé (180°)",
     "orientation_270": "Rotation gauche (270°)",
-    "settings_description": "Moniteur #{{id}} · {{type}}"
+    "settings_description": "Moniteur #{{id}} · {{type}}",
+    "settings_restricted_account": "Les réglages de la caméra sont en lecture seule. La modification exige la permission System: Edit sur votre compte ZoneMinder.",
+    "settings_restricted_monitor": "Les réglages de la caméra sont en lecture seule. ZoneMinder restreint ce moniteur pour votre compte."
   },
   "montage": {
     "title": "Montage",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -253,7 +253,9 @@
     "filter_by_server": "Filtrer par serveur",
     "filter_hides_everything": "Le filtre ci-dessus masque tous les serveurs",
     "show_all_servers": "Afficher tous les serveurs",
-    "failed_to_load": "Impossible de charger les événements : {{error}}"
+    "failed_to_load": "Impossible de charger les événements : {{error}}",
+    "delete_permission_denied": "Supprimer des événements exige la permission Events: Edit.",
+    "archive_permission_denied": "Archiver des événements exige la permission Events: Edit."
   },
   "event_detail": {
     "event_id": "ID Événement",
@@ -1235,7 +1237,8 @@
     "storage_server": "Serveur",
     "storage_used": "Utilisé",
     "storage_total": "Total",
-    "no_storage": "Aucun stockage"
+    "no_storage": "Aucun stockage",
+    "run_state_permission_denied": "Changer l'état d'exécution exige la permission System: Edit."
   },
   "eventMontage": {
     "grid_layout_applied": "Grille appliquée : {{cols}} colonnes",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -152,7 +152,8 @@
     "fit_none": "Aucun",
     "fit_scale_down": "Réduire",
     "view_events": "Événements",
-    "group_by_server": "Grouper par serveur"
+    "group_by_server": "Grouper par serveur",
+    "stream_permission_denied": "Ce compte n'a pas la permission de diffusion."
   },
   "events": {
     "title": "Événements",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -41,6 +41,7 @@
     "selected": "Sélectionné",
     "unknown_error": "Erreur inconnue",
     "auth_required": "Authentification requise",
+    "permission_denied": "Votre compte ZoneMinder n'a pas la permission requise.",
     "cannot_reach_host": "Impossible de joindre {{host}}. Vérifiez l’adresse dans les Réglages ou que le serveur est démarré.",
     "running": "En cours d'exécution",
     "stopped": "Arrêté",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -153,7 +153,8 @@
     "fit_scale_down": "Réduire",
     "view_events": "Événements",
     "group_by_server": "Grouper par serveur",
-    "stream_permission_denied": "Ce compte n'a pas la permission de diffusion."
+    "stream_permission_denied": "Ce compte n'a pas la permission de diffusion.",
+    "no_monitor_permission": "Ce compte n'a aucune permission sur les moniteurs."
   },
   "events": {
     "title": "Événements",
@@ -255,7 +256,8 @@
     "show_all_servers": "Afficher tous les serveurs",
     "failed_to_load": "Impossible de charger les événements : {{error}}",
     "delete_permission_denied": "Supprimer des événements exige la permission Events: Edit.",
-    "archive_permission_denied": "Archiver des événements exige la permission Events: Edit."
+    "archive_permission_denied": "Archiver des événements exige la permission Events: Edit.",
+    "no_event_permission": "Ce compte n'a aucune permission sur les événements."
   },
   "event_detail": {
     "event_id": "ID Événement",
@@ -1238,7 +1240,16 @@
     "storage_used": "Utilisé",
     "storage_total": "Total",
     "no_storage": "Aucun stockage",
-    "run_state_permission_denied": "Changer l'état d'exécution exige la permission System: Edit."
+    "run_state_permission_denied": "Changer l'état d'exécution exige la permission System: Edit.",
+    "permissions_title": "Permissions du compte",
+    "permissions_desc": "Ce que ce compte ZoneMinder peut faire.",
+    "permission_system": "Système",
+    "permission_monitors": "Moniteurs",
+    "permission_stream": "Diffusion",
+    "permission_events": "Événements",
+    "permission_control": "Contrôle",
+    "permission_groups": "Groupes",
+    "permission_unknown": "Non déterminé"
   },
   "eventMontage": {
     "grid_layout_applied": "Grille appliquée : {{cols}} colonnes",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -153,7 +153,8 @@
     "fit_scale_down": "缩小",
     "view_events": "事件",
     "group_by_server": "按服务器分组",
-    "stream_permission_denied": "此账户没有视频流权限。"
+    "stream_permission_denied": "此账户没有视频流权限。",
+    "no_monitor_permission": "此账户没有监视器权限。"
   },
   "events": {
     "title": "事件",
@@ -255,7 +256,8 @@
     "show_all_servers": "显示所有服务器",
     "failed_to_load": "加载事件失败：{{error}}",
     "delete_permission_denied": "删除事件需要 Events: Edit 权限。",
-    "archive_permission_denied": "归档事件需要 Events: Edit 权限。"
+    "archive_permission_denied": "归档事件需要 Events: Edit 权限。",
+    "no_event_permission": "此账户没有事件权限。"
   },
   "event_detail": {
     "event_id": "事件 ID",
@@ -1238,7 +1240,16 @@
     "storage_used": "已用",
     "storage_total": "总共",
     "no_storage": "无存储信息",
-    "run_state_permission_denied": "更改运行状态需要 System: Edit 权限。"
+    "run_state_permission_denied": "更改运行状态需要 System: Edit 权限。",
+    "permissions_title": "账户权限",
+    "permissions_desc": "此 ZoneMinder 账户可执行的操作。",
+    "permission_system": "系统",
+    "permission_monitors": "监视器",
+    "permission_stream": "视频流",
+    "permission_events": "事件",
+    "permission_control": "云台控制",
+    "permission_groups": "分组",
+    "permission_unknown": "未确定"
   },
   "eventMontage": {
     "grid_layout_applied": "网格布局应用: {{cols}} 列",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -790,7 +790,9 @@
     "orientation_90": "向右旋转 (90°)",
     "orientation_180": "翻转 (180°)",
     "orientation_270": "向左旋转 (270°)",
-    "settings_description": "Monitor #{{id}} · {{type}}"
+    "settings_description": "Monitor #{{id}} · {{type}}",
+    "settings_restricted_account": "摄像机设置为只读。编辑需要 ZoneMinder 账户具备 System: Edit 权限。",
+    "settings_restricted_monitor": "摄像机设置为只读。ZoneMinder 对你的账户限制了此监视器。"
   },
   "montage": {
     "title": "蒙太奇",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -41,6 +41,7 @@
     "selected": "已选择",
     "unknown_error": "未知错误",
     "auth_required": "需要身份验证",
+    "permission_denied": "你的 ZoneMinder 账户没有此权限。",
     "cannot_reach_host": "无法连接 {{host}}。请检查设置中的地址，或确认服务器正在运行。",
     "running": "运行中",
     "stopped": "已停止",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -253,7 +253,9 @@
     "filter_by_server": "按服务器筛选",
     "filter_hides_everything": "上方的筛选条件隐藏了所有服务器",
     "show_all_servers": "显示所有服务器",
-    "failed_to_load": "加载事件失败：{{error}}"
+    "failed_to_load": "加载事件失败：{{error}}",
+    "delete_permission_denied": "删除事件需要 Events: Edit 权限。",
+    "archive_permission_denied": "归档事件需要 Events: Edit 权限。"
   },
   "event_detail": {
     "event_id": "事件 ID",
@@ -1235,7 +1237,8 @@
     "storage_server": "服务器",
     "storage_used": "已用",
     "storage_total": "总共",
-    "no_storage": "无存储信息"
+    "no_storage": "无存储信息",
+    "run_state_permission_denied": "更改运行状态需要 System: Edit 权限。"
   },
   "eventMontage": {
     "grid_layout_applied": "网格布局应用: {{cols}} 列",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -152,7 +152,8 @@
     "fit_none": "无",
     "fit_scale_down": "缩小",
     "view_events": "事件",
-    "group_by_server": "按服务器分组"
+    "group_by_server": "按服务器分组",
+    "stream_permission_denied": "此账户没有视频流权限。"
   },
   "events": {
     "title": "事件",

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -9,6 +9,9 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../lib/query/query-keys';
 import { getEvent, getEventVideoUrl, getEventImageUrl, setEventArchived } from '../api/events';
+import { usePermissions } from '../hooks/usePermissions';
+import { canEditEvents } from '../lib/permissions/zm-permissions';
+import { useDeniedControl } from '../hooks/useDeniedControl';
 import { getSession, tryGetCurrentSession } from '../services/sessions';
 import type { ApiClient } from '../api/client';
 import { eventHasAlarmFrame } from '../lib/event/thumbnail-chain';
@@ -231,6 +234,17 @@ export default function EventDetail() {
       setIsArchiving(false);
     }
   }, [event, isArchived, isArchiving, routeProfileId, ownerProfile?.id, queryClient, t]);
+
+  // Archiving needs Events: Edit. Greyed and still live, so hover, hold and tap
+  // all say which permission is missing (refs #344).
+  const { permissions } = usePermissions(ownerProfile?.id);
+  const archiveProps = useDeniedControl({
+    denied: canEditEvents(permissions) === 'denied',
+    message: t('events.archive_permission_denied'),
+    onClick: handleArchiveToggle,
+    title: isArchived ? t('event_detail.unarchive') : t('event_detail.archive'),
+    className: 'gap-2 h-8 sm:h-9',
+  });
 
   // Generate video markers for alarm frames
   // NOTE: This hook must be called before any conditional returns
@@ -506,10 +520,8 @@ export default function EventDetail() {
           <Button
             variant={isArchived ? "default" : "outline"}
             size="sm"
-            className="gap-2 h-8 sm:h-9"
-            onClick={handleArchiveToggle}
+            {...archiveProps}
             disabled={isArchiving}
-            title={isArchived ? t('event_detail.unarchive') : t('event_detail.archive')}
             data-testid="event-detail-archive"
           >
             <Archive className={isArchived ? "h-4 w-4 fill-current" : "h-4 w-4"} />

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -544,6 +544,7 @@ export default function MonitorDetail() {
               <div className="w-full flex flex-col items-center gap-4">
                 <PTZControls
                   onCommand={handlePTZCommand}
+                  profileId={ownerProfile?.id}
                   className="w-full"
                   control={controlData?.control.Control}
                 />

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -44,6 +44,10 @@ import { useServerUrls } from '../hooks/useServerUrls';
 import { usePTZControl, useAlarmControl, useModeControl, useMonitorNavigation } from './hooks';
 
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
+import { usePermissions } from '../hooks/usePermissions';
+import { canEditMonitorSettings } from '../lib/permissions/zm-permissions';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import { markPermissionDenied, useIsPermissionDenied } from '../stores/permissions';
 import { MonitorControlsCard } from '../components/monitor-detail/MonitorControlsCard';
 import { ZoomControls } from '../components/ui/zoom-controls';
 import { ErrorBanner, DetailPageSkeleton } from '../components/ui/query-state';
@@ -182,6 +186,14 @@ export default function MonitorDetail() {
   const zmVersion = useAuthSlice(ownerProfile?.id ?? null).version;
   const is138Plus = isZmVersionAtLeast(zmVersion, '1.38.0');
 
+  // Whether the settings dialog offers an editor at all. Unknown permissions
+  // stay optimistic: System='None' with Monitors='Edit' is a legal account, so
+  // only a real denial takes the editor away (refs #344).
+  const { permissions } = usePermissions(ownerProfile?.id);
+  const monitorEditRefused = useIsPermissionDenied(ownerProfile?.id, 'monitor-settings', id);
+  const canEditSettings =
+    canEditMonitorSettings(permissions) !== 'denied' && !monitorEditRefused;
+
   // Settings dialog save handler: batches all changes into one or more API calls
   const [isSavingSettings, setIsSavingSettings] = useState(false);
 
@@ -200,11 +212,19 @@ export default function MonitorDetail() {
       toast.success(t('monitor_detail.capture_updated'));
     } catch (error) {
       log.monitorDetail('Settings save failed', LogLevel.ERROR, { error });
-      toast.error(t('monitor_detail.capture_failed'));
+      // ZoneMinder can refuse one monitor even when the account columns say
+      // Edit, through per-monitor permission rows the API never exposes. Latch
+      // it so the dialog stops offering an editor that cannot save (refs #344).
+      if (isPermissionDenied(error) && ownerProfile) {
+        markPermissionDenied(ownerProfile.id, 'monitor-settings', monitor.Monitor.Id);
+        toast.error(t('common.permission_denied'));
+      } else {
+        toast.error(t('monitor_detail.capture_failed'));
+      }
     } finally {
       setIsSavingSettings(false);
     }
-  }, [monitor?.Monitor.Id, routeProfileId, refetch, t]);
+  }, [monitor?.Monitor.Id, routeProfileId, refetch, t, ownerProfile]);
 
   // Computed values
   const orientedResolution = useMemo(
@@ -563,7 +583,8 @@ export default function MonitorDetail() {
         onOpenChange={setShowSettingsDialog}
         monitor={monitor.Monitor}
         zmVersion={zmVersion}
-        onSave={handleSaveSettings}
+        onSave={canEditSettings ? handleSaveSettings : undefined}
+        restrictedReason={monitorEditRefused ? 'monitor' : 'account'}
         isSaving={isSavingSettings}
         cycleSeconds={settings.monitorDetailCycleSeconds}
         onCycleSecondsChange={handleCycleSecondsChange}

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -27,7 +27,7 @@ import { MonitorCard } from '../components/monitors/MonitorCard';
 import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
 import { usePermissions } from '../hooks/usePermissions';
-import { canEditMonitorSettings } from '../lib/permissions/zm-permissions';
+import { canEditMonitorSettings, canViewMonitors } from '../lib/permissions/zm-permissions';
 import { isPermissionDenied } from '../lib/permissions/permission-error';
 import { markPermissionDenied, useIsPermissionDenied } from '../stores/permissions';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
@@ -191,6 +191,12 @@ export default function Monitors() {
       setIsSavingSettings(false);
     }
   }, [selectedMonitor, settingsProfileId, refetchProfile, t]);
+
+  // An account with Monitors='None' gets an empty list from ZoneMinder, not an
+  // error - so without this the page would blame the server for having no
+  // cameras (refs #344).
+  const { permissions: currentPermissions } = usePermissions(currentProfile?.id);
+  const monitorsDenied = canViewMonitors(currentPermissions) === 'denied';
 
   // Unknown permissions stay optimistic; only a denial removes the editor.
   const { permissions: settingsPermissions } = usePermissions(settingsProfileId);
@@ -435,7 +441,13 @@ export default function Monitors() {
           <div data-testid={allFailed ? 'monitors-all-failed-state' : 'monitors-empty-state'}>
             <EmptyState
               icon={Video}
-              title={t(allFailed ? 'monitors.all_failed_title' : 'monitors.no_cameras')}
+              title={t(
+                allFailed
+                  ? 'monitors.all_failed_title'
+                  : monitorsDenied
+                    ? 'monitors.no_monitor_permission'
+                    : 'monitors.no_cameras',
+              )}
               className="p-8 text-center border rounded-lg bg-muted/20 text-muted-foreground"
             />
           </div>

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -26,6 +26,10 @@ import { RefreshButton } from '../components/common/RefreshButton';
 import { MonitorCard } from '../components/monitors/MonitorCard';
 import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
+import { usePermissions } from '../hooks/usePermissions';
+import { canEditMonitorSettings } from '../lib/permissions/zm-permissions';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import { markPermissionDenied, useIsPermissionDenied } from '../stores/permissions';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { filterMonitorsByGroup } from '../lib/monitor/filters';
 import { useGroupFilter } from '../hooks/useGroupFilter';
@@ -174,11 +178,29 @@ export default function Monitors() {
       toast.success(t('monitor_detail.capture_updated'));
     } catch (error) {
       log.monitor('Settings save failed', LogLevel.ERROR, { error });
-      toast.error(t('monitor_detail.capture_failed'));
+      // Per-monitor permission rows can refuse a save the account columns
+      // allowed, and they are not in the API - so the refusal itself is the
+      // only way to learn about them (refs #344).
+      if (isPermissionDenied(error)) {
+        markPermissionDenied(settingsProfileId, 'monitor-settings', selectedMonitor.Id);
+        toast.error(t('common.permission_denied'));
+      } else {
+        toast.error(t('monitor_detail.capture_failed'));
+      }
     } finally {
       setIsSavingSettings(false);
     }
   }, [selectedMonitor, settingsProfileId, refetchProfile, t]);
+
+  // Unknown permissions stay optimistic; only a denial removes the editor.
+  const { permissions: settingsPermissions } = usePermissions(settingsProfileId);
+  const settingsMonitorRefused = useIsPermissionDenied(
+    settingsProfileId,
+    'monitor-settings',
+    selectedMonitor?.Id,
+  );
+  const canEditSettings =
+    canEditMonitorSettings(settingsPermissions) !== 'denied' && !settingsMonitorRefused;
 
   const handleFeedFitChange = (value: string) => {
     if (!currentProfileId) return;
@@ -443,7 +465,8 @@ export default function Monitors() {
           onOpenChange={setShowPropertiesDialog}
           monitor={selectedMonitor}
           zmVersion={settingsZmVersion}
-          onSave={handleSaveSettings}
+          onSave={canEditSettings ? handleSaveSettings : undefined}
+          restrictedReason={settingsMonitorRefused ? 'monitor' : 'account'}
           isSaving={isSavingSettings}
           profileId={settingsProfileId ?? undefined}
         />

--- a/app/src/pages/Server.tsx
+++ b/app/src/pages/Server.tsx
@@ -37,6 +37,9 @@ import { useTranslation } from 'react-i18next';
 import { getServers, getLoad, getDiskPercent, getDaemonCheck, getStorages } from '../api/server';
 import { getServerTimeZone } from '../api/time';
 import { getStates, changeState } from '../api/states';
+import { usePermissions } from '../hooks/usePermissions';
+import { canChangeRunState, canViewSystem } from '../lib/permissions/zm-permissions';
+import { useDeniedControl } from '../hooks/useDeniedControl';
 import { getSession } from '../services/sessions';
 import { useToast } from '../hooks/use-toast';
 import { log, LogLevel } from '../lib/logger';
@@ -153,6 +156,18 @@ export default function Server() {
       changeStateMutation.mutate(effectiveAction);
     }
   };
+
+  // Changing the run state needs System: Edit (StatesController). Greyed rather
+  // than hidden: a System View account may legitimately read the current state,
+  // and the greyed button is what tells an administrator why it is inert
+  // (refs #344).
+  const { permissions } = usePermissions(currentProfile?.id);
+  const applyProps = useDeniedControl({
+    denied: canChangeRunState(permissions) === 'denied',
+    message: t('server.run_state_permission_denied'),
+    onClick: handleApply,
+    className: 'flex items-center gap-2',
+  });
 
   const formatMemory = (bytes: number | undefined) => {
     if (!bytes) return t('common.unknown');
@@ -516,7 +531,11 @@ export default function Server() {
       )}
 
       {/* ZoneMinder Control */}
-      <Card>
+      {/* ZoneMinder control. states.json needs System View, so an account
+          without it has nothing to show here rather than an empty picker
+          (refs #344). */}
+      {canViewSystem(permissions) !== 'denied' && (
+      <Card data-testid="server-zm-control-card">
         <CardHeader>
           <div className="flex items-center gap-2">
             <PlayCircle className="h-5 w-5 text-primary" />
@@ -590,9 +609,8 @@ export default function Server() {
                   </SelectContent>
                 </Select>
                 <Button
-                  onClick={handleApply}
+                  {...applyProps}
                   disabled={!effectiveAction || changeStateMutation.isPending}
-                  className="flex items-center gap-2"
                   data-testid="server-apply-button"
                 >
                   {changeStateMutation.isPending ? (
@@ -613,6 +631,7 @@ export default function Server() {
           </div>
         </CardContent>
       </Card>
+      )}
     </PageContainer>
   );
 }

--- a/app/src/pages/Server.tsx
+++ b/app/src/pages/Server.tsx
@@ -40,6 +40,7 @@ import { getStates, changeState } from '../api/states';
 import { usePermissions } from '../hooks/usePermissions';
 import { canChangeRunState, canViewSystem } from '../lib/permissions/zm-permissions';
 import { useDeniedControl } from '../hooks/useDeniedControl';
+import { AccountPermissionsCard } from '../components/settings/AccountPermissionsCard';
 import { getSession } from '../services/sessions';
 import { useToast } from '../hooks/use-toast';
 import { log, LogLevel } from '../lib/logger';
@@ -531,6 +532,8 @@ export default function Server() {
       )}
 
       {/* ZoneMinder Control */}
+      <AccountPermissionsCard profileId={currentProfile?.id} />
+
       {/* ZoneMinder control. states.json needs System View, so an account
           without it has nothing to show here rather than an empty picker
           (refs #344). */}

--- a/app/src/pages/Timeline.tsx
+++ b/app/src/pages/Timeline.tsx
@@ -22,6 +22,8 @@ import { useTimelineFilters } from '../hooks/useTimelineFilters';
 import { useTimelineData } from '../hooks/useTimelineData';
 import { useScopedTimelineEvents, type ScopedTimelineEvent } from '../hooks/useScopedTimelineEvents';
 import { useProfileScope } from '../hooks/useProfileScope';
+import { usePermissions } from '../hooks/usePermissions';
+import { canViewEvents } from '../lib/permissions/zm-permissions';
 import { useTvKeyHandler } from '../hooks/useTvKeyHandler';
 import { useScopedEventTagMapping, type ScopedEventRef } from '../hooks/useScopedEventTags';
 import { monitorCacheKey } from '../stores/monitors';
@@ -116,6 +118,13 @@ export default function Timeline() {
   // queries via `enabled` so only the active mode's hook actually fetches.
   const scope = useProfileScope();
   const isAllMode = scope?.mode === 'all';
+
+  // Single mode only: in All mode the events come from several accounts, and
+  // one verdict cannot speak for all of them (refs #344).
+  const { permissions: scopePermissions } = usePermissions(
+    scope?.mode === 'single' ? scope.profile.id : null,
+  );
+  const eventsDenied = canViewEvents(scopePermissions) === 'denied';
   const totalScopeProfiles = scope?.profiles.length ?? 0;
 
   const single = useTimelineData({
@@ -456,8 +465,14 @@ export default function Timeline() {
             <div className="h-[600px] flex items-center justify-center" data-testid="timeline-empty-state">
               <EmptyState
                 icon={Clock}
-                title={detectionCategory !== 'all' ? t('timeline.no_events_in_range') : t('timeline.no_events_found')}
-                description={t('timeline.adjust_filters')}
+                title={
+                  eventsDenied
+                    ? t('events.no_event_permission')
+                    : detectionCategory !== 'all'
+                      ? t('timeline.no_events_in_range')
+                      : t('timeline.no_events_found')
+                }
+                description={eventsDenied ? undefined : t('timeline.adjust_filters')}
               />
             </div>
           ) : (

--- a/app/src/pages/__tests__/Monitors.memo.test.tsx
+++ b/app/src/pages/__tests__/Monitors.memo.test.tsx
@@ -58,6 +58,12 @@ vi.mock('../../components/filters/GroupFilterSelect', () => ({
   GroupFilterSelect: () => <div data-testid="group-filter-select-stub" />,
 }));
 
+// The permission probe is a React Query call; this suite renders without a
+// QueryClientProvider and is not about permissions (refs #344).
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: { system: 'Edit' }, isLoading: false }),
+}));
+
 vi.mock('../../stores/settings', () => ({
   useSettingsStore: (selector: (state: { updateProfileSettings: (...args: unknown[]) => void }) => unknown) =>
     selector({ updateProfileSettings: vi.fn() }),
@@ -89,8 +95,10 @@ vi.mock('../../components/monitors/MonitorCard', async () => {
 });
 
 vi.mock('../../stores/profile', () => ({
-  useProfileStore: (selector: (state: { currentProfileId: string }) => unknown) =>
-    selector({ currentProfileId: 'profile-1' }),
+  // `profiles` is read by usePermissions for the account name (refs #344).
+  useProfileStore: (
+    selector: (state: { currentProfileId: string; profiles: { id: string; username?: string }[] }) => unknown,
+  ) => selector({ currentProfileId: 'profile-1', profiles: [{ id: 'profile-1', username: 'admin' }] }),
 }));
 
 vi.mock('../../stores/auth', () => ({

--- a/app/src/pages/__tests__/Monitors.test.tsx
+++ b/app/src/pages/__tests__/Monitors.test.tsx
@@ -59,8 +59,16 @@ vi.mock('../../components/monitors/MonitorCard', () => ({
 }));
 
 vi.mock('../../stores/profile', () => ({
-  useProfileStore: (selector: (state: { currentProfileId: string }) => unknown) =>
-    selector({ currentProfileId: 'profile-1' }),
+  // `profiles` is read by usePermissions for the account name (refs #344).
+  useProfileStore: (
+    selector: (state: { currentProfileId: string; profiles: { id: string; username?: string }[] }) => unknown,
+  ) => selector({ currentProfileId: 'profile-1', profiles: [{ id: 'profile-1', username: 'admin' }] }),
+}));
+
+// The permission probe is a React Query call; this suite renders without a
+// QueryClientProvider and is not about permissions (refs #344).
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: { system: 'Edit' }, isLoading: false }),
 }));
 
 vi.mock('../../stores/settings', () => ({

--- a/app/src/pages/__tests__/Server.test.tsx
+++ b/app/src/pages/__tests__/Server.test.tsx
@@ -10,6 +10,12 @@ import { getSession } from '../../services/sessions';
 import { getServers } from '../../api/server';
 import { asProfileId, ALL_PROFILES_ID } from '../../api/types';
 
+// The permission probe reaches the profile store, which this suite's session
+// mock cannot satisfy; permissions are not what it tests (refs #344).
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: { system: 'Edit' }, isLoading: false }),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));

--- a/app/src/pages/__tests__/Timeline.test.tsx
+++ b/app/src/pages/__tests__/Timeline.test.tsx
@@ -6,6 +6,12 @@ const useTimelineDataMock = vi.fn();
 const useScopedTimelineEventsMock = vi.fn();
 const useProfileScopeMock = vi.fn();
 
+// The permission probe is a React Query call; these suites render without a
+// provider and are not about permissions (refs #344).
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({ permissions: undefined, isLoading: false }),
+}));
+
 vi.mock('../../hooks/useTimelineData', () => ({
   useTimelineData: (opts: unknown) => useTimelineDataMock(opts),
 }));

--- a/app/src/stores/permissions.ts
+++ b/app/src/stores/permissions.ts
@@ -1,0 +1,74 @@
+/**
+ * Permission refusals this session has already been told about.
+ *
+ * The account's columns (`api/users.ts`) do not decide everything. ZoneMinder
+ * also keeps per-monitor and per-group permission rows that override them
+ * (`web/includes/auth.php`, `editableMonitor`), and nothing in the API exposes
+ * those - so a save can still be refused by a server that told us the account
+ * has Edit. When that happens the surface latches here and stops offering the
+ * action for the rest of the session, which is how the optimistic path stays
+ * honest without asking the user to discover the same refusal twice.
+ *
+ * Deliberately not persisted: granting a permission on the server should take
+ * effect on the next launch with no cache to bust.
+ */
+
+import { create } from 'zustand';
+import type { ProfileId } from '../api/types';
+
+/** The actions a refusal can latch. One per surface that writes. */
+export type PermissionSurface = 'monitor-settings' | 'events-edit' | 'run-state' | 'ptz';
+
+interface PermissionDenialState {
+  /** `${profileId}:${surface}` or `${profileId}:${surface}:${targetId}`. */
+  denied: Record<string, true>;
+  /**
+   * Records that ZoneMinder refused this action. `targetId` narrows the latch
+   * to one monitor or event, for the per-monitor rows the account columns
+   * cannot see; leaving it off latches the surface for the whole profile.
+   */
+  markDenied: (profileId: ProfileId, surface: PermissionSurface, targetId?: string) => void;
+}
+
+export function denialKey(
+  profileId: ProfileId,
+  surface: PermissionSurface,
+  targetId?: string,
+): string {
+  return targetId ? `${profileId}:${surface}:${targetId}` : `${profileId}:${surface}`;
+}
+
+export const usePermissionDenialStore = create<PermissionDenialState>((set) => ({
+  denied: {},
+  markDenied: (profileId, surface, targetId) =>
+    set((state) => {
+      const key = denialKey(profileId, surface, targetId);
+      if (state.denied[key]) return state;
+      return { denied: { ...state.denied, [key]: true } };
+    }),
+}));
+
+/**
+ * Whether this surface has already been refused.
+ *
+ * Reads a single boolean out of the store so a subscribing component
+ * re-renders only when its own latch flips, never on another surface's.
+ */
+export function useIsPermissionDenied(
+  profileId: ProfileId | null | undefined,
+  surface: PermissionSurface,
+  targetId?: string,
+): boolean {
+  return usePermissionDenialStore((state) =>
+    profileId ? state.denied[denialKey(profileId, surface, targetId)] === true : false,
+  );
+}
+
+/** Records a refusal from outside React (mutation handlers, services). */
+export function markPermissionDenied(
+  profileId: ProfileId,
+  surface: PermissionSurface,
+  targetId?: string,
+): void {
+  usePermissionDenialStore.getState().markDenied(profileId, surface, targetId);
+}

--- a/app/tests/features/monitor-detail.feature
+++ b/app/tests/features/monitor-detail.feature
@@ -73,6 +73,12 @@ Feature: Monitor Detail Page
     Then the dialog should close
 
   @all
+  Scenario: An account that may edit still gets the editor
+    When I open the monitor settings dialog
+    Then I should see the monitor settings dialog
+    And the dialog should offer the camera source field
+
+  @all
   Scenario: Settings dialog closes on backdrop tap
     When I click the settings button
     Then I should see the monitor settings dialog

--- a/app/tests/steps/monitor-detail.steps.ts
+++ b/app/tests/steps/monitor-detail.steps.ts
@@ -85,6 +85,17 @@ Then('I should see the monitor settings dialog', async ({ page }) => {
   await expect(dialog.first()).toBeVisible({ timeout: 10000 });
 });
 
+/**
+ * The permission gating (refs #344) hands an account without System Edit a
+ * read-only dialog. The configured test account has Edit, so the editor must
+ * survive: this fails if the probe ever mistakes an administrator for a
+ * restricted user, which is the regression that would hurt most.
+ */
+Then('the dialog should offer the camera source field', async ({ page }) => {
+  await expect(page.getByTestId('settings-source-input')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId('monitor-settings-restricted-note')).toHaveCount(0);
+});
+
 // MJPEG streaming regression steps (issue #155, Tauri socket pool)
 
 /**

--- a/docs/developer-guide/07-api-and-data-fetching.rst
+++ b/docs/developer-guide/07-api-and-data-fetching.rst
@@ -49,6 +49,7 @@ GET     ``/host/getTimeZone.json``                                  Server timez
 GET     ``/configs.json``                                           All ZoneMinder config entries                                             ``server.ts``
 GET     ``/configs/viewByName/<key>.json``                          Single config value (ZM_PATH_ZMS, ZM_GO2RTC_PATH, ZM_MIN_STREAMING_PORT)  ``auth.ts``, ``server.ts``
 GET     ``/groups.json``                                            List monitor groups                                                       ``groups.ts``
+GET     ``/users.json``                                             Permissions of the account this profile signs in as                       ``users.ts``
 GET     ``/states.json``                                            List run states                                                           ``states.ts``
 POST    ``/states/change/<stateName>.json``                         Switch to a run state                                                     ``states.ts``
 GET     ``/notifications.json``                                     List push notification registrations                                      ``notifications.ts``
@@ -1553,6 +1554,57 @@ filter monitors in the Monitors and Montage views.
 
 ``useGroups`` wraps this with ``queryKeys.groups(profileId)`` and a 5-minute
 ``staleTime``.
+
+Account Permissions API (``api/users.ts``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ZoneMinder has no endpoint for "what may the current user do". The permission
+columns live on the Users row, and ``UsersController`` gates ``/users.json`` on
+``System() != 'None'``, so an account can read its own permissions only when it
+already has some system access. ``fetchAccountPermissions`` works with that
+shape rather than around it:
+
+.. code:: tsx
+
+   import { fetchAccountPermissions } from '../api/users';
+
+   // Matches the row whose Username equals the profile's, case-insensitively.
+   const permissions = await fetchAccountPermissions(client, profile.username);
+
+Three results, each meaning something different:
+
+- The account's columns, when the list came back and contained its row.
+- ``SYSTEM_NONE_PERMISSIONS`` when the server answered 401. That refusal is
+  itself an answer: it proves ``System`` is ``'None'``, and leaves every other
+  column unknown.
+- ``undefined`` when the list came back without a matching row, which happens
+  if ZoneMinder maps the token to a name the profile does not store. Gating a
+  session on somebody else's row would be worse than knowing nothing.
+
+A profile with no username talks to a server with ``ZM_OPT_USE_AUTH`` off,
+where ZoneMinder short-circuits every check on ``!$user``. That returns
+``UNRESTRICTED_PERMISSIONS`` without a request.
+
+Transport failures reject, so the query retries them. A privilege refusal does
+not: retrying spends requests to be told the same thing.
+
+Every consumer asks ``lib/permissions/zm-permissions.ts`` for a verdict rather
+than reading a column, and every verdict has three values:
+
+.. code:: tsx
+
+   import { canViewStream } from '../lib/permissions/zm-permissions';
+
+   canViewStream(permissions); // 'allowed' | 'denied' | 'unknown'
+
+Only ``denied`` may hide or grey a control. ``unknown`` has to leave the
+surface exactly as it was, because ``System='None'`` with ``Monitors='Edit'``
+is a legal ZoneMinder account: guessing there takes a feature away from someone
+who has it. ``usePermissions(profileId)`` wraps the fetch with
+``queryKeys.accountPermissions(profileId)`` and an infinite ``staleTime``. It
+takes an explicit profile id because an aggregate has no account of its own;
+in All mode each monitor and event belongs to a real profile, and that owner's
+permissions are the ones that decide what its controls can do.
 
 Event Tags API (``api/tags.ts``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -3050,6 +3050,125 @@ land in the wrong bucket.
 Flow 21 covers the scope these connectors fan out over; Flow 7 is the
 single-profile mechanics each one repeats N times over.
 
+Flow 24: Opening a monitor's settings on a restricted account
+-------------------------------------------------------------
+
+ZoneMinder accounts are not all administrators, and the app has to work out
+what this one may do without an endpoint that answers the question. The
+counterintuitive part: the request that fails tells you as much as the one that
+succeeds. ``/users.json`` is gated on ``System() != 'None'``, so a 401 there
+proves the account has no system access, which is exactly the fact the gear
+needs.
+
+.. mermaid::
+
+   sequenceDiagram
+       autonumber
+       participant UI as MonitorDetail
+       participant Hook as usePermissions
+       participant Api as api/users.ts
+       participant ZM as ZoneMinder
+       participant Dialog as MonitorSettingsDialog
+
+       UI->>Hook: usePermissions(ownerProfile.id)
+       Hook->>Api: fetchAccountPermissions(client, username)
+       Api->>ZM: GET /users.json
+       ZM-->>Api: 401 Insufficient Privileges
+       Api-->>Hook: SYSTEM_NONE_PERMISSIONS
+       UI->>Dialog: onSave omitted, restrictedReason="account"
+       Dialog-->>UI: read-only panel, no camera fields
+
+#. **The page asks about the owning profile, not the current one.**
+   ``usePermissions`` takes an explicit id because an aggregate has no account:
+   in All mode the monitor on screen belongs to one real profile, and that is
+   whose permissions decide what its controls do.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/hooks/usePermissions.ts>`__
+   · → :doc:`07-api-and-data-fetching`
+
+#. **The probe runs once per profile.** The query uses an infinite
+   ``staleTime``: permissions change when an administrator edits the account,
+   which this app can neither observe nor cause. React Query's cache makes
+   every later consumer a cache read rather than a request.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/hooks/usePermissions.ts>`__
+   · → :doc:`07-api-and-data-fetching`
+
+#. **A profile with no username never asks.** That server has
+   ``ZM_OPT_USE_AUTH`` off, where ZoneMinder short-circuits every check on
+   ``!$user``, so the answer is ``UNRESTRICTED_PERMISSIONS`` with no request.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/api/users.ts>`__
+   · → :doc:`07-api-and-data-fetching`
+
+#. **The refusal is parsed, not just counted.** ``isPermissionDenied`` matches
+   ZoneMinder's "Insufficient Privileges" body rather than the bare 401 status,
+   because the same status also means "log in again" and the two need opposite
+   handling.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/permissions/permission-error.ts>`__
+   · → :doc:`07-api-and-data-fetching`
+
+#. **A privilege 401 skips token recovery.** In ``api/client.ts`` the retry
+   path is what a stale session needs and what a refusal cannot use: a refusal
+   survives any number of fresh tokens, so refreshing one only spends a refresh
+   and a retry before failing identically.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/api/client.ts>`__
+   · → :doc:`07-api-and-data-fetching`
+
+#. **The verdict is three-valued.** ``canEditMonitorSettings`` answers
+   ``allowed``, ``denied`` or ``unknown``, and only ``denied`` may take
+   anything away. ``System='None'`` with ``Monitors='Edit'`` is a legal
+   account, so guessing on ``unknown`` would remove an editor from someone
+   entitled to it.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/permissions/zm-permissions.ts>`__
+   · → :doc:`12-shared-services-and-components`
+
+#. **The page withholds the callback rather than passing a flag.** Denied,
+   ``MonitorDetail`` omits ``onSave``, and the dialog's existing
+   ``editable = !!onSave`` does the rest. No new state, and the read-only path
+   cannot drift from the "no save handler" path because they are the same path.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/pages/MonitorDetail.tsx>`__
+   · → :doc:`04-pages-and-views`
+
+#. **The restricted panel keeps what was never ZoneMinder's.** Force-ZMS, the
+   per-monitor Go2RTC override and the cycle interval are profile settings, not
+   monitor columns, and they are the stream troubleshooting knobs a restricted
+   user needs most. The camera's address, username and password are what goes.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/monitor-detail/MonitorRestrictedSettings.tsx>`__
+   · → :doc:`05-component-architecture`
+
+#. **A save can still be refused, and the refusal is remembered.** ZoneMinder
+   also keeps per-monitor permission rows (``editableMonitor`` in
+   ``web/includes/auth.php``) that override the account columns and appear
+   nowhere in the API, so ``System='Edit'`` does not guarantee a save. The
+   catch latches that monitor through ``markPermissionDenied``, and the dialog
+   turns read-only with a note naming the monitor rather than the account.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/stores/permissions.ts>`__
+   · → :doc:`03-state-management-zustand`
+
+#. **The latch is deliberately not persisted.** Granting a permission on the
+   server should take effect on the next launch with no cache to bust.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/stores/permissions.ts>`__
+   · → :doc:`03-state-management-zustand`
+
+#. **Buttons elsewhere grey instead of vanishing, and stay clickable.**
+   ``useDeniedControl`` returns ``aria-disabled`` rather than ``disabled``: a
+   disabled button dispatches no pointer events, so ``useLongPressHint`` never
+   fires and browsers suppress ``title`` too. It would grey out and explain
+   nothing.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/hooks/useDeniedControl.ts>`__
+   · → :doc:`12-shared-services-and-components`
+
+#. **One capability has no failing request to catch.** ``zms.cpp`` checks
+   ``Stream`` independently of ``Monitors``, and a denied stream is an image
+   that never loads. ``LiveMonitorPlayer`` is the single gate for every stream
+   surface, so the probe is what turns a permanently blank tile into a
+   sentence.
+   `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/monitors/LiveMonitorPlayer.tsx>`__
+   · → :doc:`05-component-architecture`
+
+Absent here: any attempt to discover permissions before login, and any check
+that hides a surface on ``unknown``. Flow 6 covers the token lifecycle this
+flow deliberately steps around; Flow 17 is the PTZ path whose pad the
+``Control`` column removes.
+
 These flows touch most of the moving parts of the app. When you need to change
 something, find the nearest scene, open its ``source`` link to land on the exact
 code, and follow the ``→`` link for the chapter that explains that layer.

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -103,6 +103,8 @@ Both fields remain editable. Changing the camera's hostname while the password i
 
 To read a stored password, turn on **Settings → Advanced → Disable log redaction**, then turn it off again when you are done. Note that ZoneMinder's API returns these credentials to any account that can view the monitor, so hiding them in the app is not a substitute for restricting who has an account on your server.
 
+The dialog only offers these fields to an account with the System: Edit permission. Anything less opens a read-only panel instead, with the app's own per-monitor settings and a few read-only facts, and no camera address or credentials at all. See [What your account can do](server.md#what-your-account-can-do).
+
 ## Monitor Status Indicators
 
 | Status | Meaning |

--- a/docs/user-guide/server.md
+++ b/docs/user-guide/server.md
@@ -35,9 +35,32 @@ Each enabled storage area is listed with:
 - Used and total space in GB, with a usage bar
 - The server it belongs to (in multi-server setups)
 
+## Account permissions
+
+Lists what the ZoneMinder account this profile signs in as is allowed to do: its System, Monitors, Stream, Events, Control and Groups levels. These come from the account's own ZoneMinder user record, and only an administrator can change them, in Options then Users in the ZoneMinder web console.
+
+Where a level reads "Not determined", the app could not read it. ZoneMinder only lets an account read its own permissions when it has at least System View, so an account below that is told what is known about it, which is that it has no system access.
+
+These levels explain what the rest of the app does or does not offer you. See [What your account can do](#what-your-account-can-do) below.
+
 ## ZoneMinder control
 
 Shows the current ZoneMinder run state and lets you apply a different one. Changing the run state takes effect on the server, so you can switch between configured states (for example a "Home" or "Away" state) without opening the ZoneMinder web console.
+
+Applying a state needs System: Edit. Without it the Apply button is greyed; tap or hover it and it says which permission is missing. Below System: View the whole card is hidden, because ZoneMinder will not list the states at all.
+
+## What your account can do
+
+A restricted ZoneMinder account can use the app, and the app tries to say so rather than appearing broken. What changes:
+
+- **Camera settings**: without System: Edit, the gear on a monitor opens a read-only panel. The app's own per-monitor settings stay usable there, including "Always use ZMS" and the Go2RTC override, along with resolution, colours and linked monitors. The camera's source address, username and password are not shown.
+- **Live video**: Stream is a separate permission from Monitors. An account that can list a camera but not stream it sees a message in place of the video instead of a picture that never loads.
+- **PTZ**: the pan, tilt and zoom pad needs the Control permission. Without it the pad is not shown, even for a camera that supports it.
+- **Events**: archiving and deleting need Events: Edit. Those buttons stay visible but greyed, and say what is missing when you tap, hover or hold them.
+- **Logs**: the Logs page needs System: View. Without it the entry is not in the sidebar.
+- **Groups**: the group filter needs the Groups permission, which is separate from monitor access.
+
+If a camera or event list is empty, check the matching permission here before assuming the server has nothing to show.
 
 ## Multi-server clusters
 


### PR DESCRIPTION
Closes #344 once you confirm.

## What this does

A restricted ZoneMinder account can now use the app without it looking broken. Before this, a view-only user got a fully editable monitor settings dialog, pressed Save, and read "Failed to update capture settings" - a message about the server, for a problem with the account. Each press also spent a token refresh and a retry first, because the client mistook the privilege 401 for an expired session.

## The constraint that shaped it

ZoneMinder has no "my permissions" endpoint. `/host/login.json` returns tokens only; the JWT carries the username and nothing else. The columns live on the Users row, and `UsersController` gates `users.json` on `System() != 'None'`.

So permissions are readable only for an account that already has some system access. Measured against a live 1.39.18 server with a restricted account:

```
users.json    -> 401 Insufficient Privileges     monitors.json -> 200
states.json   -> 401                             configs.json  -> 200
logs.json     -> 401                             POST monitors/1.json -> 401
groups.json   -> 401
```

The refusal is still an answer: it proves `System` is `'None'`. Everything it hides stays genuinely unknown.

## Three states, not two

Every verdict is `allowed`, `denied` or `unknown`, and only `denied` may hide or grey anything. `unknown` leaves the surface exactly as it was and lets the write fail honestly. Guessing there would take a feature away from someone who has it: `System='None'` with `Monitors='Edit'` is a legal account.

Two things the probe cannot see, both covered by the same latch: ZoneMinder's `Monitor_Permissions` and `Group_Permissions` rows (`web/includes/auth.php`, `editableMonitor`) override the account columns and appear nowhere in the API. So a save can be refused even at `System='Edit'`; the first refusal latches that monitor for the session and the dialog turns read-only with a note naming the monitor rather than the account.

## Surface by surface

| Surface | Denied behavior |
|---|---|
| Monitor settings gear | Opens a read-only panel below System: Edit. App-local settings (force-ZMS, Go2RTC override, cycle) stay; camera address, username, password and every ZM field go |
| Live video | `Stream` is separate from `Monitors`. Denied, an explanation replaces the player, and the app stops asking for the stream |
| PTZ | Pad hidden when `Control` is None, even on a controllable camera |
| Archive / delete | Greyed and still clickable, explaining on hover, hold and tap |
| Run state | Apply greyed below System: Edit; whole card hidden below System: View |
| Logs | Nav entry removed below System: View |
| Group filter | Query skipped when `Groups` is None |
| Monitors / Timeline empty states | Say the account has no permission instead of blaming the server |
| Server page | New card listing every column, "Not determined" where unreadable |

Force-alarm is deliberately left alone: `MonitorsController::alarm` has no permission check upstream, so gating our button would diverge from what the server actually enforces.

## Two details worth reviewing

**Greyed controls are `aria-disabled`, never `disabled`.** A disabled button dispatches no pointer events, so `useLongPressHint` never fires and browsers suppress `title` too - it would grey out and explain nothing, which is the failure this change exists to fix. Live and greyed, one string explains three ways: hover, hold, tap. Tap matters most, since that is what a phone user tries first. It also keeps the control focusable so a screen reader announces it as unavailable (I3).

**A privilege 401 skips token recovery.** `isPermissionDenied` matches ZoneMinder's "Insufficient Privileges" body rather than the bare status, deliberately narrowly: anything it cannot positively identify keeps the old recovery path, because misreading a stale session as a permission problem would strand a user who only needed a new token.

## Scope note

The issue listed withholding the assistant's write tools. Not needed: `lib/assistant/tools.ts` has been read-only by construction since #246 - `deleteEvent`, `setMonitorEnabled` and `changeState` do not exist as tools. Nothing to gate.

## Verification

- `npm run gates` passes: 4051 unit tests, build, and all three lints (ratchet baseline unchanged at 202).
- Live-server probing against 1.39.18 with a restricted account, which is where the endpoint table above comes from.
- **Browser e2e did not run.** The test server (192.168.50.108) became unreachable partway through the run - 100% packet loss, and it had been answering earlier in the session. The 20 failures are all the pre-login connection probe timing out on the profile form, a path this branch does not touch. Needs a rerun of `npm run test:e2e -- monitor-detail.feature` once the server is back.

Also unverified: device e2e (iOS, Android, Tauri), which is manual-only.

Claude assisting @pliablepixels
