### PR TITLE
fix(android): drive system bar icon style through SystemBars plugin

### DIFF
--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
@@ -38,6 +38,12 @@ public class MainActivity extends BridgeActivity {
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         applyStatusBarVisibility(newConfig.orientation);
+        // Posted so it lands after SystemBars' own configuration-change
+        // handler, which re-applies its tracked style and repaints the decor
+        // view with the Android theme's windowBackground. Without this the
+        // window flashes the OS night mode's colour - white behind a dark app
+        // under a light system theme - while the WebView resizes (refs #356).
+        getWindow().getDecorView().post(() -> WindowThemePlugin.reapply(getWindow()));
     }
 
     private void applyStatusBarVisibility(int orientation) {

--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
@@ -3,8 +3,6 @@ package com.zoneminder.zmNinjaNG;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.view.Window;
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -22,16 +20,14 @@ public class WindowThemePlugin extends Plugin {
         }
         try {
             int color = Color.parseColor(hex);
-            // Use luminance to decide whether system bar icons should be dark (light bg) or light (dark bg).
-            double luminance = (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255.0;
-            boolean useDarkIcons = luminance > 0.5;
+            // Bar icon appearance is owned by the core SystemBars plugin
+            // (driven from syncNativeSystemBarsStyle in the web layer).
+            // Setting it here via the insets controller bypasses SystemBars'
+            // tracked style, which re-applies on every configuration change
+            // and stomps the direct call (refs #356).
             getActivity().runOnUiThread(() -> {
                 Window window = getActivity().getWindow();
                 window.setBackgroundDrawable(new ColorDrawable(color));
-                WindowInsetsControllerCompat controller =
-                    WindowCompat.getInsetsController(window, window.getDecorView());
-                controller.setAppearanceLightStatusBars(useDarkIcons);
-                controller.setAppearanceLightNavigationBars(useDarkIcons);
             });
             call.resolve();
         } catch (IllegalArgumentException e) {

--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
@@ -11,6 +11,26 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "WindowTheme")
 public class WindowThemePlugin extends Plugin {
 
+    /**
+     * The colour the web layer last asked for, kept so a configuration change
+     * can restore it. SystemBars.setStyle ends by repainting the decor view
+     * with the Android theme's windowBackground, and it re-applies its tracked
+     * style on every configuration change, so a rotation otherwise leaves the
+     * window painted in the OS night mode's colour - white behind a dark app
+     * on a light system theme, visible while the WebView resizes (refs #356).
+     *
+     * Static because the value has to survive the activity being recreated,
+     * where the web layer's theme effect does not re-run.
+     */
+    private static Integer lastColor = null;
+
+    /** Re-applies the last colour the web layer set, if there is one. */
+    static void reapply(Window window) {
+        if (lastColor != null) {
+            window.setBackgroundDrawable(new ColorDrawable(lastColor));
+        }
+    }
+
     @PluginMethod
     public void setBackgroundColor(PluginCall call) {
         String hex = call.getString("color");
@@ -20,6 +40,7 @@ public class WindowThemePlugin extends Plugin {
         }
         try {
             int color = Color.parseColor(hex);
+            lastColor = color;
             // Bar icon appearance is owned by the core SystemBars plugin
             // (driven from syncNativeSystemBarsStyle in the web layer).
             // Setting it here via the insets controller bypasses SystemBars'

--- a/app/src/components/__tests__/theme-provider.test.tsx
+++ b/app/src/components/__tests__/theme-provider.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '../theme-provider';
+
+const mocks = vi.hoisted(() => ({
+  syncNativeWindowBackground: vi.fn(),
+  syncNativeSystemBarsStyle: vi.fn(),
+}));
+
+vi.mock('../../lib/native-window-theme', () => ({
+  syncNativeWindowBackground: mocks.syncNativeWindowBackground,
+  syncNativeSystemBarsStyle: mocks.syncNativeSystemBarsStyle,
+}));
+
+describe('ThemeProvider native theme sync', () => {
+  beforeEach(() => {
+    mocks.syncNativeWindowBackground.mockClear();
+    mocks.syncNativeSystemBarsStyle.mockClear();
+    // jsdom has no matchMedia; the "system" branch reads it.
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia;
+  });
+
+  it('applies the window background after the bar style, so it is not overwritten', () => {
+    render(<ThemeProvider defaultTheme="dark"><div /></ThemeProvider>);
+
+    // Capacitor's SystemBars.setStyle repaints the decor view with the Android
+    // theme's windowBackground as its last step, so a background set before it
+    // is lost. Order is the fix, not a style preference (refs #356).
+    const styleCall = mocks.syncNativeSystemBarsStyle.mock.invocationCallOrder[0];
+    const backgroundCall = mocks.syncNativeWindowBackground.mock.invocationCallOrder[0];
+    expect(styleCall).toBeLessThan(backgroundCall);
+  });
+
+  it('runs both syncs for the system theme', () => {
+    render(<ThemeProvider defaultTheme="system"><div /></ThemeProvider>);
+
+    expect(mocks.syncNativeSystemBarsStyle).toHaveBeenCalled();
+    expect(mocks.syncNativeWindowBackground).toHaveBeenCalled();
+  });
+});

--- a/app/src/components/theme-provider.tsx
+++ b/app/src/components/theme-provider.tsx
@@ -79,8 +79,14 @@ export function ThemeProvider({
         // Both syncs must also run for the "system" branch: a previously set
         // explicit bar style or window background does not revert when the
         // user switches back to "system" (refs #356).
-        syncNativeWindowBackground()
+        //
+        // Order matters. SystemBars.setStyle ends by repainting the decor view
+        // with the Android theme's windowBackground, which follows the OS night
+        // mode, not the app theme. Running it after the background sync would
+        // discard the colour WindowTheme just applied and show, for example, a
+        // white decor behind a dark app during rotation or overscroll.
         syncNativeSystemBarsStyle()
+        syncNativeWindowBackground()
     }, [theme])
 
     const handleSetTheme = useCallback((newTheme: Theme) => {

--- a/app/src/components/theme-provider.tsx
+++ b/app/src/components/theme-provider.tsx
@@ -9,7 +9,7 @@
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from "react"
 import { useProfileStore } from '../stores/profile';
 import { useSettingsStore, type ThemePreference } from '../stores/settings';
-import { syncNativeWindowBackground } from '../lib/native-window-theme';
+import { syncNativeWindowBackground, syncNativeSystemBarsStyle } from '../lib/native-window-theme';
 
 type Theme = ThemePreference
 
@@ -70,16 +70,17 @@ export function ThemeProvider({
                 : "light"
 
             root.classList.add(systemTheme)
-            return
-        }
-
-        if (theme === "slate" || theme === "amber") {
+        } else if (theme === "slate" || theme === "amber") {
             root.classList.add("dark", theme)
         } else {
             root.classList.add(theme)
         }
 
+        // Both syncs must also run for the "system" branch: a previously set
+        // explicit bar style or window background does not revert when the
+        // user switches back to "system" (refs #356).
         syncNativeWindowBackground()
+        syncNativeSystemBarsStyle()
     }, [theme])
 
     const handleSetTheme = useCallback((newTheme: Theme) => {

--- a/app/src/lib/__tests__/native-window-theme.test.ts
+++ b/app/src/lib/__tests__/native-window-theme.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { syncNativeSystemBarsStyle } from '../native-window-theme';
+
+const mocks = vi.hoisted(() => ({
+  platform: { value: 'android' },
+  setStyle: vi.fn(),
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    getPlatform: () => mocks.platform.value,
+    isNativePlatform: () => mocks.platform.value !== 'web',
+  },
+  registerPlugin: () =>
+    new Proxy({}, { get: () => vi.fn().mockResolvedValue(undefined) }),
+  SystemBars: {
+    setStyle: (options: unknown) => mocks.setStyle(options),
+  },
+  SystemBarsStyle: { Dark: 'DARK', Light: 'LIGHT', Default: 'DEFAULT' },
+}));
+
+describe('syncNativeSystemBarsStyle', () => {
+  beforeEach(() => {
+    mocks.platform.value = 'android';
+    mocks.setStyle.mockReset();
+    mocks.setStyle.mockResolvedValue(undefined);
+    document.documentElement.classList.remove('light', 'dark', 'slate', 'amber', 'cream');
+  });
+
+  it('sets DARK style (light icons) when the effective theme is dark', () => {
+    document.documentElement.classList.add('dark');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).toHaveBeenCalledWith({ style: 'DARK' });
+  });
+
+  it('sets DARK style for composite dark themes (slate)', () => {
+    document.documentElement.classList.add('dark', 'slate');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).toHaveBeenCalledWith({ style: 'DARK' });
+  });
+
+  it('sets LIGHT style (dark icons) when the effective theme is light', () => {
+    document.documentElement.classList.add('light');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).toHaveBeenCalledWith({ style: 'LIGHT' });
+  });
+
+  it('does nothing off Android', () => {
+    mocks.platform.value = 'web';
+    document.documentElement.classList.add('dark');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).not.toHaveBeenCalled();
+
+    mocks.platform.value = 'ios';
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when the native call rejects', async () => {
+    document.documentElement.classList.add('dark');
+    mocks.setStyle.mockRejectedValue(new Error('native unavailable'));
+    expect(() => syncNativeSystemBarsStyle()).not.toThrow();
+    await vi.waitFor(() => expect(mocks.setStyle).toHaveBeenCalled());
+  });
+});

--- a/app/src/lib/native-window-theme.ts
+++ b/app/src/lib/native-window-theme.ts
@@ -1,4 +1,4 @@
-import { registerPlugin } from '@capacitor/core';
+import { registerPlugin, SystemBars, SystemBarsStyle } from '@capacitor/core';
 import { Platform } from './platform';
 import { log, LogLevel } from './logger';
 
@@ -29,5 +29,28 @@ export function syncNativeWindowBackground(): void {
 
   WindowTheme.setBackgroundColor({ color: hex }).catch((err: unknown) => {
     log.app('Failed to set native window background', LogLevel.WARN, { hex, err });
+  });
+}
+
+/**
+ * Keeps Android status/navigation bar icon color readable against the app
+ * theme. Must go through the SystemBars plugin, not the insets controller
+ * directly: SystemBars re-applies its own tracked style on every
+ * configuration change (rotation), so a direct controller call is stomped
+ * back to DEFAULT, which follows the OS theme. With a light OS theme and a
+ * dark app theme that re-apply requests dark icons on a dark background
+ * (refs #356). setStyle updates the tracked style, so re-applies preserve
+ * it. Must run on every effective theme change, including the "system"
+ * branch: an explicitly set style never reverts to DEFAULT on its own.
+ * iOS is left on its existing default pending a device pass.
+ */
+export function syncNativeSystemBarsStyle(): void {
+  if (!Platform.isAndroid) return;
+  if (typeof document === 'undefined') return;
+
+  const dark = document.documentElement.classList.contains('dark');
+  const style = dark ? SystemBarsStyle.Dark : SystemBarsStyle.Light;
+  SystemBars.setStyle({ style }).catch((err: unknown) => {
+    log.app('Failed to set system bars style', LogLevel.WARN, { style, err });
   });
 }

--- a/app/src/tests/setup.ts
+++ b/app/src/tests/setup.ts
@@ -117,6 +117,10 @@ vi.mock('@capacitor/core', () => ({
   registerPlugin: () => new Proxy({}, {
     get: () => vi.fn().mockResolvedValue(undefined),
   }),
+  SystemBars: {
+    setStyle: vi.fn().mockResolvedValue(undefined),
+  },
+  SystemBarsStyle: { Dark: 'DARK', Light: 'LIGHT', Default: 'DEFAULT' },
 }));
 
 // Mock Capacitor Haptics


### PR DESCRIPTION
Fixes #356

## Summary

Status bar icons rendered black on the dark app theme after any rotation when the OS theme is light. `WindowThemePlugin` set icon appearance directly on the insets controller from background luminance, but Capacitor 8's SystemBars plugin re-applies its own tracked style on every configuration change, and that style stayed `DEFAULT` (follows the OS theme) because nothing called `SystemBars.setStyle`. One rotation stomped the direct call.

The web layer now calls `SystemBars.setStyle` (Dark style for dark themes, Light for light) on every effective theme change, including the `system` branch, which updates the plugin's tracked style so config-change re-applies preserve it. The bypassed insets-controller calls are removed from `WindowThemePlugin`, leaving SystemBars the single owner of bar icon appearance. Android only; iOS keeps its existing default pending a device pass.

## Verification

- Reproduced on device: after a rotation cycle the old build's window requested `apr=LIGHT_STATUS_BARS` (dark icons) over the dark UI (`dumpsys window windows`); the fixed build no longer does, and the style survives rotations.
- New unit tests for `syncNativeSystemBarsStyle` (dark, composite dark themes, light, non-Android no-op, rejected native call).
- `npm run gates`.

## Testing checklist

- [x] Android 16 tablet: rotation cycles with light OS theme + dark app theme, theme toggle
- [x] Native change (`WindowThemePlugin`) exercised on device via theme-provider path
- [ ] Optional follow-up: same treatment for iOS after a device pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
