### PR TITLE
fix(monitors): show no-video instead of a stale or broken MJPEG frame

### DIFF
--- a/agents/project/domain-context.md
+++ b/agents/project/domain-context.md
@@ -55,6 +55,17 @@ matching reality, fixing it is a protocol change like any rule edit.
 - Electron background/occlusion process switches do not fix MJPEG going
   blank on occluded windows; tried and reverted (69990402). The fix is
   stream-level reconnect on focus or visibility return (f7a8292e).
+- A minted connkey is not a frame. Gate an `<img>`'s visibility on a `load`
+  for the src it currently holds, never on the URL existing: the element
+  keeps a dead stream's last frame (which may be half written) with no error
+  event, and on a mobile resume WebKit re-fetches images it evicted while
+  backgrounded against connkeys that are now dead, painting its broken-image
+  glyph before any error event lands. Alt text on a stream image is what the
+  browser draws beside that glyph, so keep it empty (#352).
+- `visibilitychange` alone is not a reliable resume signal on native: the
+  WebView suspends with the app and is not obliged to report an app state
+  change as a visibility change. Pair it with Capacitor `appStateChange`.
+  Notifications learned this in #274 and streams re-learned it in #352.
 - Tauri snapshot thumbnails fetch as blob URLs, or WebKitGTK leaks sockets;
   same constraint as the MJPEG workaround, separate code path (7e121140).
 - iOS video.js fullscreen: CSS overrides cannot reliably intercept the

--- a/app/.lint-baseline.json
+++ b/app/.lint-baseline.json
@@ -6,7 +6,7 @@
   "react-hooks/exhaustive-deps": 32,
   "react-hooks/globals": 1,
   "react-hooks/preserve-manual-memoization": 10,
-  "react-hooks/refs": 22,
+  "react-hooks/refs": 21,
   "react-hooks/set-state-in-effect": 11,
   "react-hooks/static-components": 10,
   "react-refresh/only-export-components": 8,

--- a/app/src/components/monitors/LiveMonitorPlayer.tsx
+++ b/app/src/components/monitors/LiveMonitorPlayer.tsx
@@ -538,12 +538,13 @@ export function LiveMonitorPlayer({
 
   // Undoes the inline hide handleMjpegError applies below. React never clears
   // an imperatively set style key on its own (it only diffs the keys its own
-  // style prop carried), so every path that can put a usable frame back on
-  // this element clears it explicitly. That matters most when the element is
-  // never unmounted in between: a multipart stream can fire error and then
-  // load in the same task, and React batches both, so the load handler runs on
-  // the still-mounted, still-hidden element and its setMjpegError(false) keeps
-  // it mounted. Without this the tile would go permanently blank.
+  // style prop carried), and the visibility prop on the <img> can hold the same
+  // value either side of a hide, so the load handler clears it explicitly. That
+  // matters when the element is never unmounted in between: a multipart stream
+  // can fire error and then load in the same task, and React batches both, so
+  // the load handler runs on the still-mounted, still-hidden element and its
+  // setMjpegError(false) keeps it mounted. Without this the tile would go
+  // permanently blank.
   //
   // Depends on mjpegStream.imgRef, not mjpegStream: useMonitorStream returns a
   // bare object literal, so the hook result is a new reference every render.
@@ -559,12 +560,13 @@ export function LiveMonitorPlayer({
     if (img) img.style.visibility = '';
   }, [imgRef]);
 
+  // A fresh connkey unlatches the error, so the tile recovers instead of
+  // sitting on the placeholder until a full remount. refs #150
   useEffect(() => {
     if (effectiveStreamingMethod === 'mjpeg' || showMjpegPlaceholder) {
-      showMjpegImg();
       setMjpegError(false);
     }
-  }, [effectiveStreamingMethod, showMjpegPlaceholder, monitor.Id, mjpegStream.imageSrc, showMjpegImg]);
+  }, [effectiveStreamingMethod, showMjpegPlaceholder, monitor.Id, mjpegStream.imageSrc]);
 
   const handleMjpegLoad = useCallback(() => {
     showMjpegImg();
@@ -655,9 +657,20 @@ export function LiveMonitorPlayer({
   }, [isWebRTC, status.state, hasVideoFrames, onLoad]);
 
   // The MJPEG <img> is rendered both when MJPEG is the real stream and as the
-  // MJPEG-first placeholder while MSE connects. It has a frame to show whenever
-  // the stream is configured and not errored.
-  const hasMjpegFrame = !!mjpegStream.streamUrl && !!mjpegStream.imageSrc && !mjpegError;
+  // MJPEG-first placeholder while MSE connects. It stays mounted whenever a
+  // stream URL exists and no error is latched - an unmounted element can never
+  // load - but only paints once that src has actually produced a frame.
+  const showMjpegElement =
+    (effectiveStreamingMethod === 'mjpeg' || showMjpegPlaceholder) &&
+    !!mjpegStream.imageSrc &&
+    !mjpegError;
+
+  // Whether the element has a picture worth showing. A minted connkey is not a
+  // frame: on a mobile resume the element still holds the dead connection's
+  // last frame, which may be half written, and WebKit re-fetching an evicted
+  // image against a dead connkey paints its broken-image glyph before any error
+  // event lands. Both used to count as "has a frame" here. refs #352
+  const hasMjpegFrame = showMjpegElement && mjpegStream.hasFrame;
 
   // Single named content state feeding the render branches below. See the
   // PlayerViewState doc comment for the state machine and what drives each
@@ -700,18 +713,30 @@ export function LiveMonitorPlayer({
         />
       )}
 
-      {(viewState === 'mjpeg-placeholder' || viewState === 'mjpeg') && (
+      {showMjpegElement && (
         <img
           ref={mjpegStream.imgRef}
           className={`w-full h-full ${className}`}
+          // visibility, not conditional mounting: the element has to be in the
+          // tree to load at all, and it must not paint until it has a frame.
+          // Always passing the key keeps React's diff in charge of it.
           style={
             showMjpegPlaceholder
-              ? { objectFit, position: 'absolute', inset: 0, zIndex: 1 }
-              : { objectFit }
+              ? {
+                objectFit,
+                position: 'absolute',
+                inset: 0,
+                zIndex: 1,
+                visibility: hasMjpegFrame ? 'visible' : 'hidden',
+              }
+              : { objectFit, visibility: hasMjpegFrame ? 'visible' : 'hidden' }
           }
           data-testid="video-player-mjpeg"
           src={mjpegStream.imageSrc}
-          alt={monitor.Name}
+          // Empty: a failing load with alt text makes WebKit draw its glyph
+          // beside the text, and nothing describes a live feed in words. The
+          // surrounding tile carries the monitor name.
+          alt=""
           // Disable the browser's native image drag so a mouse drag pans the
           // zoomed view instead of dragging a ghost of the picture (issue #191).
           draggable={false}

--- a/app/src/components/monitors/MonitorHoverPreview.tsx
+++ b/app/src/components/monitors/MonitorHoverPreview.tsx
@@ -7,7 +7,7 @@
  * which sends CMD_QUIT to tear down the extra stream on the ZM server.
  */
 
-import { useRef, type ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import { getStreamUrl } from '../../api/monitors';
 import { resolveMinStreamingPort } from '../../lib/monitor/multiport';
 import { useProfileById } from '../../hooks/useCurrentProfile';
@@ -67,6 +67,10 @@ function MonitorLivePreview({ monitor, profileId }: { monitor: Monitor; profileI
   const { profile: currentProfile, settings } = useProfileById(profileId);
   const { token: accessToken, isFresh: isAccessTokenFresh } = useFreshAccessToken(profileId);
   const imgRef = useRef<HTMLImageElement>(null);
+  // Same rule as the player: nothing paints until this src has produced a
+  // frame, so a stream that fails or never arrives shows the no-video
+  // placeholder rather than the browser's broken-image glyph. refs #352
+  const [hasFrame, setHasFrame] = useState(false);
   const effectiveMinStreamingPort = resolveMinStreamingPort(
     currentProfile?.minStreamingPort,
     settings.forceDisableMultiPort,
@@ -85,12 +89,17 @@ function MonitorLivePreview({ monitor, profileId }: { monitor: Monitor; profileI
     profileId: currentProfile?.id,
   });
 
+  const noVideoPlaceholder = (
+    <div
+      className="absolute inset-0 flex items-center justify-center bg-muted/30"
+      data-testid="monitor-hover-preview-novideo"
+    >
+      <VideoOff className="h-8 w-8 text-muted-foreground/40" />
+    </div>
+  );
+
   if (!currentProfile || connKey === 0 || !isAccessTokenFresh) {
-    return (
-      <div className="w-full h-full flex items-center justify-center bg-muted/30">
-        <VideoOff className="h-8 w-8 text-muted-foreground/40" />
-      </div>
-    );
+    return <div className="relative w-full h-full">{noVideoPlaceholder}</div>;
   }
 
   const streamUrl = getStreamUrl(currentProfile.cgiUrl, monitor.Id, {
@@ -101,11 +110,20 @@ function MonitorLivePreview({ monitor, profileId }: { monitor: Monitor; profileI
   });
 
   return (
-    <img
-      ref={imgRef}
-      src={streamUrl}
-      alt={monitor.Name}
-      className="w-full h-full object-contain bg-black"
-    />
+    <div className="relative w-full h-full">
+      {!hasFrame && noVideoPlaceholder}
+      <img
+        ref={imgRef}
+        src={streamUrl}
+        // Empty on purpose: alt text is what the browser draws beside its
+        // broken-image glyph, and the card behind this popover names the monitor.
+        alt=""
+        data-testid="monitor-hover-preview-img"
+        className="w-full h-full object-contain bg-black"
+        style={{ visibility: hasFrame ? 'visible' : 'hidden' }}
+        onLoad={() => setHasFrame(true)}
+        onError={() => setHasFrame(false)}
+      />
+    </div>
   );
 }

--- a/app/src/components/monitors/__tests__/LiveMonitorPlayer.test.tsx
+++ b/app/src/components/monitors/__tests__/LiveMonitorPlayer.test.tsx
@@ -22,6 +22,7 @@ let mockMjpegReturn: {
   regenerateConnection: () => void;
   reportStreamError: () => void;
   reportStreamLoad: () => void;
+  hasFrame: boolean;
 };
 
 // Every request the player has made of the MJPEG hook, so a test can assert
@@ -116,6 +117,7 @@ describe('LiveMonitorPlayer MJPEG recovery', () => {
       regenerateConnection: vi.fn(),
       reportStreamError: vi.fn(),
       reportStreamLoad: vi.fn(),
+      hasFrame: true,
     };
   });
 
@@ -224,6 +226,7 @@ describe('LiveMonitorPlayer Go2RTC failure cache scoping', () => {
       regenerateConnection: vi.fn(),
       reportStreamError: vi.fn(),
       reportStreamLoad: vi.fn(),
+      hasFrame: true,
     };
     go2rtc.state = 'connecting';
     go2rtc.optionsLog = [];
@@ -304,6 +307,7 @@ describe('LiveMonitorPlayer reduced stream tuning', () => {
       regenerateConnection: vi.fn(),
       reportStreamError: vi.fn(),
       reportStreamLoad: vi.fn(),
+      hasFrame: true,
     };
     mockSettings = { streamMaxFps: 10, streamScale: 50 };
     streamCalls.length = 0;
@@ -351,6 +355,7 @@ describe('LiveMonitorPlayer paused tiles', () => {
       regenerateConnection: vi.fn(),
       reportStreamError: vi.fn(),
       reportStreamLoad: vi.fn(),
+      hasFrame: true,
     };
     mockSettings = undefined;
     streamCalls.length = 0;
@@ -410,6 +415,7 @@ describe('LiveMonitorPlayer paused WebRTC frames', () => {
       regenerateConnection: vi.fn(),
       reportStreamError: vi.fn(),
       reportStreamLoad: vi.fn(),
+      hasFrame: true,
     };
     mockSettings = undefined;
     streamCalls.length = 0;
@@ -489,6 +495,7 @@ describe('LiveMonitorPlayer without streaming permission', () => {
       regenerateConnection: vi.fn(),
       reportStreamError: vi.fn(),
       reportStreamLoad: vi.fn(),
+      hasFrame: true,
     };
   });
 
@@ -530,5 +537,70 @@ describe('LiveMonitorPlayer without streaming permission', () => {
 
     expect(screen.queryByTestId('video-player-no-permission')).not.toBeInTheDocument();
     expect(screen.getByTestId('video-player-mjpeg')).toBeInTheDocument();
+  });
+});
+
+// refs #352: on a mobile resume the element still holds whatever the dead
+// connection left on it - a partially written JPEG, or the browser's
+// broken-image glyph after WebKit re-fetches an evicted image against a dead
+// connkey. Neither fires an error the player can react to in time, so a mounted
+// <img> is only allowed to paint once the src it holds has produced a frame.
+describe('LiveMonitorPlayer MJPEG frame gating', () => {
+  beforeEach(() => {
+    mockSettings = undefined;
+    mockStreamPermission = undefined;
+    mockMjpegReturn = {
+      streamUrl: 'https://t/stream?connkey=1',
+      imageSrc: 'https://t/stream?connkey=1',
+      imgRef: { current: null },
+      regenerateConnection: vi.fn(),
+      reportStreamError: vi.fn(),
+      reportStreamLoad: vi.fn(),
+      hasFrame: false,
+    };
+  });
+
+  it('keeps a connected but frameless <img> unpaintable and shows the placeholder', () => {
+    render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    // Mounted, because an unmounted element can never load.
+    const img = screen.getByTestId('video-player-mjpeg');
+    expect(img).toHaveAttribute('src', 'https://t/stream?connkey=1');
+    expect(img).not.toBeVisible();
+    expect(screen.getByTestId('video-player-loading')).toBeInTheDocument();
+  });
+
+  it('paints the <img> and drops the placeholder once a frame arrives', () => {
+    const { rerender } = render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    mockMjpegReturn = { ...mockMjpegReturn, hasFrame: true };
+    rerender(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(screen.getByTestId('video-player-mjpeg')).toBeVisible();
+    expect(screen.queryByTestId('video-player-loading')).not.toBeInTheDocument();
+  });
+
+  it('hides the picture again when the stream loses its frame', () => {
+    mockMjpegReturn = { ...mockMjpegReturn, hasFrame: true };
+    const { rerender } = render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+    expect(screen.getByTestId('video-player-mjpeg')).toBeVisible();
+
+    // A resume withdraws the frame without any error event and before the new
+    // connkey lands, so imageSrc is still the old one here.
+    mockMjpegReturn = { ...mockMjpegReturn, hasFrame: false };
+    rerender(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(screen.getByTestId('video-player-mjpeg')).not.toBeVisible();
+    expect(screen.getByTestId('video-player-loading')).toBeInTheDocument();
+  });
+
+  // A failing load with alt text makes WebKit draw its glyph next to the text.
+  // Nothing describes a live video feed in words anyway; the surrounding tile
+  // carries the monitor name.
+  it('gives the stream image no alt text to render on failure', () => {
+    mockMjpegReturn = { ...mockMjpegReturn, hasFrame: true };
+    render(<LiveMonitorPlayer monitor={monitor} profile={profile} />);
+
+    expect(screen.getByTestId('video-player-mjpeg')).toHaveAttribute('alt', '');
   });
 });

--- a/app/src/components/monitors/__tests__/MonitorHoverPreview.test.tsx
+++ b/app/src/components/monitors/__tests__/MonitorHoverPreview.test.tsx
@@ -9,7 +9,7 @@
  * profile resolution.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { MonitorHoverPreview } from '../MonitorHoverPreview';
 import { useProfileStore } from '../../../stores/profile';
 import type { Monitor, Profile } from '../../../api/types';
@@ -98,5 +98,52 @@ describe('MonitorHoverPreview profile threading', () => {
     // selected profile is A.
     expect(streamLifecycleCalls).toEqual([{ monitorId: 'mon-1', profileId: 'profile-b' }]);
     expect(freshTokenCalls).toEqual(['profile-b']);
+  });
+});
+
+// refs #352: the preview had no load or error handling at all, so a stream that
+// never arrives left the browser's broken-image glyph sitting in the popover.
+describe('MonitorHoverPreview frame gating', () => {
+  beforeEach(() => {
+    useProfileStore.setState({
+      profiles: [profileA],
+      currentProfileId: profileA.id,
+      isInitialized: true,
+      isBootstrapping: false,
+      bootstrapStep: null,
+    });
+  });
+
+  const renderPreview = () =>
+    render(
+      <MonitorHoverPreview monitor={monitor}>
+        <div>trigger</div>
+      </MonitorHoverPreview>,
+    );
+
+  it('shows the no-video placeholder until the stream produces a frame', () => {
+    const { getByTestId } = renderPreview();
+
+    expect(getByTestId('monitor-hover-preview-img')).not.toBeVisible();
+    expect(getByTestId('monitor-hover-preview-novideo')).toBeInTheDocument();
+  });
+
+  it('paints the stream once it loads', () => {
+    const { getByTestId, queryByTestId } = renderPreview();
+
+    fireEvent.load(getByTestId('monitor-hover-preview-img'));
+
+    expect(getByTestId('monitor-hover-preview-img')).toBeVisible();
+    expect(queryByTestId('monitor-hover-preview-novideo')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the placeholder when the stream fails', () => {
+    const { getByTestId } = renderPreview();
+    fireEvent.load(getByTestId('monitor-hover-preview-img'));
+
+    fireEvent.error(getByTestId('monitor-hover-preview-img'));
+
+    expect(getByTestId('monitor-hover-preview-img')).not.toBeVisible();
+    expect(getByTestId('monitor-hover-preview-novideo')).toBeInTheDocument();
   });
 });

--- a/app/src/hooks/__tests__/useMonitorStream.frame.test.tsx
+++ b/app/src/hooks/__tests__/useMonitorStream.frame.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * useMonitorStream: the has-a-frame gate
+ *
+ * Asserts that `hasFrame` means "the src the <img> currently holds has
+ * produced a frame", not "a stream URL exists". Refs #352: the player used to
+ * treat a minted connkey as a frame, so on a mobile resume every tile showed
+ * whatever the element still held - a partially written JPEG, or the browser's
+ * broken-image glyph - instead of the VideoOff placeholder.
+ *
+ * The resume case is the reason the clear has to be synchronous: `zms` dying
+ * while the app is suspended fires no `error` on the <img> at all (it keeps the
+ * last frame forever, see agents/project/domain-context.md), so the resume
+ * itself is the only moment that knows the frame is stale, and it must not wait
+ * for the token refresh it kicks off before saying so.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useMonitorStream } from '../useMonitorStream';
+import { useMonitorStore } from '../../stores/monitors';
+import { useProfileStore } from '../../stores/profile';
+import { useAuthStore } from '../../stores/auth';
+import { useSettingsStore, DEFAULT_SETTINGS } from '../../stores/settings';
+import type { Profile } from '../../api/types';
+import { asProfileId } from '../../api/types';
+
+vi.mock('../../lib/http', () => ({
+  httpGet: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../lib/logger', () => ({
+  log: {
+    monitor: vi.fn(),
+    auth: vi.fn(),
+    dedupe: (_key: string, _windowMs: number, emit: (suffix: string) => void) => emit(''),
+  },
+  LogLevel: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 },
+}));
+
+vi.mock('../../api/monitors', () => ({
+  getStreamUrl: (cgiUrl: string, monitorId: string, options: Record<string, unknown>) => {
+    const params = new URLSearchParams();
+    params.set('monitor', monitorId);
+    if (options.mode) params.set('mode', String(options.mode));
+    if (options.connkey) params.set('connkey', String(options.connkey));
+    if (options.cacheBuster) params.set('cacheBuster', String(options.cacheBuster));
+    return `${cgiUrl}/nph-zms?${params.toString()}`;
+  },
+}));
+
+vi.mock('../../lib/zm/url-builder', () => ({
+  getZmsControlUrl: (portalUrl: string, command: string, connkey: string) =>
+    `${portalUrl}/zms?command=${command}&connkey=${connkey}`,
+}));
+
+vi.mock('../../lib/zm/zm-constants', () => ({
+  ZMS_COMMANDS: { cmdQuit: 'quit' },
+}));
+
+// Captured so a test can fire the resume the way returning to the foreground
+// does, without depending on which platform signal delivered it.
+let resumeCallback: (() => void) | null = null;
+vi.mock('../useVisibilityResume', () => ({
+  useVisibilityResume: (onResume: () => void) => {
+    resumeCallback = onResume;
+  },
+}));
+
+describe('useMonitorStream: has-a-frame gate', () => {
+  const mockProfile: Profile = {
+    id: asProfileId('profile-1'),
+    name: 'Test Profile',
+    apiUrl: 'https://test.com',
+    portalUrl: 'https://test.com',
+    cgiUrl: 'https://test.com/cgi-bin',
+    isDefault: false,
+    createdAt: 0,
+  };
+
+  let nextConnKey = 100;
+
+  beforeEach(() => {
+    resumeCallback = null;
+    nextConnKey = 100;
+
+    useProfileStore.setState({
+      profiles: [mockProfile],
+      currentProfileId: mockProfile.id,
+      isInitialized: true,
+      isBootstrapping: false,
+      bootstrapStep: null,
+    });
+
+    useSettingsStore.setState({
+      profileSettings: {
+        'profile-1': { ...DEFAULT_SETTINGS, viewMode: 'streaming', snapshotRefreshInterval: 1 },
+      },
+    });
+
+    useMonitorStore.setState({
+      connKeys: {},
+      regenerateConnKey: vi.fn(() => (nextConnKey += 1)),
+    });
+
+    useAuthStore.setState({
+      slices: {
+        [mockProfile.id]: {
+          accessToken: 'FRESH',
+          refreshToken: null,
+          accessTokenExpires: Date.now() + 60 * 60 * 1000,
+          refreshTokenExpires: null,
+          version: null,
+          apiVersion: null,
+          isAuthenticated: true,
+          requiresAuth: true,
+        },
+      },
+      getFreshAccessToken: vi.fn().mockResolvedValue('FRESH'),
+    });
+  });
+
+  /** Renders the hook and waits for the first connkey to mint a stream URL. */
+  async function renderStreaming(viewModeOverride?: 'streaming' | 'snapshot') {
+    const view = renderHook(() => useMonitorStream({ monitorId: '1', viewModeOverride }));
+    await waitFor(() => expect(view.result.current.imageSrc).not.toBe(''));
+    return view;
+  }
+
+  it('reports no frame while the stream URL exists but nothing has loaded', async () => {
+    const { result } = await renderStreaming();
+
+    expect(result.current.imageSrc).not.toBe('');
+    expect(result.current.hasFrame).toBe(false);
+  });
+
+  it('reports a frame once the <img> load handler runs', async () => {
+    const { result } = await renderStreaming();
+
+    act(() => result.current.reportStreamLoad());
+
+    expect(result.current.hasFrame).toBe(true);
+  });
+
+  it('drops the frame when the stream errors', async () => {
+    const { result } = await renderStreaming();
+    act(() => result.current.reportStreamLoad());
+
+    act(() => result.current.reportStreamError());
+
+    expect(result.current.hasFrame).toBe(false);
+  });
+
+  it('drops the frame the moment a fresh connkey replaces the loaded one', async () => {
+    const { result } = await renderStreaming();
+    act(() => result.current.reportStreamLoad());
+    const loadedSrc = result.current.imageSrc;
+
+    act(() => result.current.regenerateConnection());
+
+    expect(result.current.imageSrc).not.toBe(loadedSrc);
+    expect(result.current.hasFrame).toBe(false);
+  });
+
+  it('drops the frame on resume without waiting for the token refresh', async () => {
+    // A refresh that never settles: if the clear were sequenced behind the
+    // await, hasFrame would still be true here.
+    useAuthStore.setState({ getFreshAccessToken: vi.fn(() => new Promise<string>(() => {})) });
+
+    const { result } = await renderStreaming();
+    act(() => result.current.reportStreamLoad());
+    expect(result.current.hasFrame).toBe(true);
+
+    expect(resumeCallback).not.toBeNull();
+    act(() => resumeCallback!());
+
+    expect(result.current.hasFrame).toBe(false);
+  });
+
+  // Snapshot mode swaps the src on every refresh tick (a new cacheBuster), and
+  // the previous still frame stays perfectly good in the meantime. Hiding it
+  // per tick would blink the tile on every interval.
+  it('keeps the frame across a snapshot refresh', async () => {
+    vi.useFakeTimers();
+    try {
+      const view = renderHook(() =>
+        useMonitorStream({ monitorId: '1', viewModeOverride: 'snapshot' }),
+      );
+      await vi.waitFor(() => expect(view.result.current.imageSrc).not.toBe(''));
+      act(() => view.result.current.reportStreamLoad());
+      const firstSrc = view.result.current.imageSrc;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+
+      expect(view.result.current.imageSrc).not.toBe(firstSrc);
+      expect(view.result.current.hasFrame).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/app/src/hooks/__tests__/useVisibilityResume.test.ts
+++ b/app/src/hooks/__tests__/useVisibilityResume.test.ts
@@ -3,11 +3,29 @@ import { renderHook } from '@testing-library/react';
 import { useVisibilityResume } from '../useVisibilityResume';
 
 let mockIsElectron = false;
+let mockIsNative = false;
 vi.mock('../../lib/platform', () => ({
   Platform: {
     get isElectron() {
       return mockIsElectron;
     },
+    get isNative() {
+      return mockIsNative;
+    },
+  },
+}));
+
+// Stands in for the Capacitor App plugin: the test drives appStateChange
+// directly instead of loading a plugin that does not exist under vitest.
+let appStateHandler: ((state: { isActive: boolean }) => void) | null = null;
+vi.mock('../useCapacitorListener', () => ({
+  useCapacitorListener: (
+    _getPlugin: unknown,
+    eventName: string,
+    handler: (state: { isActive: boolean }) => void,
+    opts?: { enabled?: boolean },
+  ) => {
+    if (eventName === 'appStateChange' && opts?.enabled !== false) appStateHandler = handler;
   },
 }));
 
@@ -23,6 +41,8 @@ describe('useVisibilityResume', () => {
     vi.useFakeTimers();
     visibilityState = 'visible';
     mockIsElectron = false;
+    mockIsNative = false;
+    appStateHandler = null;
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: () => visibilityState,
@@ -191,6 +211,62 @@ describe('useVisibilityResume', () => {
     // Restore: both focus and visibilitychange(visible) fire.
     window.dispatchEvent(new Event('focus'));
     setVisibility('visible');
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+
+// refs #352: on native the WebView suspends with the app and its timers freeze,
+// and visibilitychange is not something a WebView is obliged to fire on an app
+// state change. Notifications already learned this in #274; streams recover
+// through this hook, so it needs the same signal.
+describe('useVisibilityResume on native', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    visibilityState = 'visible';
+    mockIsElectron = false;
+    mockIsNative = true;
+    appStateHandler = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires when the app comes back to the foreground', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityResume(cb, { minHiddenMs: 1000 }));
+
+    expect(appStateHandler).not.toBeNull();
+    appStateHandler!({ isActive: false });
+    vi.advanceTimersByTime(2000);
+    appStateHandler!({ isActive: true });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an app-switch flick', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityResume(cb, { minHiddenMs: 1500 }));
+
+    appStateHandler!({ isActive: false });
+    vi.advanceTimersByTime(200);
+    appStateHandler!({ isActive: true });
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  // Both signals can fire for one background/foreground round trip. The away
+  // marker is shared, so the return resumes once, not once per signal.
+  it('resumes once when both signals report the same round trip', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityResume(cb, { minHiddenMs: 1000 }));
+
+    appStateHandler!({ isActive: false });
+    setVisibility('hidden');
+    vi.advanceTimersByTime(2000);
+    setVisibility('visible');
+    appStateHandler!({ isActive: true });
 
     expect(cb).toHaveBeenCalledTimes(1);
   });

--- a/app/src/hooks/useMonitorStream.ts
+++ b/app/src/hooks/useMonitorStream.ts
@@ -71,6 +71,14 @@ interface UseMonitorStreamReturn {
    * the give-up cap still applies to a permanently dead feed.
    */
   reportStreamLoad: () => void;
+  /**
+   * Whether the `<img>` has produced a frame for the src it currently holds.
+   * Not "a stream URL exists": a minted connkey proves nothing has been
+   * decoded yet, and an element showing a stale or half-written frame is
+   * indistinguishable from a live one until this says so. The consumer keeps
+   * the element unpaintable while this is false. refs #352
+   */
+  hasFrame: boolean;
 }
 
 /**
@@ -116,6 +124,12 @@ export function useMonitorStream({
   const insomniaRef = useRef(settings.insomnia);
   insomniaRef.current = settings.insomnia;
   const [imageSrc, setImageSrc] = useState<string>('');
+  // The src that last fired `load`. Compared against the current one rather
+  // than kept as a boolean flag, so a src swap withdraws the frame during the
+  // same render that introduces it. A flag reset from an effect would not: an
+  // effect runs after paint, which is one painted frame of the old picture
+  // under the new connection. refs #352
+  const [loadedSrc, setLoadedSrc] = useState<string>('');
 
   // Stream lifecycle: connKey generation, CMD_QUIT on regen/unmount, media abort
   const { connKey, forceRegenerate, releaseConnection } = useStreamLifecycle({
@@ -213,6 +227,9 @@ export function useMonitorStream({
   // server process from a dropped-but-alive one); on give-up the final connkey
   // is released too, instead of being orphaned until unmount.
   const scheduleReconnect = () => {
+    // Whatever the element is holding, it is not a frame off a working
+    // connection any more.
+    setLoadedSrc('');
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);
       reconnectTimerRef.current = null;
@@ -244,6 +261,7 @@ export function useMonitorStream({
   // when a remembered analysis setting can be applied to it.
   const reportStreamLoad = () => {
     analysisFrames.applyOnStreamLoad();
+    setLoadedSrc(imageSrc);
     reconnectAttemptRef.current = 0;
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);
@@ -287,6 +305,12 @@ export function useMonitorStream({
         reconnectAttempts: reconnectAttemptRef.current,
       }),
     );
+    // Before anything async. A stream that died while the app was suspended
+    // fires no `error` on the `<img>` - it keeps its last frame, which may be
+    // half written - so the resume is the only moment that knows the picture is
+    // stale, and the consumer must be told now rather than after the token
+    // round trip below. refs #352
+    setLoadedSrc('');
     reconnectAttemptRef.current = 0;
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);
@@ -303,6 +327,16 @@ export function useMonitorStream({
     });
   }, { enabled: enabled && effectiveViewMode === 'streaming' });
 
+  // Snapshot mode swaps the src on every refresh tick (a fresh cacheBuster) and
+  // the still frame already on screen stays good until the next one decodes, so
+  // matching the src there would blink the tile once per interval. A snapshot
+  // that starts failing does fire `error`, which clears loadedSrc, so it still
+  // falls back to the placeholder.
+  const hasFrame =
+    imageSrc !== '' &&
+    loadedSrc !== '' &&
+    (effectiveViewMode === 'snapshot' || loadedSrc === imageSrc);
+
   return {
     streamUrl,
     imageSrc,
@@ -310,5 +344,6 @@ export function useMonitorStream({
     regenerateConnection,
     reportStreamError: scheduleReconnect,
     reportStreamLoad,
+    hasFrame,
   };
 }

--- a/app/src/hooks/useVisibilityResume.ts
+++ b/app/src/hooks/useVisibilityResume.ts
@@ -1,20 +1,24 @@
 /**
  * Fires a callback when the window returns to the foreground after being away.
  *
- * Two signals feed this. `visibilitychange` covers tab switches and window
+ * Three signals feed this. `visibilitychange` covers tab switches and window
  * minimize. On Electron desktop, covering the window with another app does not
  * fire visibilitychange (only minimize does), but it does fire window
- * blur/focus, so those are also used there. In both cases the stream's
- * connection can drop while the window is in the background, and recovery has
- * to happen on return. refs #150
+ * blur/focus, so those are also used there. On native, Capacitor's
+ * `appStateChange` covers the app being backgrounded: the WebView suspends with
+ * the app and freezes its timers, and a WebView is not obliged to fire
+ * visibilitychange for that (notifications hit the same wall in #274). In every
+ * case the stream's connection can drop while the app or window is in the
+ * background, and recovery has to happen on return. refs #150, refs #352
  *
  * Debounces a rapid away→back flicker (e.g., quick alt-tab) so a brief blur
  * does not trigger a reconnect storm. The minimum time away before a return is
  * considered worth acting on is `minHiddenMs` (default 1500ms).
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Platform } from '../lib/platform';
+import { useCapacitorListener } from './useCapacitorListener';
 
 export interface UseVisibilityResumeOptions {
   enabled?: boolean;
@@ -34,22 +38,36 @@ export function useVisibilityResume(
   const onResumeRef = useRef(onResume);
   onResumeRef.current = onResume;
 
+  // Record when the window left the foreground. The first signal wins so a
+  // following pair (blur plus visibilitychange, or appStateChange plus
+  // visibilitychange) does not reset the away timer. Shared by every signal, so
+  // one background/foreground round trip resumes once however many of them fire.
+  const markAway = useCallback(() => {
+    if (hiddenAtRef.current === null) hiddenAtRef.current = Date.now();
+  }, []);
+
+  const tryResume = useCallback(() => {
+    const awayAt = hiddenAtRef.current;
+    hiddenAtRef.current = null;
+    if (awayAt === null) return;
+    if (Date.now() - awayAt < minHiddenMs) return;
+    onResumeRef.current();
+  }, [minHiddenMs]);
+
+  // Native: the app being backgrounded and foregrounded. Inert on web and
+  // desktop, where the two signals below cover it.
+  useCapacitorListener<{ isActive: boolean }>(
+    () => import('@capacitor/app').then((m) => m.App),
+    'appStateChange',
+    ({ isActive }) => {
+      if (isActive) tryResume();
+      else markAway();
+    },
+    { enabled: enabled && Platform.isNative },
+  );
+
   useEffect(() => {
     if (!enabled || typeof document === 'undefined') return;
-
-    // Record when the window left the foreground. The first signal wins so a
-    // following blur/visibilitychange pair does not reset the away timer.
-    const markAway = () => {
-      if (hiddenAtRef.current === null) hiddenAtRef.current = Date.now();
-    };
-
-    const tryResume = () => {
-      const awayAt = hiddenAtRef.current;
-      hiddenAtRef.current = null;
-      if (awayAt === null) return;
-      if (Date.now() - awayAt < minHiddenMs) return;
-      onResumeRef.current();
-    };
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
@@ -82,5 +100,5 @@ export function useVisibilityResume(
       // brief flick would resume as if the page had been gone for hours.
       hiddenAtRef.current = null;
     };
-  }, [enabled, minHiddenMs]);
+  }, [enabled, minHiddenMs, markAway, tryResume]);
 }

--- a/app/tests/steps/analysis-frames.steps.ts
+++ b/app/tests/steps/analysis-frames.steps.ts
@@ -50,8 +50,11 @@ async function clickAnalysisToggle(page: import('@playwright/test').Page): Promi
   analysisRequestUrls = [];
   // The command only exists on an MJPEG stream; a go2rtc/WebRTC feed has no
   // command socket. Transport, not the control under test, so the toggle's own
-  // assertions below still run either way.
-  mjpegTransport = await page.getByTestId('video-player-mjpeg').isVisible().catch(() => false);
+  // assertions below still run either way. Attachment, not visibility: the
+  // element is mounted for the whole connection but only paints once a frame
+  // has arrived (refs #352), so a visibility probe would read "no MJPEG" purely
+  // because it ran during the connect.
+  mjpegTransport = (await page.getByTestId('video-player-mjpeg').count()) > 0;
   if (!mjpegTransport) {
     log.info('E2E: monitor is not served over MJPEG, skipping stream-command assertions', {
       component: 'e2e',

--- a/app/tests/steps/monitor-navigation.steps.ts
+++ b/app/tests/steps/monitor-navigation.steps.ts
@@ -53,7 +53,9 @@ function urlMonitorId(page: import('@playwright/test').Page): string | null {
 
 async function mjpegMonitorId(page: import('@playwright/test').Page): Promise<string | null> {
   const img = page.getByTestId('video-player-mjpeg');
-  if (!(await img.isVisible().catch(() => false))) return null;
+  // Attached, not visible: the element stays hidden until its first frame
+  // decodes (refs #352), and the src it carries is what this reads.
+  if ((await img.count()) === 0) return null;
   const src = await img.getAttribute('src').catch(() => null);
   const m = src?.match(/[?&]monitor=(\d+)/);
   return m ? m[1] : null;

--- a/docs/developer-guide/11-application-lifecycle.rst
+++ b/docs/developer-guide/11-application-lifecycle.rst
@@ -282,7 +282,13 @@ When the user re-opens the app:
 - **State**: App comes to Foreground.
 - **Streams**: ``useVisibilityResume`` fires and ``useMonitorStream`` mints a
   fresh ``connkey`` and rebinds. It debounces on ``minHiddenMs`` (1500ms by
-  default) so that a quick alt-tab does not trigger a reconnect storm.
+  default) so that a quick alt-tab does not trigger a reconnect storm. On native
+  the signal is Capacitor's ``appStateChange`` as well as ``visibilitychange``,
+  for the same reason notifications need both (refs #274): the WebView suspends
+  with the app and is not obliged to report an app state change as a visibility
+  change. The resume drops the recorded frame before it awaits anything, so tiles
+  show the VideoOff placeholder for the length of the reconnect rather than the
+  stale picture the suspended connection left behind (refs #352).
 - **Token**: ``useTokenRefresh`` re-checks expiry on ``visibilitychange``,
   because its 60-second interval was not running while suspended.
 - **WebSocket Liveness**: ``useNotificationAutoConnect`` calls

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -1209,6 +1209,16 @@ monitor id (refs #201).
 mode is on), and ``reportStreamLoad`` (wired to ``<img onLoad>``) resets the
 backoff after a good frame.
 
+The hook also answers whether there is a picture to show at all. ``hasFrame``
+means "the ``src`` the element currently holds has fired ``load``", tracked by
+recording that ``src`` in ``reportStreamLoad`` and comparing it with the current
+one, and cleared by ``reportStreamError`` and by the visibility resume. It is a
+comparison rather than a boolean flag on purpose: a flag reset from an effect
+would clear one paint too late, because effects run after the browser has already
+painted the new ``src`` with the old picture still on the element. Snapshot mode
+is the exception the comparison has to carve out, since a refresh tick changes
+the ``src`` on a still frame that remains perfectly good (refs #352).
+
 Profile switch cannot rely on unmount
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -299,7 +299,13 @@ collide on the server and never leak a zombie process when they go away.
    ``<img src={imageSrc} onLoad onError>``. The browser itself opens the
    multipart MJPEG connection through the ``<img>``; the connkey lives right in
    the ``src``. A good frame calls ``reportStreamLoad``, which zeroes the
-   reconnect backoff.
+   reconnect backoff and records which ``src`` produced it. That record is what
+   ``hasFrame`` compares against, and the player keeps the ``<img>``
+   ``visibility: hidden`` until it agrees, so the VideoOff placeholder covers the
+   tile instead of a stale frame or the browser's broken-image glyph. A minted
+   connkey is not a frame: nothing has been decoded yet, and after a mobile
+   suspend the element is still holding the dead connection's last picture (refs
+   #352).
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/hooks/useMonitorStream.ts#L198>`__
    · → :doc:`05-component-architecture`
 


### PR DESCRIPTION
Fixes the broken/garbled live tiles after a long background on mobile. refs #352

## The rule this establishes

An `<img>` carrying a stream is only allowed to paint once the src it currently holds has fired `load`.

That is deliberately mechanism-independent, because three different things produce the symptom and only one of them gives the app an error event to react to:

1. `zms` dies while the app is suspended. The `<img>` fires nothing and keeps its last frame, which may be half written (already documented in `agents/project/domain-context.md`). The whole error latch and its synchronous hide never run.
2. WebKit evicts decoded image data while backgrounded and re-fetches it on resume against a connkey that is now dead. That does error, but the synchronous hide is still *reactive*: with every tile erroring at once behind a token refresh and a burst of CMD_QUITs, the glyph stays on screen for as long as the error task is delayed.
3. The reconnect window itself. A new connkey used to un-hide the element and unmount the placeholder before a byte had arrived.

`hasMjpegFrame` was the common cause: it meant "a stream URL exists and no error is latched", never "this src has produced a frame". The WebRTC path never had the bug — it gates on a real `videoWidth > 0` check.

Auth was not involved: `useMonitorStream` already gates `streamUrl` on token freshness, so a lapsed token shows the placeholder correctly today.

## What changed

- `useMonitorStream` records which src produced the last frame and exposes `hasFrame` as a comparison against the current one. A comparison rather than a flag reset from an effect, because effects run after paint — a flag would clear one painted frame too late, which is the same class of bug.
- The visibility resume clears that record before it awaits the token refresh. For mechanism 1 the resume is the only thing that knows the picture is stale, so it must not wait a network round trip to say so.
- Snapshot mode keeps its frame across a refresh tick: the still image on screen stays good until the next one decodes, and hiding per tick would blink the tile once per interval.
- `LiveMonitorPlayer` keeps the element mounted and hidden rather than unmounting it (an unmounted `<img>` can never load), which also retires the effect that used to un-hide it. `alt` goes empty: alt text is what the browser draws beside its glyph, and nothing describes a live feed in words. The #150 error latch and the #313 synchronous hide are unchanged, and their regression tests still pass as written.
- `MonitorHoverPreview` had no `onLoad` or `onError` at all and gets the same gating.
- `useVisibilityResume` learns Capacitor `appStateChange`. On native the WebView suspends with the app and is not obliged to report that as a visibility change; notifications hit this in #274 and streams never got the same signal, so a resume could depend on a listener that never fires.
- Two e2e transport probes decided "is this monitor served over MJPEG" from the element's *visibility*. That predicate is now timing-dependent, so they test attachment, which is what they meant.

## The assumption worth reviewing

The gate depends on `<img>` firing `load` for the first part of a multipart MJPEG stream on WKWebView. Evidence it holds: `domain-context.md` records that multipart MJPEG renders fine in an `<img>` on WKWebView; `useAnalysisFrames` documents that a multipart `<img>` "fires `load` per frame on some engines" and applies a remembered analysis toggle *only* from that load handler, which works today; `ZmsEventPlayer` already gates `display` on load and error and ships. If it turned out not to fire on some engine, live view there would show the placeholder forever, and the fallback would be a status-query watchdog rather than a load gate.

Related: MJPEG live streams have no liveness watchdog at all — the freeze watchdog is video-element-only — so mechanism 1 is invisible to the app until a resume happens to fire. Left alone here; this PR makes it show honestly rather than pretending to be live.

## Verification

`npm run gates` green: 4127 tests passed, 1 skipped file, build clean, lint backlog 201 problems (down one, baseline updated).

New coverage: `useMonitorStream.frame.test.tsx` (no frame from a bare URL, frame after load, dropped on error, dropped on a fresh connkey, dropped synchronously on resume against a refresh that never settles, kept across a snapshot refresh), frame-gating cases in `LiveMonitorPlayer.test.tsx` and `MonitorHoverPreview.test.tsx`, and the native resume signal in `useVisibilityResume.test.ts`.

Device verification is pending and is what actually confirms the reported symptom is gone: background the app on iOS for several minutes, return, and watch the tiles show VideoOff for the reconnect instead of broken thumbnails. Also worth confirming on device that the tiles do come back — that is the `load`-fires assumption above.

Claude assisting @pliablepixels
