### PR TITLE
fix(fullscreen): derive toolbar clearance from one height variable

### DIFF
--- a/app/src/components/montage/FullscreenControls.tsx
+++ b/app/src/components/montage/FullscreenControls.tsx
@@ -37,7 +37,7 @@ export function FullscreenControls({
       className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))] pt-[var(--sai-top,env(safe-area-inset-top))]"
       data-testid="montage-fullscreen-toolbar"
     >
-      <div className="h-8 flex items-center justify-between px-3">
+      <div className="h-[var(--fullscreen-toolbar-h)] flex items-center justify-between px-3">
         <span className="text-white/70 font-medium text-xs">{t('montage.title')}</span>
         <div className="flex items-center gap-1">
           <Button

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -27,6 +27,15 @@
   margin-right: var(--sai-right, env(safe-area-inset-right)) !important;
 }
 
+/* Height of the thin fullscreen toolbars (montage, monitor detail). One
+   source for both the toolbar row (h-[var(...)]) and the content padding
+   that clears the fixed bar (calc(var(...) + safe-area inset)): a hardcoded
+   2rem clearance drifts from the row when compact mode shrinks heights
+   (refs #358). Compact override lives next to the .h-8 rule it tracks. */
+:root {
+  --fullscreen-toolbar-h: 2rem;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -500,6 +509,8 @@
 }
 .compact-mode .h-7 { height: 1.5rem; }
 .compact-mode .h-8 { height: 1.75rem; }
+/* Fullscreen toolbar rows track .h-8; see the :root default (refs #358). */
+.compact-mode { --fullscreen-toolbar-h: 1.75rem; }
 .compact-mode .h-9 { height: 1.875rem; }
 .compact-mode .h-10 { height: 2rem; }
 .compact-mode .h-11 { height: 2rem; }

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -385,7 +385,7 @@ export default function MonitorDetail() {
           className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))] pt-[var(--sai-top,env(safe-area-inset-top))]"
           data-testid="monitor-detail-fullscreen-toolbar"
         >
-          <div className="h-8 flex items-center justify-between px-3">
+          <div className="h-[var(--fullscreen-toolbar-h)] flex items-center justify-between px-3">
             <span className="text-white/70 font-medium text-xs truncate min-w-0" title={monitor.Monitor.Name}>
               {monitor.Monitor.Name}
             </span>
@@ -408,7 +408,7 @@ export default function MonitorDetail() {
       <div className={cn(
         'flex-1 flex flex-col items-center justify-center',
         isFullscreen
-          ? 'pt-[calc(2rem+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
+          ? 'pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
           : 'p-2 sm:p-3 md:p-4 bg-muted/10'
       )}>
         <Card

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -681,7 +681,7 @@ export default function Montage() {
         className={cn(
           'flex-1 overflow-auto bg-muted/10',
           isFullscreen
-            ? 'pt-[calc(2rem+var(--sai-top,env(safe-area-inset-top)))] overscroll-contain'
+            ? 'pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] overscroll-contain'
             : 'touch-pan-y'
         )}
       >


### PR DESCRIPTION
Fixes #358

## Summary

In compact display mode, a blank strip appeared between the thin fullscreen toolbar and the content below it in Montage and MonitorDetail. The toolbar row uses `h-8`, which compact mode overrides to 1.75rem, while the content cleared the fixed toolbar with a hardcoded `pt-[calc(2rem+...)]`. Compact mode cannot rewrite arbitrary values, so the toolbar shrank to 28px while the clearance stayed 32px.

Both the toolbar rows and both clearance paddings now read one variable, `--fullscreen-toolbar-h`, defined at `:root` (2rem) and overridden in the compact-mode block next to the `.h-8` rule it tracks (1.75rem).

## Verification

- On device (Android 16 tablet, compact mode): toolbar bottom, scroller padding, and first tile top all measure 28px in fullscreen montage, gap 0, in portrait and landscape.
- `npm run gates`.

## Testing checklist

- [x] Android 16 tablet, compact mode: fullscreen montage and monitor detail
- [x] Normal display mode unaffected (both sides resolve to 2rem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
