### PR TITLE
fix(montage): exclude overlay header from fullscreen tile heights

### DIFF
--- a/app/src/components/montage/hooks/__tests__/useMontageGrid.test.ts
+++ b/app/src/components/montage/hooks/__tests__/useMontageGrid.test.ts
@@ -293,6 +293,49 @@ describe('tile heights for rotated monitors', () => {
   });
 });
 
+describe('tile header allowance (#359)', () => {
+  const profileId = 'header-profile';
+
+  const setup = (tileHeaderPx: number) => {
+    useSettingsStore.setState({ profileSettings: {} });
+    useSettingsStore.getState().updateMontageGroupLayout(profileId, 'A', {
+      gridCols: 2,
+      workingLayout: [],
+    });
+    const settings = useSettingsStore.getState().getProfileSettings(profileId);
+    const monitors = [makeMonitor('1', 'ROTATE_0')];
+
+    type HookProps = Parameters<typeof useMontageGrid>[0];
+    return renderHook(
+      (props: HookProps) => useMontageGrid(props),
+      { initialProps: { monitors, profileId: asProfileId(profileId), settings, isEditMode: false, groupKey: 'A', tileHeaderPx } }
+    );
+  };
+
+  // gridWidth 1200 over 2 display columns: 600px of video width.
+  // ROTATE_0: 600 * (1080/1920) = 337.5; +32 header -> ceil 370, no header -> 338.
+
+  it('excludes the header from tile height when tileHeaderPx is 0 (fullscreen overlay header)', () => {
+    const { result } = setup(0);
+    act(() => { result.current.handleWidthChange(1200); });
+    expect(result.current.layout[0].h).toBe(338);
+  });
+
+  it('recalculates heights when tileHeaderPx changes (fullscreen toggle)', () => {
+    const { result, rerender } = setup(32);
+    act(() => { result.current.handleWidthChange(1200); });
+    expect(result.current.layout[0].h).toBe(370);
+
+    const settings = useSettingsStore.getState().getProfileSettings(profileId);
+    const monitors = [makeMonitor('1', 'ROTATE_0')];
+    rerender({ monitors, profileId: asProfileId(profileId), settings, isEditMode: false, groupKey: 'A', tileHeaderPx: 0 });
+    expect(result.current.layout[0].h).toBe(338);
+
+    rerender({ monitors, profileId: asProfileId(profileId), settings, isEditMode: false, groupKey: 'A', tileHeaderPx: 28 });
+    expect(result.current.layout[0].h).toBe(366);
+  });
+});
+
 describe('group-switch re-init', () => {
   const profileId = 'test-profile';
   const monitors = [makeMonitor('10'), makeMonitor('20')];

--- a/app/src/components/montage/hooks/useMontageGrid.ts
+++ b/app/src/components/montage/hooks/useMontageGrid.ts
@@ -67,7 +67,8 @@ const calculateHeightUnits = (
   widthUnits: number,
   gridWidth: number,
   margin: number,
-  internalCols: number
+  internalCols: number,
+  headerPx: number
 ): number => {
   const monitor = monitorMap.get(monitorId);
   if (!monitor) return 200;
@@ -76,7 +77,7 @@ const calculateHeightUnits = (
   const columnWidth = (gridWidth - margin * (internalCols - 1)) / internalCols;
   const itemWidth = columnWidth * widthUnits + margin * (widthUnits - 1);
   const videoPx = itemWidth * aspectRatio;
-  const heightPx = videoPx + MONTAGE_GRID.cardHeaderHeightPx;
+  const heightPx = videoPx + headerPx;
   const unit = (heightPx + margin) / (GRID_LAYOUT.montageRowHeight + margin);
 
   return Math.max(2, Math.ceil(unit));
@@ -124,6 +125,12 @@ interface UseMontageGridOptions {
   settings: ProfileSettings;
   isEditMode: boolean;
   groupKey: string;
+  /** In-flow height of the tile header the layout must allow for. 0 in
+   *  fullscreen, where the header is an absolute overlay over the video;
+   *  the compact-mode value when compact rendering shrinks h-8 rows. A
+   *  mismatch letterboxes every video vertically inside its tile because
+   *  object-fit: contain centers the difference (refs #359). */
+  tileHeaderPx?: number;
 }
 
 interface UseMontageGridReturn {
@@ -147,6 +154,7 @@ export function useMontageGrid({
   settings,
   isEditMode,
   groupKey,
+  tileHeaderPx = MONTAGE_GRID.cardHeaderHeightPx,
 }: UseMontageGridOptions): UseMontageGridReturn {
   const { t } = useTranslation();
   const updateMontageGroupLayout = useSettingsStore(
@@ -184,6 +192,8 @@ export function useMontageGrid({
   const groupKeyRef = useRef(groupKey);
   useEffect(() => { groupKeyRef.current = groupKey; }, [groupKey]);
 
+  const tileHeaderPxRef = useRef(tileHeaderPx);
+
   const monitorMap = useMemo(() => {
     return new Map(monitors.map((item) => [tileIdFor(item), item.Monitor]));
   }, [monitors]);
@@ -200,7 +210,7 @@ export function useMontageGrid({
       const map = monitorMapRef.current;
       return monitorList.map((item, index) => {
         const id = tileIdFor(item);
-        const h = calculateHeightUnits(map, id, w, gridWidth, 0, internalCols);
+        const h = calculateHeightUnits(map, id, w, gridWidth, 0, internalCols, tileHeaderPxRef.current);
         return {
           i: id,
           x: (index % perRow) * w,
@@ -223,11 +233,21 @@ export function useMontageGrid({
         ...item,
         w: Math.min(item.w, internalCols),
         x: Math.min(item.x, internalCols - item.w),
-        h: calculateHeightUnits(map, item.i, item.w, gridWidth, 0, internalCols),
+        h: calculateHeightUnits(map, item.i, item.w, gridWidth, 0, internalCols, tileHeaderPxRef.current),
       }));
     },
     [] // Uses ref, stable identity
   );
+
+  // Recalculate heights when the in-flow header allowance changes (fullscreen
+  // toggle), same as a width change: the ref updates first so every later
+  // recalc path uses the new value.
+  useEffect(() => {
+    if (tileHeaderPxRef.current === tileHeaderPx) return;
+    tileHeaderPxRef.current = tileHeaderPx;
+    if (currentWidthRef.current === 0) return;
+    setLayout((prev) => recalcHeights(prev, currentWidthRef.current, displayColsRef.current));
+  }, [tileHeaderPx, recalcHeights]);
 
   // Update displayCols when profile changes (external change only)
   useEffect(() => {
@@ -389,7 +409,8 @@ export function useMontageGrid({
         newItem.w,
         currentWidthRef.current,
         0,
-        internalColsForCols(displayColsRef.current)
+        internalColsForCols(displayColsRef.current),
+        tileHeaderPxRef.current
       );
 
       setLayout((prev) => {

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -1042,6 +1042,11 @@ export const MONTAGE_GRID = {
   // h-8 header bar height with monitor name + buttons (px)
   cardHeaderHeightPx: 32,
 
+  // The same header under compact display mode, which shrinks h-8 rows to
+  // 1.75rem (index.css .compact-mode .h-8). Layout math must use the value
+  // that actually renders or the difference letterboxes the video (refs #359).
+  cardHeaderHeightCompactPx: 28,
+
   // All-mode only cap on total tiles (== streams) rendered across every
   // profile's monitors combined. Single mode has no cap (unchanged,
   // unlimited) - this only guards the aggregate view, where N profiles each

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -278,6 +278,14 @@ export default function Montage() {
     settings,
     isEditMode,
     groupKey,
+    // In fullscreen the tile header is an absolute overlay and takes no flow
+    // space; in normal mode it is in flow at the height the display mode
+    // actually renders (refs #359).
+    tileHeaderPx: isFullscreen
+      ? 0
+      : settings.displayMode === 'compact'
+        ? MONTAGE_GRID.cardHeaderHeightCompactPx
+        : MONTAGE_GRID.cardHeaderHeightPx,
   });
 
   // Tile render resolvers passed to MontageGridSections: the owning profile


### PR DESCRIPTION
Fixes #359

## Summary

Entering montage fullscreen made every video drop about 16px, leaving a black band between the toolbar and each video. `calculateHeightUnits` sizes each tile as video height plus the 32px card header. In fullscreen the header is an absolute overlay and takes no flow space, but the 32px was still added, so the media box was 32px taller than the video and `object-fit: contain` centered the difference as letterbox.

The layout math now receives the in-flow header height that actually renders: 0 in fullscreen, 28px in compact display mode (which shrinks `h-8` rows to 1.75rem), 32px otherwise. Tile heights recalculate when that value changes (fullscreen toggle), same as the existing width-change recalculation. New constant `cardHeaderHeightCompactPx` documents the compact value next to its source.

## Verification

- On device (Android 16 tablet): fullscreen montage tile measures exactly the video's contain size (459x816 for a 360x640 stream), letterbox 0px, video flush against the toolbar; toggling fullscreen no longer shifts videos.
- Two new unit tests: zero-header tile height, and height recalculation across tileHeaderPx changes (40/40 pass).
- `npm run gates`.

## Testing checklist

- [x] Android 16 tablet: fullscreen toggle in landscape and portrait, compact mode
- [x] Edit-mode resize path uses the same header allowance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
