### PR TITLE
Finish the permission backstop on the event and run-state writes

### DIFF
--- a/app/src/components/events/EventCard.tsx
+++ b/app/src/components/events/EventCard.tsx
@@ -30,6 +30,8 @@ import { setEventArchived } from '../../api/events';
 import { usePermissions } from '../../hooks/usePermissions';
 import { canEditEvents } from '../../lib/permissions/zm-permissions';
 import { useDeniedControl } from '../../hooks/useDeniedControl';
+import { isPermissionDenied } from '../../lib/permissions/permission-error';
+import { markPermissionDenied, useIsPermissionDenied } from '../../stores/permissions';
 import { getSession } from '../../services/sessions';
 import { log, LogLevel } from '../../lib/logger';
 import { TagChipList } from './TagChip';
@@ -108,6 +110,7 @@ function EventCardComponent({ event, monitorName, profileId, profileChip, thumbn
   };
 
   const { permissions } = usePermissions(ownerProfileId);
+  const archiveRefused = useIsPermissionDenied(ownerProfileId, 'events-edit');
 
   const handleArchiveClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -123,7 +126,16 @@ function EventCardComponent({ event, monitorName, profileId, profileChip, thumbn
       toast.success(next ? t('events.archived_success') : t('events.unarchived_success'));
     } catch (err) {
       log.eventCard('Archive toggle failed', LogLevel.ERROR, { eventId: event.Id, next, error: err });
-      toast.error(t('events.archive_failed'));
+      // An account too restricted to read its own permissions leaves this
+      // control ungated, so the refusal is the only thing that can explain
+      // itself. Spend it once: say what happened, and grey the control so the
+      // next press is not the same discovery (refs #344).
+      if (isPermissionDenied(err) && ownerProfileId) {
+        markPermissionDenied(ownerProfileId, 'events-edit');
+        toast.error(t('events.archive_permission_denied'));
+      } else {
+        toast.error(t('events.archive_failed'));
+      }
     } finally {
       setIsArchiving(false);
     }
@@ -132,7 +144,7 @@ function EventCardComponent({ event, monitorName, profileId, profileChip, thumbn
   // Archiving needs Events: Edit. The control stays live and greyed so it can
   // still say why it does nothing (refs #344).
   const archiveProps = useDeniedControl({
-    denied: canEditEvents(permissions) === 'denied',
+    denied: canEditEvents(permissions) === 'denied' || archiveRefused,
     message: t('events.archive_permission_denied'),
     onClick: handleArchiveClick,
     title: isArchived ? t('events.unarchive') : t('events.archive'),

--- a/app/src/components/events/EventDeleteButton.tsx
+++ b/app/src/components/events/EventDeleteButton.tsx
@@ -12,6 +12,7 @@ import { HintButton } from '../ui/button';
 import { usePermissions } from '../../hooks/usePermissions';
 import { canEditEvents } from '../../lib/permissions/zm-permissions';
 import { useDeniedControl } from '../../hooks/useDeniedControl';
+import { useIsPermissionDenied } from '../../stores/permissions';
 
 interface EventDeleteButtonProps {
   eventId: string;
@@ -32,8 +33,9 @@ export function EventDeleteButton({ eventId, profileId, size = 'md', className }
   // Deleting needs Events: Edit. Greyed rather than hidden, so an
   // administrator can see which permission their account is missing (refs #344).
   const { permissions } = usePermissions(profileId);
+  const deleteRefused = useIsPermissionDenied(profileId, 'events-edit');
   const deniedProps = useDeniedControl({
-    denied: canEditEvents(permissions) === 'denied',
+    denied: canEditEvents(permissions) === 'denied' || deleteRefused,
     message: t('events.delete_permission_denied'),
     onClick: (e) => {
       e.stopPropagation();

--- a/app/src/components/events/__tests__/EventCard.test.tsx
+++ b/app/src/components/events/__tests__/EventCard.test.tsx
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import { EventCard } from '../EventCard';
+import { setEventArchived } from '../../../api/events';
+import { asProfileId } from '../../../api/types';
+import { toast } from 'sonner';
+import { createHttpError } from '../../../lib/http/types';
+import { usePermissionDenialStore } from '../../../stores/permissions';
 
 const navigate = vi.fn();
 
@@ -18,6 +23,17 @@ vi.mock('../../../hooks/usePermissions', () => ({
     permissions: mockEventsPermission === undefined ? undefined : { events: mockEventsPermission },
     isLoading: false,
   }),
+}));
+
+vi.mock('../../../api/events', () => ({ setEventArchived: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }));
+
+// Partial: the profile store registers its own gate against this module on
+// import, so the real exports have to survive the mock.
+vi.mock('../../../services/sessions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../services/sessions')>()),
+  getSession: () => ({ client: {} }),
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -40,6 +56,7 @@ vi.mock('../../../lib/logger', () => ({
     api: vi.fn(),
     auth: vi.fn(),
     profile: vi.fn(),
+    eventCard: vi.fn(),
   },
   LogLevel: {
     DEBUG: 0,
@@ -89,9 +106,13 @@ function makeEvent(overrides: Partial<typeof baseEvent>) {
   return { ...baseEvent, ...overrides };
 }
 
-function renderEventCard(eventOverrides: Partial<typeof baseEvent> = {}) {
+function renderEventCard(
+  eventOverrides: Partial<typeof baseEvent> = {},
+  props: Record<string, unknown> = {},
+) {
   return renderWithClient(
     <EventCard
+      {...props}
       event={makeEvent(eventOverrides)}
       monitorName="Front Door"
       thumbnailUrls={['https://example.test/thumb.jpg']}
@@ -346,6 +367,64 @@ describe('EventCard without permission to archive', () => {
   it('leaves it alone while the permission is unknown', () => {
     renderEventCard({});
 
+    expect(screen.getByTestId('event-archive-button')).not.toHaveAttribute('aria-disabled');
+  });
+});
+
+/**
+ * When the account is too restricted to be gated in advance (refs #344).
+ *
+ * An account that cannot read its own permissions - System='None', which is
+ * every account below System View - leaves canEditEvents at 'unknown', so the
+ * archive control is deliberately left alone. The refusal is then the only
+ * thing that can teach anyone anything, so it has to be spent well: say what
+ * actually happened, and do not make the user discover it twice.
+ */
+describe('EventCard when ZoneMinder refuses the archive', () => {
+  const privilegeRefusal = createHttpError(
+    401,
+    'Unauthorized',
+    { success: false, data: { name: 'Insufficient Privileges' } },
+    {},
+  );
+
+  beforeEach(() => {
+    mockEventsPermission = undefined;
+    usePermissionDenialStore.setState({ denied: {} });
+    vi.mocked(setEventArchived).mockReset();
+  });
+
+  it('names the permission instead of blaming the archive', async () => {
+    vi.mocked(setEventArchived).mockRejectedValue(privilegeRefusal);
+
+    renderEventCard({}, { profileId: asProfileId('p1') });
+    fireEvent.click(screen.getByTestId('event-archive-button'));
+
+    await waitFor(() =>
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('events.archive_permission_denied'),
+    );
+  });
+
+  it('greys the control afterwards so the refusal is spent once', async () => {
+    vi.mocked(setEventArchived).mockRejectedValue(privilegeRefusal);
+
+    renderEventCard({}, { profileId: asProfileId('p1') });
+    fireEvent.click(screen.getByTestId('event-archive-button'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('event-archive-button')).toHaveAttribute('aria-disabled', 'true'),
+    );
+  });
+
+  it('leaves the control alone when the failure was not about permission', async () => {
+    // A timeout says nothing about the account, and greying on it would take
+    // archiving away from someone who has it.
+    vi.mocked(setEventArchived).mockRejectedValue(new Error('Failed to fetch'));
+
+    renderEventCard({}, { profileId: asProfileId('p1') });
+    fireEvent.click(screen.getByTestId('event-archive-button'));
+
+    await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('events.archive_failed'));
     expect(screen.getByTestId('event-archive-button')).not.toHaveAttribute('aria-disabled');
   });
 });

--- a/app/src/hooks/__tests__/useBulkDeleteEvents.test.tsx
+++ b/app/src/hooks/__tests__/useBulkDeleteEvents.test.tsx
@@ -8,6 +8,8 @@ import { getSession } from '../../services/sessions';
 import { eventSelectionKey } from '../../stores/deleteSelection';
 import { asProfileId } from '../../api/types';
 import { toast } from 'sonner';
+import { createHttpError } from '../../lib/http/types';
+import { usePermissionDenialStore, denialKey } from '../../stores/permissions';
 
 const P1 = asProfileId('p1');
 const P2 = asProfileId('p2');
@@ -222,5 +224,53 @@ describe('useBulkDeleteEvents - All mode', () => {
     expect(deleteEvent).not.toHaveBeenCalled();
     // Nothing survived, so there is no count worth reporting.
     expect(toast.error).toHaveBeenCalledWith('events.delete_failed:');
+  });
+});
+
+/**
+ * A refused delete has to be told apart from a failed one (refs #344).
+ *
+ * allSettled only counts, so before this the 401 that means "your account may
+ * not" and the timeout that means "try again" produced the same sentence, and
+ * the user could queue the same events forever.
+ */
+describe('useBulkDeleteEvents when ZoneMinder refuses', () => {
+  const privilegeRefusal = createHttpError(
+    401,
+    'Unauthorized',
+    { success: false, data: { name: 'Insufficient Privileges' } },
+    {},
+  );
+
+  beforeEach(() => {
+    usePermissionDenialStore.setState({ denied: {} });
+  });
+
+  it('names the permission rather than reporting a generic failure', async () => {
+    vi.mocked(deleteEvent).mockRejectedValue(privilegeRefusal);
+
+    const { result } = renderHook(() => useBulkDeleteEvents(), { wrapper });
+    await act(async () => { await result.current.deleteEvents(['1']); });
+
+    expect(toast.error).toHaveBeenCalledWith('events.delete_permission_denied:');
+  });
+
+  it('latches the profile so the controls grey afterwards', async () => {
+    vi.mocked(deleteEvent).mockRejectedValue(privilegeRefusal);
+
+    const { result } = renderHook(() => useBulkDeleteEvents(), { wrapper });
+    await act(async () => { await result.current.deleteEvents(['1']); });
+
+    expect(usePermissionDenialStore.getState().denied[denialKey(P1, 'events-edit')]).toBe(true);
+  });
+
+  it('leaves the generic message and no latch for an ordinary failure', async () => {
+    vi.mocked(deleteEvent).mockRejectedValue(new Error('Failed to fetch'));
+
+    const { result } = renderHook(() => useBulkDeleteEvents(), { wrapper });
+    await act(async () => { await result.current.deleteEvents(['1']); });
+
+    expect(toast.error).toHaveBeenCalledWith('events.delete_failed:');
+    expect(usePermissionDenialStore.getState().denied).toEqual({});
   });
 });

--- a/app/src/hooks/useBulkDeleteEvents.ts
+++ b/app/src/hooks/useBulkDeleteEvents.ts
@@ -21,6 +21,8 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { deleteEvent as apiDeleteEvent } from '../api/events';
 import { getSession } from '../services/sessions';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import { markPermissionDenied } from '../stores/permissions';
 import type { EventData, EventsResponse, ProfileId } from '../api/types';
 import { queryKeys } from '../lib/query/query-keys';
 import { parseEventSelectionKey } from '../stores/deleteSelection';
@@ -82,6 +84,10 @@ export function useBulkDeleteEvents(profileId?: ProfileId): {
       }
 
       const deletedKeys: string[] = [];
+      // allSettled counts failures but says nothing about why. A privilege
+      // refusal has to be told apart from a timeout: it is the only failure
+      // worth naming, and the only one worth remembering (refs #344).
+      let refusedByPermission = false;
       await Promise.all(
         [...byProfile].map(async ([owner, events]) => {
           let client;
@@ -96,6 +102,10 @@ export function useBulkDeleteEvents(profileId?: ProfileId): {
           const results = await Promise.allSettled(events.map((e) => apiDeleteEvent(client, e.eventId)));
           const deleted = events.filter((_, i) => results[i].status === 'fulfilled');
           failed += events.length - deleted.length;
+          if (results.some((r) => r.status === 'rejected' && isPermissionDenied(r.reason))) {
+            refusedByPermission = true;
+            markPermissionDenied(owner, 'events-edit');
+          }
           deletedKeys.push(...deleted.map((e) => e.key));
           if (deleted.length === 0) return;
 
@@ -132,7 +142,9 @@ export function useBulkDeleteEvents(profileId?: ProfileId): {
         toast.error(
           deletedKeys.length > 0
             ? t('events.delete_partial', { count: deletedKeys.length, failed })
-            : t('events.delete_failed')
+            : refusedByPermission
+              ? t('events.delete_permission_denied')
+              : t('events.delete_failed')
         );
       } else {
         toast.success(t('events.delete_selected_success', { count: deletedKeys.length }));

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -12,6 +12,8 @@ import { getEvent, getEventVideoUrl, getEventImageUrl, setEventArchived } from '
 import { usePermissions } from '../hooks/usePermissions';
 import { canEditEvents } from '../lib/permissions/zm-permissions';
 import { useDeniedControl } from '../hooks/useDeniedControl';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import { markPermissionDenied, useIsPermissionDenied } from '../stores/permissions';
 import { getSession, tryGetCurrentSession } from '../services/sessions';
 import type { ApiClient } from '../api/client';
 import { eventHasAlarmFrame } from '../lib/event/thumbnail-chain';
@@ -107,6 +109,9 @@ export default function EventDetail() {
   // existing error state below covers both cases without new branching
   // (refs #337).
   const { profile: ownerProfile, settings } = useProfileById(routeProfileId);
+  // A primitive, so the archive callback depends on the id rather than on the
+  // profile object identity.
+  const ownerProfileId = ownerProfile?.id;
   const dataEnabled = !!id && !!ownerProfile;
   const { data: event, isLoading, error } = useQuery({
     queryKey: queryKeys.event(ownerProfile?.id, id),
@@ -223,23 +228,31 @@ export default function EventDetail() {
     try {
       await setEventArchived(resolveClient(routeProfileId), event.Event.Id, next);
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.event(ownerProfile?.id, event.Event.Id) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.events(ownerProfile?.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.event(ownerProfileId, event.Event.Id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.events(ownerProfileId) }),
       ]);
       toast.success(next ? t('events.archived_success') : t('events.unarchived_success'));
     } catch (err) {
       log.eventDetail('Archive toggle failed', LogLevel.ERROR, { eventId: event.Event.Id, next, error: err });
-      toast.error(t('events.archive_failed'));
+      // The account may be too restricted to have been gated in advance, in
+      // which case this refusal is the only explanation anyone gets (refs #344).
+      if (isPermissionDenied(err) && ownerProfileId) {
+        markPermissionDenied(ownerProfileId, 'events-edit');
+        toast.error(t('events.archive_permission_denied'));
+      } else {
+        toast.error(t('events.archive_failed'));
+      }
     } finally {
       setIsArchiving(false);
     }
-  }, [event, isArchived, isArchiving, routeProfileId, ownerProfile?.id, queryClient, t]);
+  }, [event, isArchived, isArchiving, routeProfileId, ownerProfileId, queryClient, t]);
 
   // Archiving needs Events: Edit. Greyed and still live, so hover, hold and tap
   // all say which permission is missing (refs #344).
-  const { permissions } = usePermissions(ownerProfile?.id);
+  const { permissions } = usePermissions(ownerProfileId);
+  const archiveRefused = useIsPermissionDenied(ownerProfileId, 'events-edit');
   const archiveProps = useDeniedControl({
-    denied: canEditEvents(permissions) === 'denied',
+    denied: canEditEvents(permissions) === 'denied' || archiveRefused,
     message: t('events.archive_permission_denied'),
     onClick: handleArchiveToggle,
     title: isArchived ? t('event_detail.unarchive') : t('event_detail.archive'),

--- a/app/src/pages/Server.tsx
+++ b/app/src/pages/Server.tsx
@@ -40,6 +40,8 @@ import { getStates, changeState } from '../api/states';
 import { usePermissions } from '../hooks/usePermissions';
 import { canChangeRunState, canViewSystem } from '../lib/permissions/zm-permissions';
 import { useDeniedControl } from '../hooks/useDeniedControl';
+import { isPermissionDenied } from '../lib/permissions/permission-error';
+import { markPermissionDenied, useIsPermissionDenied } from '../stores/permissions';
 import { AccountPermissionsCard } from '../components/settings/AccountPermissionsCard';
 import { getSession } from '../services/sessions';
 import { useToast } from '../hooks/use-toast';
@@ -135,9 +137,16 @@ export default function Server() {
       log.server('State/action applied', LogLevel.INFO, { action: effectiveAction });
     },
     onError: (error) => {
+      // System View can read the states but not change them, and an account
+      // that cannot read its own permissions is not gated in advance at all -
+      // so this refusal is the only thing that can explain itself (refs #344).
+      const refused = isPermissionDenied(error) && !!currentProfile;
+      if (refused) markPermissionDenied(currentProfile.id, 'run-state');
       toast({
         title: t('common.error'),
-        description: t('server.state_apply_failed'),
+        description: refused
+          ? t('server.run_state_permission_denied')
+          : t('server.state_apply_failed'),
         variant: 'destructive',
       });
       log.server('Failed to apply state/action', LogLevel.ERROR, error);
@@ -163,8 +172,9 @@ export default function Server() {
   // and the greyed button is what tells an administrator why it is inert
   // (refs #344).
   const { permissions } = usePermissions(currentProfile?.id);
+  const runStateRefused = useIsPermissionDenied(currentProfile?.id, 'run-state');
   const applyProps = useDeniedControl({
-    denied: canChangeRunState(permissions) === 'denied',
+    denied: canChangeRunState(permissions) === 'denied' || runStateRefused,
     message: t('server.run_state_permission_denied'),
     onClick: handleApply,
     className: 'flex items-center gap-2',

--- a/app/src/stores/permissions.ts
+++ b/app/src/stores/permissions.ts
@@ -17,7 +17,12 @@ import { create } from 'zustand';
 import type { ProfileId } from '../api/types';
 
 /** The actions a refusal can latch. One per surface that writes. */
-export type PermissionSurface = 'monitor-settings' | 'events-edit' | 'run-state' | 'ptz';
+/**
+ * PTZ is deliberately absent: `ajax/control.php` has no else branch, so a
+ * denied command answers 200 with no body. There is no refusal to catch, which
+ * is why that pad is gated proactively or not at all.
+ */
+export type PermissionSurface = 'monitor-settings' | 'events-edit' | 'run-state';
 
 interface PermissionDenialState {
   /** `${profileId}:${surface}` or `${profileId}:${surface}:${targetId}`. */


### PR DESCRIPTION
Closes #344 (reopened).

## What was wrong

Testing with a `test/test` account: archive and delete were still enabled, and failed with "Failed to archive event".

The proactive gating from #345 did ship on those controls. It just cannot fire for that account. `users.json` refuses anyone below System View, so the probe learns `System='None'` and nothing else; `canEditEvents` returns `'unknown'`, and `unknown` deliberately never gates - `System='None'` with `Events='Edit'` is a legal account, and greying on that guess would take archiving away from someone who has it.

The refusal was supposed to carry the explanation instead. #344 says "every write path gets the same backstop regardless", and that half only ever got wired for monitor settings: `markPermissionDenied` had two call sites, both `'monitor-settings'`. So the account that most needs the fallback saw none of it, and could repeat the same failure forever.

Bulk delete was worse: `Promise.allSettled` counted failures without ever reading a reason, so a 401 and a timeout produced the same sentence.

## What this does

Four write paths now tell a privilege refusal from an ordinary failure - `EventCard`, `EventDetail`, `useBulkDeleteEvents`, and the Server run-state mutation. Each names the permission, latches the surface, and greys the control exactly as a known denial would. `EventDeleteButton` reads the same latch, so queueing greys too.

An ordinary failure still greys nothing and says nothing about permissions, which is the point: a timeout says nothing about the account.

The first attempt still fails. That is not fixable for an account below System View - nothing can be known in advance - but it now fails once, with the right sentence.

## PTZ is deliberately not wired

`ajax/control.php` gates on `canView('Control', id)` with no else branch, so a denied command answers 200 with no body. There is no refusal to catch. `'ptz'` is dropped from `PermissionSurface` rather than left as a member nothing can ever set; that pad stays proactively gated or not gated at all.

## Verification

`npm run gates` passes, and the unit suite was also run under `TZ=UTC` to match CI: 4057 passing. Ratchet baseline unchanged at 202 - `EventDetail`'s archive callback now closes over the profile id primitive rather than the profile object, which keeps `exhaustive-deps` flat.

Three test-harness gaps surfaced while writing the EventCard coverage and are fixed here: the suite's logger mock was missing `log.eventCard` (so the catch block threw before reaching its toast, silently), `services/sessions` needed a partial mock, and the card needed an owning profile to act at all.

Not run: browser e2e for this change (the affected paths have no scenario), and device e2e, which is manual-only.

Claude assisting @pliablepixels
