### PR TITLE
chore(android): let R8 optimize the release build

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -37,7 +37,13 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // The -optimize variant, because the plain proguard-android.txt sets
+            // -dontoptimize: R8 then only shrinks and obfuscates, leaving the
+            // inlining, dead-branch removal, and class merging off. Play Console
+            // flags that as a missed optimization ("Improve your app's memory and
+            // performance with R8 optimization"). R8 full mode is already on by
+            // default under AGP 8.
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             ndk {
                 debugSymbolLevel 'FULL'
             }


### PR DESCRIPTION
Play Console recommendation: "Improve your app's memory and performance with R8 optimization".

## Cause

`app/build.gradle` used `getDefaultProguardFile('proguard-android.txt')`, which sets `-dontoptimize`. The release build therefore only shrank and obfuscated: no inlining, no dead-branch removal, no class merging. R8 full mode was already on (AGP 8 default), so the flag was the only thing holding optimization back.

## Change

Switch to `proguard-android-optimize.txt`, the same default file without `-dontoptimize`. `proguard-rules.pro` is untouched.

## Verification

`./gradlew :app:assembleRelease` succeeds. Release APK: 52,547,611 bytes before, 51,569,503 after, so the optimization passes do run.

**Needs a device smoke test before release.** Optimization can break reflective paths that shrinking alone left intact — the Capacitor plugin bridge, Firebase messaging, and ML Kit GenAI are the ones to exercise. No device was attached here, so this is unverified at runtime.

Unrelated note from the same Play Console page: the "deprecated APIs for edge-to-edge" warning comes from `@capacitor/splash-screen`, not this repo. 8.0.2 (latest) still carries `SYSTEM_UI_FLAG_*` and `setDecorFitsSystemWindows` in `SplashScreen.java`, runtime-gated on splash config this app does not set. Play scans bytecode, so only an upstream release can clear it.

Posted by Claude, assisting @pliablepixels.