### PR TITLE
fix(layout): pin safe-area strip so md content cannot scroll behind status bar

### DIFF
--- a/app/src/components/layout/AppLayout.tsx
+++ b/app/src/components/layout/AppLayout.tsx
@@ -285,7 +285,15 @@ export default function AppLayout() {
       )}
 
       {/* Main Content */}
-      <main className="flex-1 overflow-y-auto overflow-x-hidden relative w-full pt-[calc(3rem+var(--sai-top,env(safe-area-inset-top)))] md:pt-[var(--sai-top,env(safe-area-inset-top))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))]" data-tv-region="main">
+      <main className="flex-1 overflow-y-auto overflow-x-hidden relative w-full pt-[calc(3rem+var(--sai-top,env(safe-area-inset-top)))] md:pt-0 pb-[var(--sai-bottom,env(safe-area-inset-bottom))]" data-tv-region="main">
+        {/* md+ has no fixed header, so the safe-area inset is this sticky
+            strip instead of padding: padding scrolls with the content and
+            lets it slide behind the status bar icons (refs #357). Sticky
+            keeps the strip pinned while content passes beneath; height is 0
+            wherever the inset is 0. z-30 clears in-content overlays such as
+            the monitor card protocol/recording badges (z-10/z-20) while
+            staying under fullscreen chrome and DeleteBatchBar (z-50). */}
+        <div className="hidden md:block sticky top-0 h-[var(--sai-top,env(safe-area-inset-top))] bg-background z-30" aria-hidden="true" />
         {/* Background gradient blob for visual interest */}
         <div className="absolute top-0 left-0 w-full h-96 bg-gradient-to-b from-primary/5 to-transparent -z-10 pointer-events-none" />
 

--- a/app/src/components/layout/AppLayout.tsx
+++ b/app/src/components/layout/AppLayout.tsx
@@ -292,7 +292,10 @@ export default function AppLayout() {
             keeps the strip pinned while content passes beneath; height is 0
             wherever the inset is 0. z-30 clears in-content overlays such as
             the monitor card protocol/recording badges (z-10/z-20) while
-            staying under fullscreen chrome and DeleteBatchBar (z-50). */}
+            staying under fullscreen chrome and DeleteBatchBar (z-50).
+            A page rendering its own sticky header inside this scroller must
+            pin below the strip with md:top-[var(--sai-top,...)], or the strip
+            covers its top edge (MonitorDetail, EventDetail). */}
         <div className="hidden md:block sticky top-0 h-[var(--sai-top,env(safe-area-inset-top))] bg-background z-30" aria-hidden="true" />
         {/* Background gradient blob for visual interest */}
         <div className="absolute top-0 left-0 w-full h-96 bg-gradient-to-b from-primary/5 to-transparent -z-10 pointer-events-none" />

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -449,7 +449,7 @@ export default function EventDetail() {
   return (
     <div className="flex flex-col h-full bg-background">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 md:top-[var(--sai-top,env(safe-area-inset-top))] z-10">
         <div className="flex items-center gap-2 sm:gap-3">
           <Button
             variant="ghost"

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -289,7 +289,7 @@ export default function MonitorDetail() {
     )}>
       {/* Header - Hidden in fullscreen */}
       {!isFullscreen && (
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 md:top-[var(--sai-top,env(safe-area-inset-top))] z-10">
         <div className="flex items-center gap-2 sm:gap-3">
           <Button
             variant="ghost"


### PR DESCRIPTION
Fixes #357

## Summary

On the tablet/desktop (`md:`) layout, scrolled content slid up into the status bar strip and rendered behind the clock and system icons. The layout has no fixed header there; the top safe-area inset was padding on the scrollable `<main>`, and padding inside a scroll container scrolls with the content. The phone layout was unaffected (its fixed header is opaque and includes the inset).

The `md:` top padding is replaced by a sticky opaque strip of height `--sai-top` as the scroller's first child: same initial layout, pinned while content passes beneath, zero height wherever insets are zero (web, landscape with bars hidden). The strip sits at `z-30`: above in-content overlays such as the monitor card protocol/recording badges (`z-10`/`z-20`), below fullscreen chrome and DeleteBatchBar (`z-50`).

Android never showed this before #355 because `--sai-top` was 0 there; the behavior exists on iPad today and this fixes it there as well.

## Verification

- On device (Android 16 tablet): scrolled Monitors and Settings in portrait, content and badges tuck under the strip; landscape stays full-bleed.
- `npm run gates`. No visual baseline changes: the strip is zero-height on web.

## Testing checklist

- [x] Android 16 tablet: portrait scroll on Monitors/Settings, landscape immersive unchanged, badge z-order
- [ ] iPad: same scroll check when an iOS pass happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
