### PR TITLE
fix(android): resolve --sai-* safe-area vars from Capacitor-injected insets

### DIFF
--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
@@ -31,7 +31,15 @@ public class MainActivity extends BridgeActivity {
             wrapWebViewWithCursor();
         }
 
-        applyStatusBarVisibility(getResources().getConfiguration().orientation);
+        // Post rather than call directly: Capacitor 8's core SystemBars plugin
+        // queues setHidden(config.hidden=false) -> controller.show(bars) to the
+        // main looper during plugin load (inside super.onCreate above). A direct
+        // hide() here runs BEFORE that queued show() and is overridden, leaving
+        // the status bar visible over the app's top chrome on a cold start in
+        // landscape. Posting queues our visibility call after SystemBars' one.
+        getWindow().getDecorView().post(() ->
+            applyStatusBarVisibility(getResources().getConfiguration().orientation)
+        );
     }
 
     @Override

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -27,6 +27,27 @@
   margin-right: var(--sai-right, env(safe-area-inset-right)) !important;
 }
 
+/* Safe-area inset source of truth for all --sai-* consumers.
+   - iOS: safe-area-bootstrap.ts overrides these with inline styles on
+     documentElement from UIView.safeAreaInsets (inline wins over this
+     stylesheet rule). refs #147.
+   - Android: Capacitor 8's core SystemBars plugin (insetsHandling: 'css',
+     the default) injects --safe-area-inset-* as inline styles on
+     documentElement with the real system-bar/cutout values. Chromium's own
+     env(safe-area-inset-*) only reports system bars on WebView >= 140 with
+     viewport-fit=cover, and is 0 on older WebViews, so the injected
+     variables must be preferred and env() kept only as a fallback.
+   - Web/desktop: neither source is set, env() resolves to 0px.
+   Without this rule, --sai-* is undefined on Android, every usage falls
+   back to env(), and app chrome renders under the status bar on devices
+   where env() reports 0 (e.g. Android 15/16 enforced edge-to-edge). */
+:root {
+  --sai-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  --sai-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
+  --sai-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+  --sai-left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/src/lib/safe-area-bootstrap.ts
+++ b/app/src/lib/safe-area-bootstrap.ts
@@ -9,9 +9,13 @@
  * (UIKit's source of truth) and emits an event on every change. Here we
  * apply those values to --sai-top/right/bottom/left on the document root.
  *
- * CSS usages should reference these via var(--sai-top, env(safe-area-inset-top))
- * so the browser-native env() value is used as the fallback on web/Android,
- * where this plugin is a no-op.
+ * CSS usages reference var(--sai-top, ...). On iOS the inline values set here
+ * win. On Android this plugin is a no-op: env(safe-area-inset-*) is NOT
+ * reliable there (0 on WebView < 140, and observed 0 even on Android 16 with
+ * enforced edge-to-edge). Capacitor 8's core SystemBars plugin instead injects
+ * --safe-area-inset-* inline on documentElement; the :root rule in index.css
+ * chains --sai-* -> --safe-area-inset-* -> env() so every consumer picks up
+ * whichever source is live on the current platform.
  */
 
 import { Capacitor } from '@capacitor/core';


### PR DESCRIPTION
Fixes #355

## Summary

Two bugs on Android 15/16 with enforced edge-to-edge:

1. App chrome rendered under the status bar because no CSS ever consumed the `--safe-area-inset-*` variables Capacitor 8's SystemBars plugin injects. All safe-area consumers use `var(--sai-top, env(safe-area-inset-top))`, `--sai-*` was only set on iOS (safe-area-bootstrap.ts), and `env()` reports 0 on Android WebView < 140 and on the tested Android 16 WebView. A `:root` rule now defines `--sai-*` once with the chain `var(--safe-area-inset-*, env(safe-area-inset-*, 0px))`, fixing every consumer without touching them. iOS still wins via the bootstrap's inline styles (inline beats stylesheet).
2. A cold start in landscape left the status bar visible over the app: SystemBars posts `setHidden(false)` to the main looper during plugin load, which ran after MainActivity's direct hide. The hide call is now posted to the decor view so it queues after SystemBars' one.

Also corrects the safe-area-bootstrap.ts comment that claimed `env()` works on Android.

## Verification

- Claims checked against `@capacitor/android` 8.4.0 source: `insetsHandling` defaults to `css`, `injectSafeAreaCSS()` sets inline `--safe-area-inset-*` on `documentElement`, `load()` posts `setHidden(false)` via `executeOnMainThread` (a `Handler.post`).
- On device (Lenovo TB373FU, Android 16, SDK 36): `env(safe-area-inset-top)` reports 0 while SystemBars injects 39px; `--sai-top` resolves to 39px in portrait and 0 in landscape with bars hidden; cold start in landscape hides the bars.
- `npm run gates` (vitest, build with `tsc -b`, three blocking lints).

## Testing checklist

- [x] Android 16 tablet: portrait, landscape, cold start in landscape, chrome://inspect inset values
- [ ] iOS regression pass (Dynamic Island device, rotation): bootstrap inline values must still win, #147 behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
