### PR TITLE
Android edge-to-edge, safe-area insets, and the scroll pad

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -37,7 +37,13 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // The -optimize variant, because the plain proguard-android.txt sets
+            // -dontoptimize: R8 then only shrinks and obfuscates, leaving the
+            // inlining, dead-branch removal, and class merging off. Play Console
+            // flags that as a missed optimization ("Improve your app's memory and
+            // performance with R8 optimization"). R8 full mode is already on by
+            // default under AGP 8.
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             ndk {
                 debugSymbolLevel 'FULL'
             }

--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
@@ -31,7 +31,15 @@ public class MainActivity extends BridgeActivity {
             wrapWebViewWithCursor();
         }
 
-        applyStatusBarVisibility(getResources().getConfiguration().orientation);
+        // Post rather than call directly: Capacitor 8's core SystemBars plugin
+        // queues setHidden(config.hidden=false) -> controller.show(bars) to the
+        // main looper during plugin load (inside super.onCreate above). A direct
+        // hide() here runs BEFORE that queued show() and is overridden, leaving
+        // the status bar visible over the app's top chrome on a cold start in
+        // landscape. Posting queues our visibility call after SystemBars' one.
+        getWindow().getDecorView().post(() ->
+            applyStatusBarVisibility(getResources().getConfiguration().orientation)
+        );
     }
 
     @Override

--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/MainActivity.java
@@ -38,6 +38,12 @@ public class MainActivity extends BridgeActivity {
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         applyStatusBarVisibility(newConfig.orientation);
+        // Posted so it lands after SystemBars' own configuration-change
+        // handler, which re-applies its tracked style and repaints the decor
+        // view with the Android theme's windowBackground. Without this the
+        // window flashes the OS night mode's colour - white behind a dark app
+        // under a light system theme - while the WebView resizes (refs #356).
+        getWindow().getDecorView().post(() -> WindowThemePlugin.reapply(getWindow()));
     }
 
     private void applyStatusBarVisibility(int orientation) {

--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
@@ -3,8 +3,6 @@ package com.zoneminder.zmNinjaNG;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.view.Window;
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -22,16 +20,14 @@ public class WindowThemePlugin extends Plugin {
         }
         try {
             int color = Color.parseColor(hex);
-            // Use luminance to decide whether system bar icons should be dark (light bg) or light (dark bg).
-            double luminance = (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255.0;
-            boolean useDarkIcons = luminance > 0.5;
+            // Bar icon appearance is owned by the core SystemBars plugin
+            // (driven from syncNativeSystemBarsStyle in the web layer).
+            // Setting it here via the insets controller bypasses SystemBars'
+            // tracked style, which re-applies on every configuration change
+            // and stomps the direct call (refs #356).
             getActivity().runOnUiThread(() -> {
                 Window window = getActivity().getWindow();
                 window.setBackgroundDrawable(new ColorDrawable(color));
-                WindowInsetsControllerCompat controller =
-                    WindowCompat.getInsetsController(window, window.getDecorView());
-                controller.setAppearanceLightStatusBars(useDarkIcons);
-                controller.setAppearanceLightNavigationBars(useDarkIcons);
             });
             call.resolve();
         } catch (IllegalArgumentException e) {

--- a/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
+++ b/app/android/app/src/main/java/com/zoneminder/zmNinjaNG/WindowThemePlugin.java
@@ -11,6 +11,26 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "WindowTheme")
 public class WindowThemePlugin extends Plugin {
 
+    /**
+     * The colour the web layer last asked for, kept so a configuration change
+     * can restore it. SystemBars.setStyle ends by repainting the decor view
+     * with the Android theme's windowBackground, and it re-applies its tracked
+     * style on every configuration change, so a rotation otherwise leaves the
+     * window painted in the OS night mode's colour - white behind a dark app
+     * on a light system theme, visible while the WebView resizes (refs #356).
+     *
+     * Static because the value has to survive the activity being recreated,
+     * where the web layer's theme effect does not re-run.
+     */
+    private static Integer lastColor = null;
+
+    /** Re-applies the last colour the web layer set, if there is one. */
+    static void reapply(Window window) {
+        if (lastColor != null) {
+            window.setBackgroundDrawable(new ColorDrawable(lastColor));
+        }
+    }
+
     @PluginMethod
     public void setBackgroundColor(PluginCall call) {
         String hex = call.getString("color");
@@ -20,6 +40,7 @@ public class WindowThemePlugin extends Plugin {
         }
         try {
             int color = Color.parseColor(hex);
+            lastColor = color;
             // Bar icon appearance is owned by the core SystemBars plugin
             // (driven from syncNativeSystemBarsStyle in the web layer).
             // Setting it here via the insets controller bypasses SystemBars'

--- a/app/src/components/__tests__/theme-provider.test.tsx
+++ b/app/src/components/__tests__/theme-provider.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '../theme-provider';
+
+const mocks = vi.hoisted(() => ({
+  syncNativeWindowBackground: vi.fn(),
+  syncNativeSystemBarsStyle: vi.fn(),
+}));
+
+vi.mock('../../lib/native-window-theme', () => ({
+  syncNativeWindowBackground: mocks.syncNativeWindowBackground,
+  syncNativeSystemBarsStyle: mocks.syncNativeSystemBarsStyle,
+}));
+
+describe('ThemeProvider native theme sync', () => {
+  beforeEach(() => {
+    mocks.syncNativeWindowBackground.mockClear();
+    mocks.syncNativeSystemBarsStyle.mockClear();
+    // jsdom has no matchMedia; the "system" branch reads it.
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia;
+  });
+
+  it('applies the window background after the bar style, so it is not overwritten', () => {
+    render(<ThemeProvider defaultTheme="dark"><div /></ThemeProvider>);
+
+    // Capacitor's SystemBars.setStyle repaints the decor view with the Android
+    // theme's windowBackground as its last step, so a background set before it
+    // is lost. Order is the fix, not a style preference (refs #356).
+    const styleCall = mocks.syncNativeSystemBarsStyle.mock.invocationCallOrder[0];
+    const backgroundCall = mocks.syncNativeWindowBackground.mock.invocationCallOrder[0];
+    expect(styleCall).toBeLessThan(backgroundCall);
+  });
+
+  it('runs both syncs for the system theme', () => {
+    render(<ThemeProvider defaultTheme="system"><div /></ThemeProvider>);
+
+    expect(mocks.syncNativeSystemBarsStyle).toHaveBeenCalled();
+    expect(mocks.syncNativeWindowBackground).toHaveBeenCalled();
+  });
+});

--- a/app/src/components/layout/AppLayout.tsx
+++ b/app/src/components/layout/AppLayout.tsx
@@ -285,7 +285,15 @@ export default function AppLayout() {
       )}
 
       {/* Main Content */}
-      <main className="flex-1 overflow-y-auto overflow-x-hidden relative w-full pt-[calc(3rem+var(--sai-top,env(safe-area-inset-top)))] md:pt-[var(--sai-top,env(safe-area-inset-top))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))]" data-tv-region="main">
+      <main className="flex-1 overflow-y-auto overflow-x-hidden relative w-full pt-[calc(3rem+var(--sai-top,env(safe-area-inset-top)))] md:pt-0 pb-[var(--sai-bottom,env(safe-area-inset-bottom))]" data-tv-region="main">
+        {/* md+ has no fixed header, so the safe-area inset is this sticky
+            strip instead of padding: padding scrolls with the content and
+            lets it slide behind the status bar icons (refs #357). Sticky
+            keeps the strip pinned while content passes beneath; height is 0
+            wherever the inset is 0. z-30 clears in-content overlays such as
+            the monitor card protocol/recording badges (z-10/z-20) while
+            staying under fullscreen chrome and DeleteBatchBar (z-50). */}
+        <div className="hidden md:block sticky top-0 h-[var(--sai-top,env(safe-area-inset-top))] bg-background z-30" aria-hidden="true" />
         {/* Background gradient blob for visual interest */}
         <div className="absolute top-0 left-0 w-full h-96 bg-gradient-to-b from-primary/5 to-transparent -z-10 pointer-events-none" />
 

--- a/app/src/components/layout/AppLayout.tsx
+++ b/app/src/components/layout/AppLayout.tsx
@@ -292,7 +292,10 @@ export default function AppLayout() {
             keeps the strip pinned while content passes beneath; height is 0
             wherever the inset is 0. z-30 clears in-content overlays such as
             the monitor card protocol/recording badges (z-10/z-20) while
-            staying under fullscreen chrome and DeleteBatchBar (z-50). */}
+            staying under fullscreen chrome and DeleteBatchBar (z-50).
+            A page rendering its own sticky header inside this scroller must
+            pin below the strip with md:top-[var(--sai-top,...)], or the strip
+            covers its top edge (MonitorDetail, EventDetail). */}
         <div className="hidden md:block sticky top-0 h-[var(--sai-top,env(safe-area-inset-top))] bg-background z-30" aria-hidden="true" />
         {/* Background gradient blob for visual interest */}
         <div className="absolute top-0 left-0 w-full h-96 bg-gradient-to-b from-primary/5 to-transparent -z-10 pointer-events-none" />

--- a/app/src/components/montage/FullscreenControls.tsx
+++ b/app/src/components/montage/FullscreenControls.tsx
@@ -37,7 +37,7 @@ export function FullscreenControls({
       className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))] pt-[var(--sai-top,env(safe-area-inset-top))]"
       data-testid="montage-fullscreen-toolbar"
     >
-      <div className="h-8 flex items-center justify-between px-3">
+      <div className="h-[var(--fullscreen-toolbar-h)] flex items-center justify-between px-3">
         <span className="text-white/70 font-medium text-xs">{t('montage.title')}</span>
         <div className="flex items-center gap-1">
           <Button

--- a/app/src/components/montage/MontageKebabMenu.tsx
+++ b/app/src/components/montage/MontageKebabMenu.tsx
@@ -29,12 +29,17 @@ interface MontageKebabMenuProps {
   items: MontageVisibilityItem[];
   hiddenMonitorIds: string[];
   onToggleVisibility: (id: string) => void;
+  /** Whether the scroll pad is currently on screen. */
+  scrollPadOn: boolean;
+  onToggleScrollPad: () => void;
 }
 
 export function MontageKebabMenu({
   items,
   hiddenMonitorIds,
   onToggleVisibility,
+  scrollPadOn,
+  onToggleScrollPad,
 }: MontageKebabMenuProps) {
   const { t } = useTranslation();
 
@@ -55,6 +60,19 @@ export function MontageKebabMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {/* Edit mode turns the pad on by itself, since a drag there reorders
+            tiles rather than scrolling. This entry covers the rest: a grid
+            taller than the screen on a touch device, where the tiles are the
+            only surface a finger can land on (refs #365). */}
+        {/* Closes on select, unlike the visibility entries below: this is one
+            switch, not a list you tick through. */}
+        <DropdownMenuCheckboxItem
+          checked={scrollPadOn}
+          onSelect={onToggleScrollPad}
+          data-testid="montage-kebab-scroll-pad"
+        >
+          {t('common.scroll_buttons')}
+        </DropdownMenuCheckboxItem>
         {items.length > 0 && (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger data-testid="montage-kebab-visibility">

--- a/app/src/components/montage/__tests__/MontageKebabMenu.test.tsx
+++ b/app/src/components/montage/__tests__/MontageKebabMenu.test.tsx
@@ -35,6 +35,8 @@ describe('MontageKebabMenu', () => {
         items={items}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     expect(screen.getByTestId('montage-kebab-menu')).toBeInTheDocument();
@@ -47,6 +49,8 @@ describe('MontageKebabMenu', () => {
         items={items}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -60,6 +64,8 @@ describe('MontageKebabMenu', () => {
         items={items}
         hiddenMonitorIds={['2']}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -81,6 +87,8 @@ describe('MontageKebabMenu', () => {
         items={items}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -99,6 +107,8 @@ describe('MontageKebabMenu', () => {
         items={[]}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -116,6 +126,8 @@ describe('MontageKebabMenu', () => {
         ]}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -135,6 +147,8 @@ describe('MontageKebabMenu', () => {
         items={allModeItems}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -151,6 +165,8 @@ describe('MontageKebabMenu', () => {
         items={allModeItems}
         hiddenMonitorIds={['profile-1:1']}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -173,6 +189,8 @@ describe('MontageKebabMenu', () => {
         items={allModeItems}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -189,11 +207,51 @@ describe('MontageKebabMenu', () => {
         items={items}
         hiddenMonitorIds={[]}
         onToggleVisibility={onToggleVisibility}
+      scrollPadOn={false}
+      onToggleScrollPad={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
     await user.hover(screen.getByTestId('montage-kebab-visibility'));
     await screen.findByTestId('montage-visibility-1');
     expect(screen.queryAllByTestId(/^montage-visibility-chip-/)).toHaveLength(0);
+  });
+
+  it('shows the scroll pad state and toggles it', async () => {
+    const onToggleScrollPad = vi.fn();
+    render(
+      <MontageKebabMenu
+        items={items}
+        hiddenMonitorIds={[]}
+        onToggleVisibility={onToggleVisibility}
+        scrollPadOn={false}
+        onToggleScrollPad={onToggleScrollPad}
+      />
+    );
+
+    await userEvent.click(screen.getByTestId('montage-kebab-menu'));
+    const item = await screen.findByTestId('montage-kebab-scroll-pad');
+    expect(item).toHaveAttribute('aria-checked', 'false');
+
+    await userEvent.click(item);
+    expect(onToggleScrollPad).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the scroll pad being on', async () => {
+    render(
+      <MontageKebabMenu
+        items={items}
+        hiddenMonitorIds={[]}
+        onToggleVisibility={onToggleVisibility}
+        scrollPadOn
+        onToggleScrollPad={vi.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByTestId('montage-kebab-menu'));
+    expect(await screen.findByTestId('montage-kebab-scroll-pad')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
   });
 });

--- a/app/src/components/montage/hooks/__tests__/useMontageGrid.test.ts
+++ b/app/src/components/montage/hooks/__tests__/useMontageGrid.test.ts
@@ -293,6 +293,49 @@ describe('tile heights for rotated monitors', () => {
   });
 });
 
+describe('tile header allowance (#359)', () => {
+  const profileId = 'header-profile';
+
+  const setup = (tileHeaderPx: number) => {
+    useSettingsStore.setState({ profileSettings: {} });
+    useSettingsStore.getState().updateMontageGroupLayout(profileId, 'A', {
+      gridCols: 2,
+      workingLayout: [],
+    });
+    const settings = useSettingsStore.getState().getProfileSettings(profileId);
+    const monitors = [makeMonitor('1', 'ROTATE_0')];
+
+    type HookProps = Parameters<typeof useMontageGrid>[0];
+    return renderHook(
+      (props: HookProps) => useMontageGrid(props),
+      { initialProps: { monitors, profileId: asProfileId(profileId), settings, isEditMode: false, groupKey: 'A', tileHeaderPx } }
+    );
+  };
+
+  // gridWidth 1200 over 2 display columns: 600px of video width.
+  // ROTATE_0: 600 * (1080/1920) = 337.5; +32 header -> ceil 370, no header -> 338.
+
+  it('excludes the header from tile height when tileHeaderPx is 0 (fullscreen overlay header)', () => {
+    const { result } = setup(0);
+    act(() => { result.current.handleWidthChange(1200); });
+    expect(result.current.layout[0].h).toBe(338);
+  });
+
+  it('recalculates heights when tileHeaderPx changes (fullscreen toggle)', () => {
+    const { result, rerender } = setup(32);
+    act(() => { result.current.handleWidthChange(1200); });
+    expect(result.current.layout[0].h).toBe(370);
+
+    const settings = useSettingsStore.getState().getProfileSettings(profileId);
+    const monitors = [makeMonitor('1', 'ROTATE_0')];
+    rerender({ monitors, profileId: asProfileId(profileId), settings, isEditMode: false, groupKey: 'A', tileHeaderPx: 0 });
+    expect(result.current.layout[0].h).toBe(338);
+
+    rerender({ monitors, profileId: asProfileId(profileId), settings, isEditMode: false, groupKey: 'A', tileHeaderPx: 28 });
+    expect(result.current.layout[0].h).toBe(366);
+  });
+});
+
 describe('group-switch re-init', () => {
   const profileId = 'test-profile';
   const monitors = [makeMonitor('10'), makeMonitor('20')];

--- a/app/src/components/montage/hooks/useMontageGrid.ts
+++ b/app/src/components/montage/hooks/useMontageGrid.ts
@@ -67,7 +67,8 @@ const calculateHeightUnits = (
   widthUnits: number,
   gridWidth: number,
   margin: number,
-  internalCols: number
+  internalCols: number,
+  headerPx: number
 ): number => {
   const monitor = monitorMap.get(monitorId);
   if (!monitor) return 200;
@@ -76,7 +77,7 @@ const calculateHeightUnits = (
   const columnWidth = (gridWidth - margin * (internalCols - 1)) / internalCols;
   const itemWidth = columnWidth * widthUnits + margin * (widthUnits - 1);
   const videoPx = itemWidth * aspectRatio;
-  const heightPx = videoPx + MONTAGE_GRID.cardHeaderHeightPx;
+  const heightPx = videoPx + headerPx;
   const unit = (heightPx + margin) / (GRID_LAYOUT.montageRowHeight + margin);
 
   return Math.max(2, Math.ceil(unit));
@@ -124,6 +125,12 @@ interface UseMontageGridOptions {
   settings: ProfileSettings;
   isEditMode: boolean;
   groupKey: string;
+  /** In-flow height of the tile header the layout must allow for. 0 in
+   *  fullscreen, where the header is an absolute overlay over the video;
+   *  the compact-mode value when compact rendering shrinks h-8 rows. A
+   *  mismatch letterboxes every video vertically inside its tile because
+   *  object-fit: contain centers the difference (refs #359). */
+  tileHeaderPx?: number;
 }
 
 interface UseMontageGridReturn {
@@ -147,6 +154,7 @@ export function useMontageGrid({
   settings,
   isEditMode,
   groupKey,
+  tileHeaderPx = MONTAGE_GRID.cardHeaderHeightPx,
 }: UseMontageGridOptions): UseMontageGridReturn {
   const { t } = useTranslation();
   const updateMontageGroupLayout = useSettingsStore(
@@ -184,6 +192,8 @@ export function useMontageGrid({
   const groupKeyRef = useRef(groupKey);
   useEffect(() => { groupKeyRef.current = groupKey; }, [groupKey]);
 
+  const tileHeaderPxRef = useRef(tileHeaderPx);
+
   const monitorMap = useMemo(() => {
     return new Map(monitors.map((item) => [tileIdFor(item), item.Monitor]));
   }, [monitors]);
@@ -200,7 +210,7 @@ export function useMontageGrid({
       const map = monitorMapRef.current;
       return monitorList.map((item, index) => {
         const id = tileIdFor(item);
-        const h = calculateHeightUnits(map, id, w, gridWidth, 0, internalCols);
+        const h = calculateHeightUnits(map, id, w, gridWidth, 0, internalCols, tileHeaderPxRef.current);
         return {
           i: id,
           x: (index % perRow) * w,
@@ -223,11 +233,21 @@ export function useMontageGrid({
         ...item,
         w: Math.min(item.w, internalCols),
         x: Math.min(item.x, internalCols - item.w),
-        h: calculateHeightUnits(map, item.i, item.w, gridWidth, 0, internalCols),
+        h: calculateHeightUnits(map, item.i, item.w, gridWidth, 0, internalCols, tileHeaderPxRef.current),
       }));
     },
     [] // Uses ref, stable identity
   );
+
+  // Recalculate heights when the in-flow header allowance changes (fullscreen
+  // toggle), same as a width change: the ref updates first so every later
+  // recalc path uses the new value.
+  useEffect(() => {
+    if (tileHeaderPxRef.current === tileHeaderPx) return;
+    tileHeaderPxRef.current = tileHeaderPx;
+    if (currentWidthRef.current === 0) return;
+    setLayout((prev) => recalcHeights(prev, currentWidthRef.current, displayColsRef.current));
+  }, [tileHeaderPx, recalcHeights]);
 
   // Update displayCols when profile changes (external change only)
   useEffect(() => {
@@ -389,7 +409,8 @@ export function useMontageGrid({
         newItem.w,
         currentWidthRef.current,
         0,
-        internalColsForCols(displayColsRef.current)
+        internalColsForCols(displayColsRef.current),
+        tileHeaderPxRef.current
       );
 
       setLayout((prev) => {

--- a/app/src/components/montage/index.ts
+++ b/app/src/components/montage/index.ts
@@ -9,7 +9,6 @@ export { FullscreenControls } from './FullscreenControls';
 export { useMontageGrid, useContainerResize, useMontageVisibilityItems } from './hooks';
 export { MontageKebabMenu } from './MontageKebabMenu';
 export type { MontageVisibilityItem } from './MontageKebabMenu';
-export { MontageScrollPad } from './MontageScrollPad';
 export { MontageTileErrorBoundary } from './MontageTileErrorBoundary';
 export { MontageErrorStrips, MontageGridSections } from './MontageGridSections';
 export type { MontageTileItem, MontageGroupedSections } from './MontageGridSections';

--- a/app/src/components/theme-provider.tsx
+++ b/app/src/components/theme-provider.tsx
@@ -79,8 +79,14 @@ export function ThemeProvider({
         // Both syncs must also run for the "system" branch: a previously set
         // explicit bar style or window background does not revert when the
         // user switches back to "system" (refs #356).
-        syncNativeWindowBackground()
+        //
+        // Order matters. SystemBars.setStyle ends by repainting the decor view
+        // with the Android theme's windowBackground, which follows the OS night
+        // mode, not the app theme. Running it after the background sync would
+        // discard the colour WindowTheme just applied and show, for example, a
+        // white decor behind a dark app during rotation or overscroll.
         syncNativeSystemBarsStyle()
+        syncNativeWindowBackground()
     }, [theme])
 
     const handleSetTheme = useCallback((newTheme: Theme) => {

--- a/app/src/components/theme-provider.tsx
+++ b/app/src/components/theme-provider.tsx
@@ -9,7 +9,7 @@
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from "react"
 import { useProfileStore } from '../stores/profile';
 import { useSettingsStore, type ThemePreference } from '../stores/settings';
-import { syncNativeWindowBackground } from '../lib/native-window-theme';
+import { syncNativeWindowBackground, syncNativeSystemBarsStyle } from '../lib/native-window-theme';
 
 type Theme = ThemePreference
 
@@ -70,16 +70,17 @@ export function ThemeProvider({
                 : "light"
 
             root.classList.add(systemTheme)
-            return
-        }
-
-        if (theme === "slate" || theme === "amber") {
+        } else if (theme === "slate" || theme === "amber") {
             root.classList.add("dark", theme)
         } else {
             root.classList.add(theme)
         }
 
+        // Both syncs must also run for the "system" branch: a previously set
+        // explicit bar style or window background does not revert when the
+        // user switches back to "system" (refs #356).
         syncNativeWindowBackground()
+        syncNativeSystemBarsStyle()
     }, [theme])
 
     const handleSetTheme = useCallback((newTheme: Theme) => {

--- a/app/src/components/timeline/TimelineToolbar.tsx
+++ b/app/src/components/timeline/TimelineToolbar.tsx
@@ -8,7 +8,7 @@
 import { useTranslation } from 'react-i18next';
 import { Button } from '../ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
-import { Crosshair, ZoomIn, ZoomOut, SkipForward, RectangleHorizontal, Info, Move, HandMetal, Radio } from 'lucide-react';
+import { Crosshair, ZoomIn, ZoomOut, SkipForward, RectangleHorizontal, Info, Move, HandMetal, Radio, ChevronsUpDown } from 'lucide-react';
 
 interface TimelineToolbarProps {
   brushMode: boolean;
@@ -19,6 +19,10 @@ interface TimelineToolbarProps {
   onZoomOut: () => void;
   onCenter: () => void;
   onGoToNow: () => void;
+  /** The canvas swallows touches, so the page may need buttons to scroll it. */
+  offerScrollPad: boolean;
+  scrollPadOn: boolean;
+  onToggleScrollPad: () => void;
 }
 
 export function TimelineToolbar({
@@ -30,12 +34,29 @@ export function TimelineToolbar({
   onZoomOut,
   onCenter,
   onGoToNow,
+  offerScrollPad,
+  scrollPadOn,
+  onToggleScrollPad,
 }: TimelineToolbarProps) {
   const { t } = useTranslation();
 
   return (
     <div className="mb-2 flex items-center justify-between">
       <div className="flex items-center gap-1">
+        {offerScrollPad && (
+          <Button
+            variant={scrollPadOn ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-6 w-6 text-muted-foreground"
+            onClick={onToggleScrollPad}
+            title={t('common.scroll_buttons')}
+            aria-label={t('common.scroll_buttons')}
+            aria-pressed={scrollPadOn}
+            data-testid="timeline-scroll-pad-toggle"
+          >
+            <ChevronsUpDown className="h-3.5 w-3.5" />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"

--- a/app/src/components/timeline/__tests__/TimelineToolbar.test.tsx
+++ b/app/src/components/timeline/__tests__/TimelineToolbar.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TimelineToolbar } from '../TimelineToolbar';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const base = {
+  brushMode: false,
+  liveMode: false,
+  onToggleBrush: vi.fn(),
+  onToggleLive: vi.fn(),
+  onZoomIn: vi.fn(),
+  onZoomOut: vi.fn(),
+  onCenter: vi.fn(),
+  onGoToNow: vi.fn(),
+  scrollPadOn: false,
+  onToggleScrollPad: vi.fn(),
+};
+
+describe('TimelineToolbar scroll pad control', () => {
+  beforeEach(() => {
+    // The help popover reads (pointer: fine); jsdom has no matchMedia.
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  it('stays hidden where the pad is not on offer', () => {
+    render(<TimelineToolbar {...base} offerScrollPad={false} />);
+    expect(screen.queryByTestId('timeline-scroll-pad-toggle')).not.toBeInTheDocument();
+  });
+
+  it('toggles the pad when offered', async () => {
+    const onToggleScrollPad = vi.fn();
+    render(
+      <TimelineToolbar {...base} offerScrollPad onToggleScrollPad={onToggleScrollPad} />
+    );
+
+    const button = screen.getByTestId('timeline-scroll-pad-toggle');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(button);
+    expect(onToggleScrollPad).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the pad being on', () => {
+    render(<TimelineToolbar {...base} offerScrollPad scrollPadOn />);
+    expect(screen.getByTestId('timeline-scroll-pad-toggle')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+});

--- a/app/src/components/ui/__tests__/scroll-pad.test.tsx
+++ b/app/src/components/ui/__tests__/scroll-pad.test.tsx
@@ -1,13 +1,13 @@
 /**
- * Tests for MontageScrollPad (edit-mode grid scrolling, refs #321).
+ * Tests for ScrollPad (edit-mode grid scrolling, refs #321).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
-import { MontageScrollPad } from '../MontageScrollPad';
-import { MONTAGE_SCROLL_PAD } from '../../../lib/zmninja-ng-constants';
+import { ScrollPad } from '../scroll-pad';
+import { SCROLL_PAD } from '../../../lib/zmninja-ng-constants';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -43,43 +43,43 @@ beforeEach(() => {
 function renderPad(element: HTMLElement | null = grid) {
   const ref = createRef<HTMLElement | null>() as React.RefObject<HTMLElement | null>;
   ref.current = element;
-  render(<MontageScrollPad targetRef={ref} />);
+  render(<ScrollPad targetRef={ref} />);
 }
 
-describe('MontageScrollPad', () => {
+describe('ScrollPad', () => {
   it('scrolls the scrolling ancestor, not the content-sized grid it is given', async () => {
     renderPad();
-    await userEvent.click(screen.getByTestId('montage-scroll-down'));
+    await userEvent.click(screen.getByTestId('scroll-down'));
 
     expect(grid.scrollBy).not.toHaveBeenCalled();
     expect(scroller.scrollBy).toHaveBeenCalledWith({
-      top: CLIENT_HEIGHT * MONTAGE_SCROLL_PAD.stepFraction,
+      top: CLIENT_HEIGHT * SCROLL_PAD.stepFraction,
       behavior: 'smooth',
     });
   });
 
   it('scrolls up by the same fraction in the other direction', async () => {
     renderPad();
-    await userEvent.click(screen.getByTestId('montage-scroll-up'));
+    await userEvent.click(screen.getByTestId('scroll-up'));
 
     expect(scroller.scrollBy).toHaveBeenCalledWith({
-      top: -CLIENT_HEIGHT * MONTAGE_SCROLL_PAD.stepFraction,
+      top: -CLIENT_HEIGHT * SCROLL_PAD.stepFraction,
       behavior: 'smooth',
     });
   });
 
   it('jumps to the ends of the grid', async () => {
     renderPad();
-    await userEvent.click(screen.getByTestId('montage-scroll-bottom'));
+    await userEvent.click(screen.getByTestId('scroll-bottom'));
     expect(scroller.scrollTo).toHaveBeenCalledWith({ top: SCROLL_HEIGHT, behavior: 'smooth' });
 
-    await userEvent.click(screen.getByTestId('montage-scroll-top'));
+    await userEvent.click(screen.getByTestId('scroll-top'));
     expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
   });
 
   it('does nothing when the grid container is not mounted', async () => {
     renderPad(null);
-    await userEvent.click(screen.getByTestId('montage-scroll-down'));
+    await userEvent.click(screen.getByTestId('scroll-down'));
 
     expect(scroller.scrollBy).not.toHaveBeenCalled();
   });

--- a/app/src/components/ui/scroll-pad.tsx
+++ b/app/src/components/ui/scroll-pad.tsx
@@ -1,26 +1,28 @@
 /**
- * Montage Scroll Pad
+ * Scroll Pad
  *
- * In edit mode every tile is a drag surface, so on a touch screen there is
- * nothing left to swipe: a drag anywhere on the grid reorders monitors instead
- * of scrolling it. With enough tiles to fill the viewport the rest of the grid
- * becomes unreachable. This pad moves the viewport without touching the
- * layout. Shown only while editing, and only when the user turns it on from
- * the toolbar (refs #321).
+ * Moves a scroll container by tapping instead of swiping, for the screens
+ * where every surface is already a gesture target and no swipe is left over:
+ * montage edit mode, where a drag reorders monitors rather than scrolling
+ * (refs #321), and monitor/event detail on a tablet, where video and controls
+ * fill the viewport and the rest of the page is unreachable (refs #365).
+ *
+ * Montage shows it on request from the toolbar; the detail pages show it when
+ * useScrollAffordance says the page needs it.
  */
 
 import type { RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, ChevronsDown, ChevronsUp } from 'lucide-react';
-import { Button } from '../ui/button';
-import { MONTAGE_SCROLL_PAD } from '../../lib/zmninja-ng-constants';
+import { Button } from './button';
+import { SCROLL_PAD } from '../../lib/zmninja-ng-constants';
 
 /** Top to bottom, as they sit in the pad. `jump` goes to the end, not a step. */
 const BUTTONS = [
-  { icon: ChevronsUp, labelKey: 'montage.scroll_top', testId: 'montage-scroll-top', jump: true, direction: -1 },
-  { icon: ChevronUp, labelKey: 'montage.scroll_up', testId: 'montage-scroll-up', jump: false, direction: -1 },
-  { icon: ChevronDown, labelKey: 'montage.scroll_down', testId: 'montage-scroll-down', jump: false, direction: 1 },
-  { icon: ChevronsDown, labelKey: 'montage.scroll_bottom', testId: 'montage-scroll-bottom', jump: true, direction: 1 },
+  { icon: ChevronsUp, labelKey: 'common.scroll_top', testId: 'scroll-top', jump: true, direction: -1 },
+  { icon: ChevronUp, labelKey: 'common.scroll_up', testId: 'scroll-up', jump: false, direction: -1 },
+  { icon: ChevronDown, labelKey: 'common.scroll_down', testId: 'scroll-down', jump: false, direction: 1 },
+  { icon: ChevronsDown, labelKey: 'common.scroll_bottom', testId: 'scroll-bottom', jump: true, direction: 1 },
 ] as const;
 
 /**
@@ -39,7 +41,7 @@ function findScrollParent(from: HTMLElement | null): HTMLElement | null {
   return null;
 }
 
-interface MontageScrollPadProps {
+interface ScrollPadProps {
   /**
    * The grid container. The pad scrolls it or the nearest scrolling ancestor.
    * A ref rather than the element itself: the element is only read on a tap, so
@@ -48,14 +50,14 @@ interface MontageScrollPadProps {
   targetRef: RefObject<HTMLElement | null>;
 }
 
-export function MontageScrollPad({ targetRef }: MontageScrollPadProps) {
+export function ScrollPad({ targetRef }: ScrollPadProps) {
   const { t } = useTranslation();
 
   const scrollBy = (direction: 1 | -1) => {
     const target = findScrollParent(targetRef.current);
     if (!target) return;
     target.scrollBy({
-      top: direction * target.clientHeight * MONTAGE_SCROLL_PAD.stepFraction,
+      top: direction * target.clientHeight * SCROLL_PAD.stepFraction,
       behavior: 'smooth',
     });
   };
@@ -72,7 +74,7 @@ export function MontageScrollPad({ targetRef }: MontageScrollPadProps) {
   return (
     <div
       className="fixed right-3 top-1/2 -translate-y-1/2 z-30 flex flex-col gap-1 rounded-full bg-background/85 p-1 shadow-lg backdrop-blur-sm border"
-      data-testid="montage-scroll-pad"
+      data-testid="scroll-pad"
     >
       {BUTTONS.map(({ icon: Icon, labelKey, testId, jump, direction }) => {
         const label = t(labelKey);

--- a/app/src/hooks/__tests__/useScrollAffordance.test.ts
+++ b/app/src/hooks/__tests__/useScrollAffordance.test.ts
@@ -75,53 +75,75 @@ describe('useScrollAffordance', () => {
     setPointer(true);
     const { content, video } = mountPage(noRoomToSwipe);
     const { result } = renderHook(() => useScrollAffordance(content, video));
-    expect(result.current).toBe(true);
+    expect(result.current.needsPad).toBe(true);
   });
 
   it('is true when the capped player still dominates the screen', () => {
     setPointer(true);
     const { content, video } = mountPage(cappedPlayer);
     const { result } = renderHook(() => useScrollAffordance(content, video));
-    expect(result.current).toBe(true);
+    expect(result.current.needsPad).toBe(true);
   });
 
   it('is false when the page has free surface to drag, even though it scrolls', () => {
     setPointer(true);
     const { content, video } = mountPage(roomToSwipe);
     const { result } = renderHook(() => useScrollAffordance(content, video));
-    expect(result.current).toBe(false);
+    expect(result.current.needsPad).toBe(false);
   });
 
   it('is false on a fine pointer, where the wheel and scrollbar already work', () => {
     setPointer(false);
     const { content, video } = mountPage(noRoomToSwipe);
     const { result } = renderHook(() => useScrollAffordance(content, video));
-    expect(result.current).toBe(false);
+    expect(result.current.needsPad).toBe(false);
   });
 
   it('is false when the page does not overflow at all', () => {
     setPointer(true);
     const { content, video } = mountPage({ ...noRoomToSwipe, scrollHeight: 800 });
     const { result } = renderHook(() => useScrollAffordance(content, video));
-    expect(result.current).toBe(false);
+    expect(result.current.needsPad).toBe(false);
   });
 
   it('is false before the gesture surface has mounted', () => {
     setPointer(true);
     const { content } = mountPage(noRoomToSwipe);
     const { result } = renderHook(() => useScrollAffordance(content, null));
-    expect(result.current).toBe(false);
+    expect(result.current.needsPad).toBe(false);
+  });
+
+  it('offers the pad by hand whenever a touch page scrolls, even with room to swipe', () => {
+    setPointer(true);
+    const { content, video } = mountPage(roomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
+    expect(result.current.needsPad).toBe(false);
+    expect(result.current.offerPad).toBe(true);
+  });
+
+  it('does not offer the pad on a page that does not scroll', () => {
+    setPointer(true);
+    const { content, video } = mountPage({ ...roomToSwipe, scrollHeight: 1200 });
+    const { result } = renderHook(() => useScrollAffordance(content, video));
+    expect(result.current.offerPad).toBe(false);
+  });
+
+  it('does not offer the pad on a fine pointer', () => {
+    setPointer(false);
+    const { content, video } = mountPage(cappedPlayer);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
+    expect(result.current.offerPad).toBe(false);
   });
 
   it('re-measures when the layout changes, such as a rotation', () => {
     setPointer(true);
     const { content, video } = mountPage(roomToSwipe);
     const { result } = renderHook(() => useScrollAffordance(content, video));
-    expect(result.current).toBe(false);
+    expect(result.current.needsPad).toBe(false);
 
     // Rotate to landscape: the video now covers everything below the header.
     setRect(video, 56, 1200);
     act(() => observers.forEach((fire) => fire()));
-    expect(result.current).toBe(true);
+    expect(result.current.needsPad).toBe(true);
   });
 });

--- a/app/src/hooks/__tests__/useScrollAffordance.test.ts
+++ b/app/src/hooks/__tests__/useScrollAffordance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useScrollAffordance } from '../useScrollAffordance';
+import { useScrollAffordance, useScrollPadToggle } from '../useScrollAffordance';
 
 /** Captures the ResizeObserver callbacks so a test can fire them by hand. */
 const observers: Array<() => void> = [];
@@ -145,5 +145,44 @@ describe('useScrollAffordance', () => {
     setRect(video, 56, 1200);
     act(() => observers.forEach((fire) => fire()));
     expect(result.current.needsPad).toBe(true);
+  });
+});
+
+describe('useScrollPadToggle', () => {
+  it('follows the automatic decision until the user touches the toggle', () => {
+    const { result, rerender } = renderHook(({ needs }) => useScrollPadToggle(needs), {
+      initialProps: { needs: false },
+    });
+    expect(result.current[0]).toBe(false);
+
+    rerender({ needs: true });
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('hides the pad when switched off, even while the page still qualifies', () => {
+    const { result } = renderHook(() => useScrollPadToggle(true));
+    expect(result.current[0]).toBe(true);
+
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('shows the pad when switched on where it would not appear by itself', () => {
+    const { result } = renderHook(() => useScrollPadToggle(false));
+
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('keeps the user choice across a re-measure', () => {
+    const { result, rerender } = renderHook(({ needs }) => useScrollPadToggle(needs), {
+      initialProps: { needs: true },
+    });
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(false);
+
+    // A rotation re-runs the measurement; the explicit "off" still wins.
+    rerender({ needs: true });
+    expect(result.current[0]).toBe(false);
   });
 });

--- a/app/src/hooks/__tests__/useScrollAffordance.test.ts
+++ b/app/src/hooks/__tests__/useScrollAffordance.test.ts
@@ -47,6 +47,12 @@ function mountPage(opts: {
 const noRoomToSwipe = { scrollHeight: 2400, clientHeight: 800, videoTop: 56, videoBottom: 800 };
 /** Portrait: the video takes the top third, the rest is free to drag. */
 const roomToSwipe = { scrollHeight: 2400, clientHeight: 1200, videoTop: 56, videoBottom: 460 };
+/**
+ * Monitor detail in landscape, where the player is capped at 100svh-7rem: 112px
+ * of page always remains, which is a strip at the screen edges rather than
+ * somewhere to swipe. This is the layout #365 reported.
+ */
+const cappedPlayer = { scrollHeight: 2400, clientHeight: 800, videoTop: 56, videoBottom: 744 };
 
 describe('useScrollAffordance', () => {
   beforeEach(() => {
@@ -68,6 +74,13 @@ describe('useScrollAffordance', () => {
   it('is true when the gesture surface leaves nothing to swipe', () => {
     setPointer(true);
     const { content, video } = mountPage(noRoomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
+    expect(result.current).toBe(true);
+  });
+
+  it('is true when the capped player still dominates the screen', () => {
+    setPointer(true);
+    const { content, video } = mountPage(cappedPlayer);
     const { result } = renderHook(() => useScrollAffordance(content, video));
     expect(result.current).toBe(true);
   });

--- a/app/src/hooks/__tests__/useScrollAffordance.test.ts
+++ b/app/src/hooks/__tests__/useScrollAffordance.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useScrollAffordance } from '../useScrollAffordance';
+
+/** Captures the ResizeObserver callbacks so a test can fire them by hand. */
+const observers: Array<() => void> = [];
+
+function setPointer(coarse: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: coarse && query.includes('coarse'),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+/** A scrolling ancestor with `content` inside it, sized as asked. */
+function mountScroller(scrollHeight: number, clientHeight: number) {
+  const scroller = document.createElement('div');
+  scroller.style.overflowY = 'auto';
+  Object.defineProperty(scroller, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(scroller, 'clientHeight', { value: clientHeight, configurable: true });
+
+  const content = document.createElement('div');
+  scroller.appendChild(content);
+  document.body.appendChild(scroller);
+  return { scroller, content };
+}
+
+describe('useScrollAffordance', () => {
+  beforeEach(() => {
+    observers.length = 0;
+    global.ResizeObserver = class {
+      constructor(callback: () => void) {
+        observers.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('is false on a fine pointer, where the wheel and scrollbar already work', () => {
+    setPointer(false);
+    const { content } = mountScroller(2000, 800);
+    const { result } = renderHook(() => useScrollAffordance(content));
+    expect(result.current).toBe(false);
+  });
+
+  it('is true on a touch screen when the scrolling ancestor overflows', () => {
+    setPointer(true);
+    const { content } = mountScroller(2000, 800);
+    const { result } = renderHook(() => useScrollAffordance(content));
+    expect(result.current).toBe(true);
+  });
+
+  it('is false on a touch screen when everything fits', () => {
+    setPointer(true);
+    const { content } = mountScroller(800, 800);
+    const { result } = renderHook(() => useScrollAffordance(content));
+    expect(result.current).toBe(false);
+  });
+
+  it('re-measures when the content resizes', () => {
+    setPointer(true);
+    const { scroller, content } = mountScroller(800, 800);
+    const { result } = renderHook(() => useScrollAffordance(content));
+    expect(result.current).toBe(false);
+
+    Object.defineProperty(scroller, 'scrollHeight', { value: 2400, configurable: true });
+    act(() => observers.forEach((fire) => fire()));
+    expect(result.current).toBe(true);
+  });
+});

--- a/app/src/hooks/__tests__/useScrollAffordance.test.ts
+++ b/app/src/hooks/__tests__/useScrollAffordance.test.ts
@@ -13,18 +13,40 @@ function setPointer(coarse: boolean) {
   })) as unknown as typeof window.matchMedia;
 }
 
-/** A scrolling ancestor with `content` inside it, sized as asked. */
-function mountScroller(scrollHeight: number, clientHeight: number) {
+function setRect(el: HTMLElement, top: number, bottom: number) {
+  el.getBoundingClientRect = () => ({ top, bottom, height: bottom - top }) as DOMRect;
+}
+
+/**
+ * A scrolling ancestor holding a page, with the video (the gesture surface)
+ * inside it. `videoTop`/`videoBottom` are viewport coordinates, the same frame
+ * getBoundingClientRect reports in.
+ */
+function mountPage(opts: {
+  scrollHeight: number;
+  clientHeight: number;
+  videoTop: number;
+  videoBottom: number;
+}) {
   const scroller = document.createElement('div');
   scroller.style.overflowY = 'auto';
-  Object.defineProperty(scroller, 'scrollHeight', { value: scrollHeight, configurable: true });
-  Object.defineProperty(scroller, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(scroller, 'scrollHeight', { value: opts.scrollHeight, configurable: true });
+  Object.defineProperty(scroller, 'clientHeight', { value: opts.clientHeight, configurable: true });
+  setRect(scroller, 0, opts.clientHeight);
 
   const content = document.createElement('div');
+  const video = document.createElement('div');
+  setRect(video, opts.videoTop, opts.videoBottom);
+  content.appendChild(video);
   scroller.appendChild(content);
   document.body.appendChild(scroller);
-  return { scroller, content };
+  return { scroller, content, video };
 }
+
+/** Landscape tablet: the video fills everything under a 56px header. */
+const noRoomToSwipe = { scrollHeight: 2400, clientHeight: 800, videoTop: 56, videoBottom: 800 };
+/** Portrait: the video takes the top third, the rest is free to drag. */
+const roomToSwipe = { scrollHeight: 2400, clientHeight: 1200, videoTop: 56, videoBottom: 460 };
 
 describe('useScrollAffordance', () => {
   beforeEach(() => {
@@ -43,34 +65,49 @@ describe('useScrollAffordance', () => {
     document.body.innerHTML = '';
   });
 
-  it('is false on a fine pointer, where the wheel and scrollbar already work', () => {
-    setPointer(false);
-    const { content } = mountScroller(2000, 800);
-    const { result } = renderHook(() => useScrollAffordance(content));
-    expect(result.current).toBe(false);
-  });
-
-  it('is true on a touch screen when the scrolling ancestor overflows', () => {
+  it('is true when the gesture surface leaves nothing to swipe', () => {
     setPointer(true);
-    const { content } = mountScroller(2000, 800);
-    const { result } = renderHook(() => useScrollAffordance(content));
+    const { content, video } = mountPage(noRoomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
     expect(result.current).toBe(true);
   });
 
-  it('is false on a touch screen when everything fits', () => {
+  it('is false when the page has free surface to drag, even though it scrolls', () => {
     setPointer(true);
-    const { content } = mountScroller(800, 800);
-    const { result } = renderHook(() => useScrollAffordance(content));
+    const { content, video } = mountPage(roomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
     expect(result.current).toBe(false);
   });
 
-  it('re-measures when the content resizes', () => {
+  it('is false on a fine pointer, where the wheel and scrollbar already work', () => {
+    setPointer(false);
+    const { content, video } = mountPage(noRoomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
+    expect(result.current).toBe(false);
+  });
+
+  it('is false when the page does not overflow at all', () => {
     setPointer(true);
-    const { scroller, content } = mountScroller(800, 800);
-    const { result } = renderHook(() => useScrollAffordance(content));
+    const { content, video } = mountPage({ ...noRoomToSwipe, scrollHeight: 800 });
+    const { result } = renderHook(() => useScrollAffordance(content, video));
+    expect(result.current).toBe(false);
+  });
+
+  it('is false before the gesture surface has mounted', () => {
+    setPointer(true);
+    const { content } = mountPage(noRoomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, null));
+    expect(result.current).toBe(false);
+  });
+
+  it('re-measures when the layout changes, such as a rotation', () => {
+    setPointer(true);
+    const { content, video } = mountPage(roomToSwipe);
+    const { result } = renderHook(() => useScrollAffordance(content, video));
     expect(result.current).toBe(false);
 
-    Object.defineProperty(scroller, 'scrollHeight', { value: 2400, configurable: true });
+    // Rotate to landscape: the video now covers everything below the header.
+    setRect(video, 56, 1200);
     act(() => observers.forEach((fire) => fire()));
     expect(result.current).toBe(true);
   });

--- a/app/src/hooks/useScrollAffordance.ts
+++ b/app/src/hooks/useScrollAffordance.ts
@@ -9,7 +9,7 @@
  * has that problem, since the wheel and the scrollbar scroll from anywhere.
  */
 
-import { useCallback, useSyncExternalStore } from 'react';
+import { useCallback, useState, useSyncExternalStore } from 'react';
 import { SCROLL_PAD } from '../lib/zmninja-ng-constants';
 
 /**
@@ -103,4 +103,20 @@ export function useScrollAffordance(
   const needsPad = useSyncExternalStore(subscribe, getNeedsPad, () => false);
 
   return { offerPad, needsPad };
+}
+
+/**
+ * Visibility of the pad, combining the automatic decision with the header
+ * toggle. The user's choice overrides the measurement rather than adding to
+ * it: OR-ing the two meant switching the toggle off did nothing wherever the
+ * page qualified on its own, which is most of the time it is visible.
+ *
+ * The choice lasts for the page visit. Leaving and coming back starts from the
+ * automatic decision again, which is the one that suits most pages.
+ */
+export function useScrollPadToggle(needsPad: boolean): [boolean, () => void] {
+  const [choice, setChoice] = useState<boolean | null>(null);
+  const visible = choice ?? needsPad;
+  const toggle = useCallback(() => setChoice(!visible), [visible]);
+  return [visible, toggle];
 }

--- a/app/src/hooks/useScrollAffordance.ts
+++ b/app/src/hooks/useScrollAffordance.ts
@@ -28,11 +28,31 @@ function findScrollParent(from: HTMLElement | null): HTMLElement | null {
 }
 
 /**
- * Takes the page element itself rather than a ref, so that a page swapping its
- * skeleton for real content - a new element, same component - re-measures. A
- * ref object would keep the stale first measurement.
+ * Height of visible page that is not the gesture surface, which is what a
+ * finger has to land on to scroll by swiping.
  */
-export function useScrollAffordance(content: HTMLElement | null): boolean {
+function freeSurfaceHeight(scroller: HTMLElement, gestureSurface: HTMLElement): number {
+  const view = scroller.getBoundingClientRect();
+  const surface = gestureSurface.getBoundingClientRect();
+  const covered = Math.max(0, Math.min(view.bottom, surface.bottom) - Math.max(view.top, surface.top));
+  return scroller.clientHeight - covered;
+}
+
+/**
+ * Takes elements rather than refs, so that a page swapping its skeleton for
+ * real content - new elements, same component - re-measures. A ref object
+ * would keep the stale first measurement.
+ *
+ * `gestureSurface` is the part of the page that consumes touches instead of
+ * scrolling: the zoom and pan container around the video. How much of the
+ * viewport it covers is what separates a tablet in landscape, where it leaves
+ * only a header strip and the page below the fold is stranded, from the same
+ * page in portrait, where there is plenty of room to swipe.
+ */
+export function useScrollAffordance(
+  content: HTMLElement | null,
+  gestureSurface: HTMLElement | null,
+): boolean {
   // Read through useSyncExternalStore rather than measuring into state from an
   // effect: the snapshot is a plain boolean, so React re-reads it whenever the
   // observer fires and there is no render-then-correct pass. Same shape as
@@ -42,22 +62,24 @@ export function useScrollAffordance(content: HTMLElement | null): boolean {
       if (!content) return () => {};
       const observer = new ResizeObserver(onChange);
       observer.observe(content);
+      if (gestureSurface) observer.observe(gestureSurface);
       const parent = findScrollParent(content);
       if (parent) observer.observe(parent);
       return () => observer.disconnect();
     },
-    [content],
+    [content, gestureSurface],
   );
 
   // Resolves the scroll parent on every read: entering or leaving fullscreen
   // swaps which ancestor scrolls without remounting the page.
   const getSnapshot = useCallback(() => {
-    if (!content) return false;
+    if (!content || !gestureSurface) return false;
     if (!(window.matchMedia?.('(pointer: coarse)').matches ?? false)) return false;
     const parent = findScrollParent(content);
     if (!parent) return false;
-    return parent.scrollHeight - parent.clientHeight > SCROLL_PAD.minOverflowPx;
-  }, [content]);
+    if (parent.scrollHeight - parent.clientHeight <= SCROLL_PAD.minOverflowPx) return false;
+    return freeSurfaceHeight(parent, gestureSurface) < SCROLL_PAD.minGrabPx;
+  }, [content, gestureSurface]);
 
   return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }

--- a/app/src/hooks/useScrollAffordance.ts
+++ b/app/src/hooks/useScrollAffordance.ts
@@ -1,0 +1,63 @@
+/**
+ * useScrollAffordance (refs #365)
+ *
+ * Answers one question for a page: does the user need a button to scroll this?
+ * They do when the pointer is coarse and the page's scrolling ancestor
+ * overflows. On a tablet a monitor or event fills the viewport with video and
+ * controls, and every remaining surface is a gesture target, so there is
+ * nowhere left to swipe: the page below the fold is unreachable. A mouse never
+ * has that problem, since the wheel and the scrollbar scroll from anywhere.
+ */
+
+import { useCallback, useSyncExternalStore } from 'react';
+import { SCROLL_PAD } from '../lib/zmninja-ng-constants';
+
+/**
+ * The nearest ancestor that scrolls. Which element that is depends on the
+ * layout a page renders in - the app's `<main>` in the normal shell, a nested
+ * container in fullscreen - so find it rather than assume it. Matches on the
+ * overflow style alone, not on current overflow, so an element that only
+ * starts overflowing later is still found.
+ */
+function findScrollParent(from: HTMLElement | null): HTMLElement | null {
+  for (let node = from; node; node = node.parentElement) {
+    const overflowY = getComputedStyle(node).overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll') return node;
+  }
+  return null;
+}
+
+/**
+ * Takes the page element itself rather than a ref, so that a page swapping its
+ * skeleton for real content - a new element, same component - re-measures. A
+ * ref object would keep the stale first measurement.
+ */
+export function useScrollAffordance(content: HTMLElement | null): boolean {
+  // Read through useSyncExternalStore rather than measuring into state from an
+  // effect: the snapshot is a plain boolean, so React re-reads it whenever the
+  // observer fires and there is no render-then-correct pass. Same shape as
+  // useIsMobile.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (!content) return () => {};
+      const observer = new ResizeObserver(onChange);
+      observer.observe(content);
+      const parent = findScrollParent(content);
+      if (parent) observer.observe(parent);
+      return () => observer.disconnect();
+    },
+    [content],
+  );
+
+  // Resolves the scroll parent on every read: entering or leaving fullscreen
+  // swaps which ancestor scrolls without remounting the page.
+  const getSnapshot = useCallback(() => {
+    if (!content) return false;
+    if (!(window.matchMedia?.('(pointer: coarse)').matches ?? false)) return false;
+    const parent = findScrollParent(content);
+    if (!parent) return false;
+    return parent.scrollHeight - parent.clientHeight > SCROLL_PAD.minOverflowPx;
+  }, [content]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/app/src/hooks/useScrollAffordance.ts
+++ b/app/src/hooks/useScrollAffordance.ts
@@ -49,14 +49,25 @@ function surfaceCoverage(scroller: HTMLElement, gestureSurface: HTMLElement): nu
  * only strips at the screen edges and the page below the fold is stranded,
  * from the same page in portrait, where there is plenty of room to swipe.
  */
+export interface ScrollAffordance {
+  /**
+   * The page scrolls and the pointer is coarse, so the pad would do something
+   * if it were shown. Gates the toggle that offers it by hand.
+   */
+  offerPad: boolean;
+  /** The video covers enough that the pad should appear without being asked. */
+  needsPad: boolean;
+}
+
 export function useScrollAffordance(
   content: HTMLElement | null,
   gestureSurface: HTMLElement | null,
-): boolean {
+): ScrollAffordance {
   // Read through useSyncExternalStore rather than measuring into state from an
-  // effect: the snapshot is a plain boolean, so React re-reads it whenever the
-  // observer fires and there is no render-then-correct pass. Same shape as
-  // useIsMobile.
+  // effect: each snapshot is a plain boolean, so React re-reads them whenever
+  // the observer fires and there is no render-then-correct pass. Same shape as
+  // useIsMobile. Two stores rather than one returning an object, which would
+  // mint a new identity on every read and loop.
   const subscribe = useCallback(
     (onChange: () => void) => {
       if (!content) return () => {};
@@ -72,14 +83,24 @@ export function useScrollAffordance(
 
   // Resolves the scroll parent on every read: entering or leaving fullscreen
   // swaps which ancestor scrolls without remounting the page.
-  const getSnapshot = useCallback(() => {
-    if (!content || !gestureSurface) return false;
-    if (!(window.matchMedia?.('(pointer: coarse)').matches ?? false)) return false;
+  const scrollParent = useCallback(() => {
+    if (!content || !gestureSurface) return null;
+    if (!(window.matchMedia?.('(pointer: coarse)').matches ?? false)) return null;
     const parent = findScrollParent(content);
-    if (!parent) return false;
-    if (parent.scrollHeight - parent.clientHeight <= SCROLL_PAD.minOverflowPx) return false;
-    return surfaceCoverage(parent, gestureSurface) > SCROLL_PAD.maxSurfaceCoverage;
+    if (!parent) return null;
+    return parent.scrollHeight - parent.clientHeight > SCROLL_PAD.minOverflowPx ? parent : null;
   }, [content, gestureSurface]);
 
-  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+  const getOfferPad = useCallback(() => scrollParent() !== null, [scrollParent]);
+
+  const getNeedsPad = useCallback(() => {
+    const parent = scrollParent();
+    if (!parent || !gestureSurface) return false;
+    return surfaceCoverage(parent, gestureSurface) > SCROLL_PAD.maxSurfaceCoverage;
+  }, [scrollParent, gestureSurface]);
+
+  const offerPad = useSyncExternalStore(subscribe, getOfferPad, () => false);
+  const needsPad = useSyncExternalStore(subscribe, getNeedsPad, () => false);
+
+  return { offerPad, needsPad };
 }

--- a/app/src/hooks/useScrollAffordance.ts
+++ b/app/src/hooks/useScrollAffordance.ts
@@ -28,14 +28,14 @@ function findScrollParent(from: HTMLElement | null): HTMLElement | null {
 }
 
 /**
- * Height of visible page that is not the gesture surface, which is what a
- * finger has to land on to scroll by swiping.
+ * Share of the visible scrollport the gesture surface covers. What is left is
+ * the page a finger can land on to scroll by swiping.
  */
-function freeSurfaceHeight(scroller: HTMLElement, gestureSurface: HTMLElement): number {
+function surfaceCoverage(scroller: HTMLElement, gestureSurface: HTMLElement): number {
   const view = scroller.getBoundingClientRect();
   const surface = gestureSurface.getBoundingClientRect();
   const covered = Math.max(0, Math.min(view.bottom, surface.bottom) - Math.max(view.top, surface.top));
-  return scroller.clientHeight - covered;
+  return scroller.clientHeight > 0 ? covered / scroller.clientHeight : 0;
 }
 
 /**
@@ -46,8 +46,8 @@ function freeSurfaceHeight(scroller: HTMLElement, gestureSurface: HTMLElement): 
  * `gestureSurface` is the part of the page that consumes touches instead of
  * scrolling: the zoom and pan container around the video. How much of the
  * viewport it covers is what separates a tablet in landscape, where it leaves
- * only a header strip and the page below the fold is stranded, from the same
- * page in portrait, where there is plenty of room to swipe.
+ * only strips at the screen edges and the page below the fold is stranded,
+ * from the same page in portrait, where there is plenty of room to swipe.
  */
 export function useScrollAffordance(
   content: HTMLElement | null,
@@ -78,7 +78,7 @@ export function useScrollAffordance(
     const parent = findScrollParent(content);
     if (!parent) return false;
     if (parent.scrollHeight - parent.clientHeight <= SCROLL_PAD.minOverflowPx) return false;
-    return freeSurfaceHeight(parent, gestureSurface) < SCROLL_PAD.minGrabPx;
+    return surfaceCoverage(parent, gestureSurface) > SCROLL_PAD.maxSurfaceCoverage;
   }, [content, gestureSurface]);
 
   return useSyncExternalStore(subscribe, getSnapshot, () => false);

--- a/app/src/hooks/useZoomPan.ts
+++ b/app/src/hooks/useZoomPan.ts
@@ -333,6 +333,9 @@ export function useZoomPan({
   return {
     ref: setContainer,
     innerRef,
+    // The element itself, for callers that have to measure it rather than only
+    // bind gestures to it (useScrollAffordance, refs #365).
+    containerEl,
     scale: displayScale,
     isZoomed,
     reset,

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -27,6 +27,27 @@
   margin-right: var(--sai-right, env(safe-area-inset-right)) !important;
 }
 
+/* Safe-area inset source of truth for all --sai-* consumers.
+   - iOS: safe-area-bootstrap.ts overrides these with inline styles on
+     documentElement from UIView.safeAreaInsets (inline wins over this
+     stylesheet rule). refs #147.
+   - Android: Capacitor 8's core SystemBars plugin (insetsHandling: 'css',
+     the default) injects --safe-area-inset-* as inline styles on
+     documentElement with the real system-bar/cutout values. Chromium's own
+     env(safe-area-inset-*) only reports system bars on WebView >= 140 with
+     viewport-fit=cover, and is 0 on older WebViews, so the injected
+     variables must be preferred and env() kept only as a fallback.
+   - Web/desktop: neither source is set, env() resolves to 0px.
+   Without this rule, --sai-* is undefined on Android, every usage falls
+   back to env(), and app chrome renders under the status bar on devices
+   where env() reports 0 (e.g. Android 15/16 enforced edge-to-edge). */
+:root {
+  --sai-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  --sai-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
+  --sai-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+  --sai-left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -27,6 +27,15 @@
   margin-right: var(--sai-right, env(safe-area-inset-right)) !important;
 }
 
+/* Height of the thin fullscreen toolbars (montage, monitor detail). One
+   source for both the toolbar row (h-[var(...)]) and the content padding
+   that clears the fixed bar (calc(var(...) + safe-area inset)): a hardcoded
+   2rem clearance drifts from the row when compact mode shrinks heights
+   (refs #358). Compact override lives next to the .h-8 rule it tracks. */
+:root {
+  --fullscreen-toolbar-h: 2rem;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -500,6 +509,8 @@
 }
 .compact-mode .h-7 { height: 1.5rem; }
 .compact-mode .h-8 { height: 1.75rem; }
+/* Fullscreen toolbar rows track .h-8; see the :root default (refs #358). */
+.compact-mode { --fullscreen-toolbar-h: 1.75rem; }
 .compact-mode .h-9 { height: 1.875rem; }
 .compact-mode .h-10 { height: 2rem; }
 .compact-mode .h-11 { height: 2rem; }

--- a/app/src/lib/__tests__/native-window-theme.test.ts
+++ b/app/src/lib/__tests__/native-window-theme.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { syncNativeSystemBarsStyle } from '../native-window-theme';
+
+const mocks = vi.hoisted(() => ({
+  platform: { value: 'android' },
+  setStyle: vi.fn(),
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    getPlatform: () => mocks.platform.value,
+    isNativePlatform: () => mocks.platform.value !== 'web',
+  },
+  registerPlugin: () =>
+    new Proxy({}, { get: () => vi.fn().mockResolvedValue(undefined) }),
+  SystemBars: {
+    setStyle: (options: unknown) => mocks.setStyle(options),
+  },
+  SystemBarsStyle: { Dark: 'DARK', Light: 'LIGHT', Default: 'DEFAULT' },
+}));
+
+describe('syncNativeSystemBarsStyle', () => {
+  beforeEach(() => {
+    mocks.platform.value = 'android';
+    mocks.setStyle.mockReset();
+    mocks.setStyle.mockResolvedValue(undefined);
+    document.documentElement.classList.remove('light', 'dark', 'slate', 'amber', 'cream');
+  });
+
+  it('sets DARK style (light icons) when the effective theme is dark', () => {
+    document.documentElement.classList.add('dark');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).toHaveBeenCalledWith({ style: 'DARK' });
+  });
+
+  it('sets DARK style for composite dark themes (slate)', () => {
+    document.documentElement.classList.add('dark', 'slate');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).toHaveBeenCalledWith({ style: 'DARK' });
+  });
+
+  it('sets LIGHT style (dark icons) when the effective theme is light', () => {
+    document.documentElement.classList.add('light');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).toHaveBeenCalledWith({ style: 'LIGHT' });
+  });
+
+  it('does nothing off Android', () => {
+    mocks.platform.value = 'web';
+    document.documentElement.classList.add('dark');
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).not.toHaveBeenCalled();
+
+    mocks.platform.value = 'ios';
+    syncNativeSystemBarsStyle();
+    expect(mocks.setStyle).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when the native call rejects', async () => {
+    document.documentElement.classList.add('dark');
+    mocks.setStyle.mockRejectedValue(new Error('native unavailable'));
+    expect(() => syncNativeSystemBarsStyle()).not.toThrow();
+    await vi.waitFor(() => expect(mocks.setStyle).toHaveBeenCalled());
+  });
+});

--- a/app/src/lib/native-window-theme.ts
+++ b/app/src/lib/native-window-theme.ts
@@ -1,4 +1,4 @@
-import { registerPlugin } from '@capacitor/core';
+import { registerPlugin, SystemBars, SystemBarsStyle } from '@capacitor/core';
 import { Platform } from './platform';
 import { log, LogLevel } from './logger';
 
@@ -29,5 +29,28 @@ export function syncNativeWindowBackground(): void {
 
   WindowTheme.setBackgroundColor({ color: hex }).catch((err: unknown) => {
     log.app('Failed to set native window background', LogLevel.WARN, { hex, err });
+  });
+}
+
+/**
+ * Keeps Android status/navigation bar icon color readable against the app
+ * theme. Must go through the SystemBars plugin, not the insets controller
+ * directly: SystemBars re-applies its own tracked style on every
+ * configuration change (rotation), so a direct controller call is stomped
+ * back to DEFAULT, which follows the OS theme. With a light OS theme and a
+ * dark app theme that re-apply requests dark icons on a dark background
+ * (refs #356). setStyle updates the tracked style, so re-applies preserve
+ * it. Must run on every effective theme change, including the "system"
+ * branch: an explicitly set style never reverts to DEFAULT on its own.
+ * iOS is left on its existing default pending a device pass.
+ */
+export function syncNativeSystemBarsStyle(): void {
+  if (!Platform.isAndroid) return;
+  if (typeof document === 'undefined') return;
+
+  const dark = document.documentElement.classList.contains('dark');
+  const style = dark ? SystemBarsStyle.Dark : SystemBarsStyle.Light;
+  SystemBars.setStyle({ style }).catch((err: unknown) => {
+    log.app('Failed to set system bars style', LogLevel.WARN, { style, err });
   });
 }

--- a/app/src/lib/safe-area-bootstrap.ts
+++ b/app/src/lib/safe-area-bootstrap.ts
@@ -9,9 +9,13 @@
  * (UIKit's source of truth) and emits an event on every change. Here we
  * apply those values to --sai-top/right/bottom/left on the document root.
  *
- * CSS usages should reference these via var(--sai-top, env(safe-area-inset-top))
- * so the browser-native env() value is used as the fallback on web/Android,
- * where this plugin is a no-op.
+ * CSS usages reference var(--sai-top, ...). On iOS the inline values set here
+ * win. On Android this plugin is a no-op: env(safe-area-inset-*) is NOT
+ * reliable there (0 on WebView < 140, and observed 0 even on Android 16 with
+ * enforced edge-to-edge). Capacitor 8's core SystemBars plugin instead injects
+ * --safe-area-inset-* inline on documentElement; the :root rule in index.css
+ * chains --sai-* -> --safe-area-inset-* -> env() so every consumer picks up
+ * whichever source is live on the current platform.
  */
 
 import { Capacitor } from '@capacitor/core';

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -1042,6 +1042,11 @@ export const MONTAGE_GRID = {
   // h-8 header bar height with monitor name + buttons (px)
   cardHeaderHeightPx: 32,
 
+  // The same header under compact display mode, which shrinks h-8 rows to
+  // 1.75rem (index.css .compact-mode .h-8). Layout math must use the value
+  // that actually renders or the difference letterboxes the video (refs #359).
+  cardHeaderHeightCompactPx: 28,
+
   // All-mode only cap on total tiles (== streams) rendered across every
   // profile's monitors combined. Single mode has no cap (unchanged,
   // unlimited) - this only guards the aggregate view, where N profiles each

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -150,6 +150,10 @@ export const SCROLL_PAD = {
   // Overflow below this is a rounding difference or a sliver of padding, not
   // content the user is missing, so the pad stays away (refs #365).
   minOverflowPx: 24,
+  // Visible page outside the zoom/pan surface, below which there is no
+  // comfortable place to start a swipe and the pad earns its keep. Two rows of
+  // touch target: a header strip alone does not count as somewhere to drag.
+  minGrabPx: 96,
 } as const;
 
 /**

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -150,10 +150,14 @@ export const SCROLL_PAD = {
   // Overflow below this is a rounding difference or a sliver of padding, not
   // content the user is missing, so the pad stays away (refs #365).
   minOverflowPx: 24,
-  // Visible page outside the zoom/pan surface, below which there is no
-  // comfortable place to start a swipe and the pad earns its keep. Two rows of
-  // touch target: a header strip alone does not count as somewhere to drag.
-  minGrabPx: 96,
+  // Share of the scrollport the zoom/pan surface has to cover before the pad
+  // appears. A fraction rather than a pixel count of leftover page: monitor
+  // detail caps the player at 100svh-7rem in landscape, so ~112px always
+  // remains and any absolute threshold under that switched the pad off on the
+  // very layout #365 reported. Above 70% the video dominates and what is left
+  // is a strip at the screen edges, where a drag up competes with the system
+  // Recents gesture.
+  maxSurfaceCoverage: 0.7,
 } as const;
 
 /**

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -143,10 +143,13 @@ export const GRID_LAYOUT = {
  * The edit-mode pad that scrolls the grid when every tile is a drag surface
  * (refs #321).
  */
-export const MONTAGE_SCROLL_PAD = {
+export const SCROLL_PAD = {
   // Fraction of the visible height one up/down tap moves. Short of a full page
   // so a row stays on screen as a reference point.
   stepFraction: 0.8,
+  // Overflow below this is a rounding difference or a sliver of padding, not
+  // content the user is missing, so the pad stays away (refs #365).
+  minOverflowPx: 24,
 } as const;
 
 /**

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -53,7 +53,8 @@
     "scroll_top": "Ganz nach oben",
     "scroll_up": "Nach oben",
     "scroll_down": "Nach unten",
-    "scroll_bottom": "Ganz nach unten"
+    "scroll_bottom": "Ganz nach unten",
+    "scroll_buttons": "Scroll-Tasten"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -49,7 +49,11 @@
     "press_back_again_to_exit": "Zum Beenden erneut zurück",
     "expand": "Aufklappen",
     "collapse": "Zuklappen",
-    "remove": "Entfernen"
+    "remove": "Entfernen",
+    "scroll_top": "Ganz nach oben",
+    "scroll_up": "Nach oben",
+    "scroll_down": "Nach unten",
+    "scroll_bottom": "Ganz nach unten"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -839,10 +843,6 @@
     "edit_layout": "Bearb.",
     "done_editing": "Fertig",
     "fill_width": "Füllen",
-    "scroll_top": "Ganz nach oben",
-    "scroll_up": "Nach oben",
-    "scroll_down": "Nach unten",
-    "scroll_bottom": "Ganz nach unten",
     "pin_monitor": "Anheften — sperren",
     "unpin_monitor": "Lösen — bewegen",
     "insomnia_enabled": "Bildschirm bleibt wach",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -53,7 +53,8 @@
     "scroll_top": "Scroll to top",
     "scroll_up": "Scroll up",
     "scroll_down": "Scroll down",
-    "scroll_bottom": "Scroll to bottom"
+    "scroll_bottom": "Scroll to bottom",
+    "scroll_buttons": "Scroll buttons"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -49,7 +49,11 @@
     "press_back_again_to_exit": "Press back again to exit",
     "expand": "Expand",
     "collapse": "Collapse",
-    "remove": "Remove"
+    "remove": "Remove",
+    "scroll_top": "Scroll to top",
+    "scroll_up": "Scroll up",
+    "scroll_down": "Scroll down",
+    "scroll_bottom": "Scroll to bottom"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -840,10 +844,6 @@
     "edit_layout": "Edit",
     "done_editing": "Done",
     "fill_width": "Fill",
-    "scroll_top": "Scroll to top",
-    "scroll_up": "Scroll up",
-    "scroll_down": "Scroll down",
-    "scroll_bottom": "Scroll to bottom",
     "pin_monitor": "Pin — lock position",
     "unpin_monitor": "Unpin — allow movement",
     "insomnia_enabled": "Screen will stay awake",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -53,7 +53,8 @@
     "scroll_top": "Ir al principio",
     "scroll_up": "Subir",
     "scroll_down": "Bajar",
-    "scroll_bottom": "Ir al final"
+    "scroll_bottom": "Ir al final",
+    "scroll_buttons": "Botones de desplazamiento"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -49,7 +49,11 @@
     "press_back_again_to_exit": "Pulsa atrás de nuevo para salir",
     "expand": "Expandir",
     "collapse": "Contraer",
-    "remove": "Quitar"
+    "remove": "Quitar",
+    "scroll_top": "Ir al principio",
+    "scroll_up": "Subir",
+    "scroll_down": "Bajar",
+    "scroll_bottom": "Ir al final"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -839,10 +843,6 @@
     "edit_layout": "Editar",
     "done_editing": "Hecho",
     "fill_width": "Rellenar",
-    "scroll_top": "Ir al principio",
-    "scroll_up": "Subir",
-    "scroll_down": "Bajar",
-    "scroll_bottom": "Ir al final",
     "pin_monitor": "Fijar — bloquear",
     "unpin_monitor": "Soltar — mover",
     "insomnia_enabled": "La pantalla permanecerá activa",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -53,7 +53,8 @@
     "scroll_top": "Aller en haut",
     "scroll_up": "Monter",
     "scroll_down": "Descendre",
-    "scroll_bottom": "Aller en bas"
+    "scroll_bottom": "Aller en bas",
+    "scroll_buttons": "Boutons de défilement"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -49,7 +49,11 @@
     "press_back_again_to_exit": "Appuyez encore pour quitter",
     "expand": "Développer",
     "collapse": "Réduire",
-    "remove": "Retirer"
+    "remove": "Retirer",
+    "scroll_top": "Aller en haut",
+    "scroll_up": "Monter",
+    "scroll_down": "Descendre",
+    "scroll_bottom": "Aller en bas"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -839,10 +843,6 @@
     "edit_layout": "Éditer",
     "done_editing": "Fini",
     "fill_width": "Remplir",
-    "scroll_top": "Aller en haut",
-    "scroll_up": "Monter",
-    "scroll_down": "Descendre",
-    "scroll_bottom": "Aller en bas",
     "pin_monitor": "Épingler — verrouiller",
     "unpin_monitor": "Détacher — déplacer",
     "insomnia_enabled": "L'écran restera actif",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -53,7 +53,8 @@
     "scroll_top": "回到顶部",
     "scroll_up": "向上滚动",
     "scroll_down": "向下滚动",
-    "scroll_bottom": "回到底部"
+    "scroll_bottom": "回到底部",
+    "scroll_buttons": "滚动按钮"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -49,7 +49,11 @@
     "press_back_again_to_exit": "再次返回以退出",
     "expand": "展开",
     "collapse": "收起",
-    "remove": "移除"
+    "remove": "移除",
+    "scroll_top": "回到顶部",
+    "scroll_up": "向上滚动",
+    "scroll_down": "向下滚动",
+    "scroll_bottom": "回到底部"
   },
   "app": {
     "name": "zmNinjaNg",
@@ -839,10 +843,6 @@
     "edit_layout": "编辑",
     "done_editing": "完成",
     "fill_width": "填充",
-    "scroll_top": "回到顶部",
-    "scroll_up": "向上滚动",
-    "scroll_down": "向下滚动",
-    "scroll_bottom": "回到底部",
     "pin_monitor": "固定 — 锁定位置",
     "unpin_monitor": "取消固定 — 允许移动",
     "insomnia_enabled": "屏幕将保持唤醒",

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -299,17 +299,17 @@ export default function EventDetail() {
   }, [id, monitorData]);
 
   // Pinch-to-zoom and pan for event video/image
-  // Tap-to-scroll affordance for touch screens where the player fills the
-  // viewport and leaves no free surface to swipe (refs #365).
+  // Page element for the tap-to-scroll affordance, shown when the player covers
+  // the viewport and leaves no free surface to swipe (refs #365).
   const pageRef = useRef<HTMLDivElement | null>(null);
   const [pageEl, setPageEl] = useState<HTMLDivElement | null>(null);
   const setPageNode = useCallback((el: HTMLDivElement | null) => {
     pageRef.current = el;
     setPageEl(el);
   }, []);
-  const needsScrollPad = useScrollAffordance(pageEl);
 
   const zoomPan = useZoomPan({ maxScale: 4 });
+  const needsScrollPad = useScrollAffordance(pageEl, zoomPan.containerEl);
 
   // Frame carousel viewer (#272): the full-size image covers the player, so
   // playback pauses while it is open and resumes on close if it was running.

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -48,6 +48,8 @@ import { log, LogLevel } from '../lib/logger';
 import { generateEventMarkers, type VideoMarker } from '../lib/event/video-markers';
 import { useEventFavoritesStore } from '../stores/eventFavorites';
 import { useZoomPan } from '../hooks/useZoomPan';
+import { useScrollAffordance } from '../hooks/useScrollAffordance';
+import { ScrollPad } from '../components/ui/scroll-pad';
 import { ZoomControls } from '../components/ui/zoom-controls';
 import { ErrorBanner, DetailPageSkeleton } from '../components/ui/query-state';
 import { useEventNavigation } from '../hooks/useEventNavigation';
@@ -297,6 +299,16 @@ export default function EventDetail() {
   }, [id, monitorData]);
 
   // Pinch-to-zoom and pan for event video/image
+  // Tap-to-scroll affordance for touch screens where the player fills the
+  // viewport and leaves no free surface to swipe (refs #365).
+  const pageRef = useRef<HTMLDivElement | null>(null);
+  const [pageEl, setPageEl] = useState<HTMLDivElement | null>(null);
+  const setPageNode = useCallback((el: HTMLDivElement | null) => {
+    pageRef.current = el;
+    setPageEl(el);
+  }, []);
+  const needsScrollPad = useScrollAffordance(pageEl);
+
   const zoomPan = useZoomPan({ maxScale: 4 });
 
   // Frame carousel viewer (#272): the full-size image covers the player, so
@@ -447,7 +459,7 @@ export default function EventDetail() {
   const incomingSlide = location.state?.slideDirection as 'left' | 'right' | undefined;
 
   return (
-    <div className="flex flex-col h-full bg-background">
+    <div ref={setPageNode} className="flex flex-col h-full bg-background">
       {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
         <div className="flex items-center gap-2 sm:gap-3">
@@ -804,6 +816,8 @@ export default function EventDetail() {
           )}
         </div>
       </div>
+
+      {needsScrollPad && <ScrollPad targetRef={pageRef} />}
     </div>
   );
 }

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -449,7 +449,7 @@ export default function EventDetail() {
   return (
     <div className="flex flex-col h-full bg-background">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 md:top-[var(--sai-top,env(safe-area-inset-top))] z-10">
         <div className="flex items-center gap-2 sm:gap-3">
           <Button
             variant="ghost"

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -48,7 +48,7 @@ import { log, LogLevel } from '../lib/logger';
 import { generateEventMarkers, type VideoMarker } from '../lib/event/video-markers';
 import { useEventFavoritesStore } from '../stores/eventFavorites';
 import { useZoomPan } from '../hooks/useZoomPan';
-import { useScrollAffordance } from '../hooks/useScrollAffordance';
+import { useScrollAffordance, useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { ScrollPad } from '../components/ui/scroll-pad';
 import { ZoomControls } from '../components/ui/zoom-controls';
 import { ErrorBanner, DetailPageSkeleton } from '../components/ui/query-state';
@@ -312,7 +312,7 @@ export default function EventDetail() {
   const { offerPad, needsPad } = useScrollAffordance(pageEl, zoomPan.containerEl);
   // Shown automatically when the player leaves nowhere to swipe, and on request
   // from the header toggle anywhere the page scrolls at all (refs #365).
-  const [showScrollPad, setShowScrollPad] = useState(false);
+  const [showScrollPad, toggleScrollPad] = useScrollPadToggle(needsPad);
 
   // Frame carousel viewer (#272): the full-size image covers the player, so
   // playback pauses while it is open and resumes on close if it was running.
@@ -531,7 +531,7 @@ export default function EventDetail() {
               aria-label={t('common.scroll_buttons')}
               aria-pressed={showScrollPad}
               className="h-8 w-8 sm:h-9 sm:w-9"
-              onClick={() => setShowScrollPad((on) => !on)}
+              onClick={toggleScrollPad}
               data-testid="scroll-pad-toggle"
             >
               <ChevronsUpDown className="h-4 w-4 sm:h-5 sm:w-5" />
@@ -834,7 +834,7 @@ export default function EventDetail() {
         </div>
       </div>
 
-      {(needsPad || showScrollPad) && <ScrollPad targetRef={pageRef} />}
+      {showScrollPad && <ScrollPad targetRef={pageRef} />}
     </div>
   );
 }

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -32,7 +32,7 @@ import { Mp4EventPlayer } from '../components/events/Mp4EventPlayer';
 import { ZmsEventPlayer } from '../components/events/ZmsEventPlayer';
 import { EventFrameCarousel } from '../components/events/EventFrameCarousel';
 import { TagChip } from '../components/events/TagChip';
-import { ArrowLeft, Calendar, Clock, HardDrive, AlertTriangle, Download, Archive, Video, Star, Timer, Tag, ChevronLeft, ChevronRight, Loader2, ListVideo } from 'lucide-react';
+import { ArrowLeft, Calendar, Clock, HardDrive, AlertTriangle, Download, Archive, Video, Star, Timer, Tag, ChevronLeft, ChevronRight, ChevronsUpDown, Loader2, ListVideo } from 'lucide-react';
 import { getEventCauseIcon } from '../lib/event/event-icons';
 import { getObjectClassIconFromList } from '../lib/event/object-class-icons';
 import { useDateTimeFormat } from '../hooks/useDateTimeFormat';
@@ -309,7 +309,10 @@ export default function EventDetail() {
   }, []);
 
   const zoomPan = useZoomPan({ maxScale: 4 });
-  const needsScrollPad = useScrollAffordance(pageEl, zoomPan.containerEl);
+  const { offerPad, needsPad } = useScrollAffordance(pageEl, zoomPan.containerEl);
+  // Shown automatically when the player leaves nowhere to swipe, and on request
+  // from the header toggle anywhere the page scrolls at all (refs #365).
+  const [showScrollPad, setShowScrollPad] = useState(false);
 
   // Frame carousel viewer (#272): the full-size image covers the player, so
   // playback pauses while it is open and resumes on close if it was running.
@@ -520,6 +523,20 @@ export default function EventDetail() {
           </Button>
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
+          {offerPad && (
+            <Button
+              variant={showScrollPad ? 'secondary' : 'ghost'}
+              size="icon"
+              title={t('common.scroll_buttons')}
+              aria-label={t('common.scroll_buttons')}
+              aria-pressed={showScrollPad}
+              className="h-8 w-8 sm:h-9 sm:w-9"
+              onClick={() => setShowScrollPad((on) => !on)}
+              data-testid="scroll-pad-toggle"
+            >
+              <ChevronsUpDown className="h-4 w-4 sm:h-5 sm:w-5" />
+            </Button>
+          )}
           <Button
             variant={isFav ? "default" : "outline"}
             size="sm"
@@ -817,7 +834,7 @@ export default function EventDetail() {
         </div>
       </div>
 
-      {needsScrollPad && <ScrollPad targetRef={pageRef} />}
+      {(needsPad || showScrollPad) && <ScrollPad targetRef={pageRef} />}
     </div>
   );
 }

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -38,6 +38,8 @@ import { getOrientedResolution, parseMonitorRotation } from '../lib/monitor/moni
 import { isZmVersionAtLeast } from '../lib/zm/zm-version';
 import { getMonitorRunState, monitorDotColor } from '../lib/monitor/monitor-status';
 import { useZoomPan } from '../hooks/useZoomPan';
+import { useScrollAffordance } from '../hooks/useScrollAffordance';
+import { ScrollPad } from '../components/ui/scroll-pad';
 import { useServerUrls } from '../hooks/useServerUrls';
 
 // Extracted hooks and components
@@ -142,6 +144,19 @@ export default function MonitorDetail() {
   });
 
   // Pinch-to-zoom and pan (zooms around focal point, pan when zoomed, swipe when not)
+  // Tap-to-scroll affordance: on a tablet the video and its controls fill the
+  // viewport and every surface below is a gesture target, so there is nothing
+  // left to swipe (refs #365). Tracked as state as well as a ref because the
+  // measurement has to re-run when the element appears, while the pad only
+  // reads it on a tap - the same split useZoomPan makes.
+  const pageRef = useRef<HTMLDivElement | null>(null);
+  const [pageEl, setPageEl] = useState<HTMLDivElement | null>(null);
+  const setPageNode = useCallback((el: HTMLDivElement | null) => {
+    pageRef.current = el;
+    setPageEl(el);
+  }, []);
+  const needsScrollPad = useScrollAffordance(pageEl);
+
   const zoomPan = useZoomPan({
     minScale: 0.5,
     maxScale: 4,
@@ -283,10 +298,12 @@ export default function MonitorDetail() {
   }
 
   return (
-    <div className={cn(
-      'flex flex-col h-full',
-      isFullscreen ? 'fixed inset-0 z-50 bg-black' : 'bg-background'
-    )}>
+    <div
+      ref={setPageNode}
+      className={cn(
+        'flex flex-col h-full',
+        isFullscreen ? 'fixed inset-0 z-50 bg-black' : 'bg-background'
+      )}>
       {/* Header - Hidden in fullscreen */}
       {!isFullscreen && (
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
@@ -592,6 +609,8 @@ export default function MonitorDetail() {
         orientedResolution={orientedResolution}
         profileId={ownerProfile.id}
       />
+
+      {needsScrollPad && !isFullscreen && <ScrollPad targetRef={pageRef} />}
     </div>
   );
 }

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -289,7 +289,7 @@ export default function MonitorDetail() {
     )}>
       {/* Header - Hidden in fullscreen */}
       {!isFullscreen && (
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 sm:p-3 border-b bg-card/50 backdrop-blur-sm sticky top-0 md:top-[var(--sai-top,env(safe-area-inset-top))] z-10">
         <div className="flex items-center gap-2 sm:gap-3">
           <Button
             variant="ghost"

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -385,7 +385,7 @@ export default function MonitorDetail() {
           className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))] pt-[var(--sai-top,env(safe-area-inset-top))]"
           data-testid="monitor-detail-fullscreen-toolbar"
         >
-          <div className="h-8 flex items-center justify-between px-3">
+          <div className="h-[var(--fullscreen-toolbar-h)] flex items-center justify-between px-3">
             <span className="text-white/70 font-medium text-xs truncate min-w-0" title={monitor.Monitor.Name}>
               {monitor.Monitor.Name}
             </span>
@@ -408,7 +408,7 @@ export default function MonitorDetail() {
       <div className={cn(
         'flex-1 flex flex-col items-center justify-center',
         isFullscreen
-          ? 'pt-[calc(2rem+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
+          ? 'pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
           : 'p-2 sm:p-3 md:p-4 bg-muted/10'
       )}>
         <Card

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -143,20 +143,17 @@ export default function MonitorDetail() {
     profileId: routeProfileId,
   });
 
-  // Pinch-to-zoom and pan (zooms around focal point, pan when zoomed, swipe when not)
-  // Tap-to-scroll affordance: on a tablet the video and its controls fill the
-  // viewport and every surface below is a gesture target, so there is nothing
-  // left to swipe (refs #365). Tracked as state as well as a ref because the
-  // measurement has to re-run when the element appears, while the pad only
-  // reads it on a tap - the same split useZoomPan makes.
+  // Page element for the tap-to-scroll affordance below. Tracked as state as
+  // well as a ref because the measurement re-runs when the element appears,
+  // while the pad only reads it on a tap - the same split useZoomPan makes.
   const pageRef = useRef<HTMLDivElement | null>(null);
   const [pageEl, setPageEl] = useState<HTMLDivElement | null>(null);
   const setPageNode = useCallback((el: HTMLDivElement | null) => {
     pageRef.current = el;
     setPageEl(el);
   }, []);
-  const needsScrollPad = useScrollAffordance(pageEl);
 
+  // Pinch-to-zoom and pan (zooms around focal point, pan when zoomed, swipe when not)
   const zoomPan = useZoomPan({
     minScale: 0.5,
     maxScale: 4,
@@ -164,6 +161,10 @@ export default function MonitorDetail() {
     onSwipeLeft,
     onSwipeRight,
   });
+
+  // The live view leaves nowhere to swipe once it covers the viewport, which is
+  // what happens on a tablet in landscape (refs #365).
+  const needsScrollPad = useScrollAffordance(pageEl, zoomPan.containerEl);
 
   const { portalPath, apiBaseUrl } = useServerUrls(monitor?.Monitor.ServerId, routeProfileId);
   const resolvedPortalUrl = portalPath ? portalPath.replace(/\/index\.php$/, '') : ownerProfile?.portalUrl || '';

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -38,7 +38,7 @@ import { getOrientedResolution, parseMonitorRotation } from '../lib/monitor/moni
 import { isZmVersionAtLeast } from '../lib/zm/zm-version';
 import { getMonitorRunState, monitorDotColor } from '../lib/monitor/monitor-status';
 import { useZoomPan } from '../hooks/useZoomPan';
-import { useScrollAffordance } from '../hooks/useScrollAffordance';
+import { useScrollAffordance, useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { ScrollPad } from '../components/ui/scroll-pad';
 import { useServerUrls } from '../hooks/useServerUrls';
 
@@ -167,7 +167,7 @@ export default function MonitorDetail() {
   const { offerPad, needsPad } = useScrollAffordance(pageEl, zoomPan.containerEl);
   // Shown automatically when the video leaves nowhere to swipe, and on request
   // from the header toggle anywhere the page scrolls at all (refs #365).
-  const [showScrollPad, setShowScrollPad] = useState(false);
+  const [showScrollPad, toggleScrollPad] = useScrollPadToggle(needsPad);
 
   const { portalPath, apiBaseUrl } = useServerUrls(monitor?.Monitor.ServerId, routeProfileId);
   const resolvedPortalUrl = portalPath ? portalPath.replace(/\/index\.php$/, '') : ownerProfile?.portalUrl || '';
@@ -393,7 +393,7 @@ export default function MonitorDetail() {
               aria-label={t('common.scroll_buttons')}
               aria-pressed={showScrollPad}
               className="h-8 w-8 sm:h-9 sm:w-9"
-              onClick={() => setShowScrollPad((on) => !on)}
+              onClick={toggleScrollPad}
               data-testid="scroll-pad-toggle"
             >
               <ChevronsUpDown className="h-4 w-4 sm:h-5 sm:w-5" />
@@ -628,7 +628,7 @@ export default function MonitorDetail() {
         profileId={ownerProfile.id}
       />
 
-      {(needsPad || showScrollPad) && !isFullscreen && <ScrollPad targetRef={pageRef} />}
+      {showScrollPad && !isFullscreen && <ScrollPad targetRef={pageRef} />}
     </div>
   );
 }

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -21,7 +21,7 @@ import { useSettingsStore } from '../stores/settings';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
-import { ArrowLeft, Settings, Maximize2, Minimize2, AlertTriangle, Download, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Layers, Video, Eye, Disc } from 'lucide-react';
+import { ArrowLeft, Settings, Maximize2, Minimize2, AlertTriangle, Download, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsUpDown, Layers, Video, Eye, Disc } from 'lucide-react';
 import { useState, useRef, useMemo, useCallback } from 'react';
 import { cn } from '../lib/utils';
 import { toast } from 'sonner';
@@ -164,7 +164,10 @@ export default function MonitorDetail() {
 
   // The live view leaves nowhere to swipe once it covers the viewport, which is
   // what happens on a tablet in landscape (refs #365).
-  const needsScrollPad = useScrollAffordance(pageEl, zoomPan.containerEl);
+  const { offerPad, needsPad } = useScrollAffordance(pageEl, zoomPan.containerEl);
+  // Shown automatically when the video leaves nowhere to swipe, and on request
+  // from the header toggle anywhere the page scrolls at all (refs #365).
+  const [showScrollPad, setShowScrollPad] = useState(false);
 
   const { portalPath, apiBaseUrl } = useServerUrls(monitor?.Monitor.ServerId, routeProfileId);
   const resolvedPortalUrl = portalPath ? portalPath.replace(/\/index\.php$/, '') : ownerProfile?.portalUrl || '';
@@ -382,6 +385,20 @@ export default function MonitorDetail() {
             </SelectContent>
           </Select>
           <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" alwaysStreaming />
+          {offerPad && (
+            <Button
+              variant={showScrollPad ? 'secondary' : 'ghost'}
+              size="icon"
+              title={t('common.scroll_buttons')}
+              aria-label={t('common.scroll_buttons')}
+              aria-pressed={showScrollPad}
+              className="h-8 w-8 sm:h-9 sm:w-9"
+              onClick={() => setShowScrollPad((on) => !on)}
+              data-testid="scroll-pad-toggle"
+            >
+              <ChevronsUpDown className="h-4 w-4 sm:h-5 sm:w-5" />
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon"
@@ -611,7 +628,7 @@ export default function MonitorDetail() {
         profileId={ownerProfile.id}
       />
 
-      {needsScrollPad && !isFullscreen && <ScrollPad targetRef={pageRef} />}
+      {(needsPad || showScrollPad) && !isFullscreen && <ScrollPad targetRef={pageRef} />}
     </div>
   );
 }

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -55,6 +55,7 @@ import {
   type MontageGroupedSections,
 } from '../components/montage';
 import { ScrollPad } from '../components/ui/scroll-pad';
+import { useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { useFullscreenMode } from '../hooks/useFullscreenMode';
 import { tileIdFor } from '../components/montage/hooks/useMontageGrid';
 
@@ -237,6 +238,9 @@ export default function Montage() {
 
   // Edit mode state lifted to page level
   const [isEditMode, setIsEditMode] = useState(false);
+  // Edit mode turns the pad on by itself - a drag there reorders tiles instead
+  // of scrolling - and the kebab entry overrides that either way (refs #365).
+  const [showScrollPad, toggleScrollPad] = useScrollPadToggle(isEditMode);
 
   // Active saved layout name (persisted in settings)
   const activeLayoutName = bucket.activeLayoutName;
@@ -663,6 +667,8 @@ export default function Montage() {
                 items={visibilityItems}
                 hiddenMonitorIds={bucket.hiddenMonitorIds}
                 onToggleVisibility={handleToggleMonitorVisibility}
+                scrollPadOn={showScrollPad}
+                onToggleScrollPad={toggleScrollPad}
               />
               <NotificationBadge />
             </div>
@@ -743,7 +749,7 @@ export default function Montage() {
         </div>
       </div>
 
-      {isEditMode && !isFullscreen && <ScrollPad targetRef={scrollContainerRef} />}
+      {showScrollPad && !isFullscreen && <ScrollPad targetRef={scrollContainerRef} />}
     </div>
   );
 }

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -278,6 +278,14 @@ export default function Montage() {
     settings,
     isEditMode,
     groupKey,
+    // In fullscreen the tile header is an absolute overlay and takes no flow
+    // space; in normal mode it is in flow at the height the display mode
+    // actually renders (refs #359).
+    tileHeaderPx: isFullscreen
+      ? 0
+      : settings.displayMode === 'compact'
+        ? MONTAGE_GRID.cardHeaderHeightCompactPx
+        : MONTAGE_GRID.cardHeaderHeightPx,
   });
 
   // Tile render resolvers passed to MontageGridSections: the owning profile

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -681,7 +681,7 @@ export default function Montage() {
         className={cn(
           'flex-1 overflow-auto bg-muted/10',
           isFullscreen
-            ? 'pt-[calc(2rem+var(--sai-top,env(safe-area-inset-top)))] overscroll-contain'
+            ? 'pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] overscroll-contain'
             : 'touch-pan-y'
         )}
       >

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -46,7 +46,6 @@ import {
   GridLayoutControls,
   FullscreenControls,
   MontageKebabMenu,
-  MontageScrollPad,
   MontageErrorStrips,
   MontageGridSections,
   useMontageGrid,
@@ -55,6 +54,7 @@ import {
   type MontageTileItem,
   type MontageGroupedSections,
 } from '../components/montage';
+import { ScrollPad } from '../components/ui/scroll-pad';
 import { useFullscreenMode } from '../hooks/useFullscreenMode';
 import { tileIdFor } from '../components/montage/hooks/useMontageGrid';
 
@@ -735,7 +735,7 @@ export default function Montage() {
         </div>
       </div>
 
-      {isEditMode && !isFullscreen && <MontageScrollPad targetRef={scrollContainerRef} />}
+      {isEditMode && !isFullscreen && <ScrollPad targetRef={scrollContainerRef} />}
     </div>
   );
 }

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -55,6 +55,7 @@ import {
   type MontageGroupedSections,
 } from '../components/montage';
 import { ScrollPad } from '../components/ui/scroll-pad';
+import { useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { useFullscreenMode } from '../hooks/useFullscreenMode';
 import { tileIdFor } from '../components/montage/hooks/useMontageGrid';
 
@@ -237,6 +238,9 @@ export default function Montage() {
 
   // Edit mode state lifted to page level
   const [isEditMode, setIsEditMode] = useState(false);
+  // Edit mode turns the pad on by itself - a drag there reorders tiles instead
+  // of scrolling - and the kebab entry overrides that either way (refs #365).
+  const [showScrollPad, toggleScrollPad] = useScrollPadToggle(isEditMode);
 
   // Active saved layout name (persisted in settings)
   const activeLayoutName = bucket.activeLayoutName;
@@ -655,6 +659,8 @@ export default function Montage() {
                 items={visibilityItems}
                 hiddenMonitorIds={bucket.hiddenMonitorIds}
                 onToggleVisibility={handleToggleMonitorVisibility}
+                scrollPadOn={showScrollPad}
+                onToggleScrollPad={toggleScrollPad}
               />
               <NotificationBadge />
             </div>
@@ -735,7 +741,7 @@ export default function Montage() {
         </div>
       </div>
 
-      {isEditMode && !isFullscreen && <ScrollPad targetRef={scrollContainerRef} />}
+      {showScrollPad && !isFullscreen && <ScrollPad targetRef={scrollContainerRef} />}
     </div>
   );
 }

--- a/app/src/pages/Timeline.tsx
+++ b/app/src/pages/Timeline.tsx
@@ -11,6 +11,8 @@ import { Card, CardContent } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { FilterX, Clock } from 'lucide-react';
 import { PageContainer } from '../components/common/PageContainer';
+import { ScrollPad } from '../components/ui/scroll-pad';
+import { useScrollAffordance, useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { ErrorBanner } from '../components/ui/query-state';
 import { resolveQueryError } from '../lib/query/query-error';
 import { subDays } from 'date-fns';
@@ -56,6 +58,19 @@ export default function Timeline() {
 
   // Brush-to-zoom mode toggle
   const [brushMode, setBrushMode] = useState(false);
+  // The canvas sets touch-action: none to own pan and pinch, and it grows one
+  // row per monitor, so on a touch screen it can cover the viewport and leave
+  // nowhere to swipe the page (refs #365). Same element serves as the pad's
+  // scroll target - it walks up to the scrolling ancestor - and as the gesture
+  // surface the measurement is about.
+  const canvasAreaRef = useRef<HTMLDivElement | null>(null);
+  const [canvasAreaEl, setCanvasAreaEl] = useState<HTMLDivElement | null>(null);
+  const setCanvasAreaNode = useCallback((el: HTMLDivElement | null) => {
+    canvasAreaRef.current = el;
+    setCanvasAreaEl(el);
+  }, []);
+  const { offerPad, needsPad } = useScrollAffordance(canvasAreaEl, canvasAreaEl);
+  const [showScrollPad, toggleScrollPad] = useScrollPadToggle(needsPad);
 
   // Live mode: subscribe to notification store for new events, fall back to polling
   const [liveMode, setLiveMode] = useState(false);
@@ -478,6 +493,9 @@ export default function Timeline() {
           ) : (
             <div className="p-4" data-testid="timeline-content">
               <TimelineToolbar
+                offerScrollPad={offerPad}
+                scrollPadOn={showScrollPad}
+                onToggleScrollPad={toggleScrollPad}
                 brushMode={brushMode}
                 liveMode={liveMode}
                 onToggleBrush={() => setBrushMode((b) => !b)}
@@ -487,6 +505,7 @@ export default function Timeline() {
                 onCenter={() => fireViewportAction('reset')}
                 onGoToNow={() => fireViewportAction('goToNow')}
               />
+              <div ref={setCanvasAreaNode}>
               <TimelineCanvas
                 monitors={monitorRows}
                 events={canvasEvents}
@@ -501,6 +520,8 @@ export default function Timeline() {
                 brushMode={brushMode}
                 liveMode={liveMode}
               />
+              </div>
+              {showScrollPad && <ScrollPad targetRef={canvasAreaRef} />}
             </div>
           )}
         </CardContent>

--- a/app/src/pages/__tests__/Montage.test.tsx
+++ b/app/src/pages/__tests__/Montage.test.tsx
@@ -149,7 +149,6 @@ vi.mock('../../components/montage', async (importOriginal) => {
       </div>
     ),
     MontageTileErrorBoundary: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-    MontageScrollPad: () => null,
     useMontageGrid: (options: unknown) => useMontageGridMock(options),
     useContainerResize: () => ({ containerRef: vi.fn() }),
   };

--- a/app/src/tests/setup.ts
+++ b/app/src/tests/setup.ts
@@ -117,6 +117,10 @@ vi.mock('@capacitor/core', () => ({
   registerPlugin: () => new Proxy({}, {
     get: () => vi.fn().mockResolvedValue(undefined),
   }),
+  SystemBars: {
+    setStyle: vi.fn().mockResolvedValue(undefined),
+  },
+  SystemBarsStyle: { Dark: 'DARK', Light: 'LIGHT', Default: 'DEFAULT' },
 }));
 
 // Mock Capacitor Haptics

--- a/app/tests/features/montage.feature
+++ b/app/tests/features/montage.feature
@@ -99,6 +99,15 @@ Feature: Montage Live Grid
     Then the montage scroll pad should be hidden
 
   @web
+  Scenario: The kebab menu shows and hides the scroll pad outside edit mode
+    Then I should see at least 1 monitor in montage grid
+    And the montage scroll pad should be hidden
+    When I toggle the montage scroll pad from the menu
+    Then the montage scroll pad should be visible
+    When I toggle the montage scroll pad from the menu
+    Then the montage scroll pad should be hidden
+
+  @web
   Scenario: Montage tile shows the new-events badge and opens filtered events
     Then I should see at least 1 monitor in montage grid
     When I seed old watermarks for montage monitors with events

--- a/app/tests/steps/montage.steps.ts
+++ b/app/tests/steps/montage.steps.ts
@@ -300,6 +300,23 @@ Then('the montage scroll pad should be hidden', async ({ page }) => {
   await expect(page.getByTestId('scroll-pad')).toHaveCount(0);
 });
 
+When('I toggle the montage scroll pad from the menu', async ({ page }) => {
+  const trigger = page.getByTestId('montage-kebab-menu');
+  // Radix keeps pointer events off the page while the menu animates shut, so
+  // a click landing in that window is swallowed and the menu never reopens.
+  // Wait for both signals rather than pausing a fixed time.
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  // Keyboard rather than click: Radix leaves a dismissable layer over the page
+  // for a beat after the menu closes, and a click landing on it never reaches
+  // the trigger, so the menu would not reopen for the second toggle.
+  await trigger.focus();
+  await trigger.press('Enter');
+
+  const item = page.getByTestId('montage-kebab-scroll-pad');
+  await expect(item).toBeVisible({ timeout: testConfig.timeouts.element });
+  await item.click();
+});
+
 When('I record the montage grid scroll position and tile order', async ({ page }) => {
   const { top, overflow, visible } = await readGridScroll(page);
   scrollPadStep = visible * SCROLL_PAD.stepFraction;

--- a/app/tests/steps/montage.steps.ts
+++ b/app/tests/steps/montage.steps.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { testConfig } from '../helpers/config';
 import { getMonitorCount, getMonitorEventCountSince } from '../helpers/zm-api';
-import { MONTAGE_SCROLL_PAD } from '../../src/lib/zmninja-ng-constants';
+import { SCROLL_PAD } from '../../src/lib/zmninja-ng-constants';
 
 const { When, Then } = createBdd();
 
@@ -291,18 +291,18 @@ When('I leave montage edit mode', async ({ page }) => {
 });
 
 Then('the montage scroll pad should be visible', async ({ page }) => {
-  await expect(page.getByTestId('montage-scroll-pad')).toBeVisible({
+  await expect(page.getByTestId('scroll-pad')).toBeVisible({
     timeout: testConfig.timeouts.element,
   });
 });
 
 Then('the montage scroll pad should be hidden', async ({ page }) => {
-  await expect(page.getByTestId('montage-scroll-pad')).toHaveCount(0);
+  await expect(page.getByTestId('scroll-pad')).toHaveCount(0);
 });
 
 When('I record the montage grid scroll position and tile order', async ({ page }) => {
   const { top, overflow, visible } = await readGridScroll(page);
-  scrollPadStep = visible * MONTAGE_SCROLL_PAD.stepFraction;
+  scrollPadStep = visible * SCROLL_PAD.stepFraction;
   // One column of tiles has to be taller than the viewport for scrolling to
   // mean anything. That is a property of the grid under test, so assert it
   // rather than skipping on it.
@@ -313,11 +313,11 @@ When('I record the montage grid scroll position and tile order', async ({ page }
 });
 
 When('I tap the montage scroll pad down button', async ({ page }) => {
-  await page.getByTestId('montage-scroll-down').click();
+  await page.getByTestId('scroll-down').click();
 });
 
 When('I tap the montage scroll pad top button', async ({ page }) => {
-  await page.getByTestId('montage-scroll-top').click();
+  await page.getByTestId('scroll-top').click();
 });
 
 Then('the montage grid should have scrolled down', async ({ page }) => {

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -97,7 +97,8 @@ The player is a zoom and pan surface, so a swipe over it zooms or pans rather
 than scrolling the page. When it covers the display, as it does on a tablet in
 landscape, four buttons appear on the right edge: jump to the top, up one screen,
 down one screen, and jump to the bottom. Wherever the page leaves room to drag,
-and on a computer, they stay away.
+and on a computer, they stay away. To call them up at any time on a touch screen,
+tap the up/down arrows in the header; tapping again puts them away.
 
 ### Navigation
 

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -93,11 +93,11 @@ Details about the event:
 
 ### Scroll Pad
 
-On a touch screen the player can fill the display, and the video is a zoom and
-pan surface, so a swipe over it does not scroll the page. When that happens and
-there is more page below, four buttons appear on the right edge: jump to the top,
-up one screen, down one screen, and jump to the bottom. On a computer they never
-appear, since the wheel and the scrollbar already scroll from anywhere.
+The player is a zoom and pan surface, so a swipe over it zooms or pans rather
+than scrolling the page. When it covers the display, as it does on a tablet in
+landscape, four buttons appear on the right edge: jump to the top, up one screen,
+down one screen, and jump to the bottom. Wherever the page leaves room to drag,
+and on a computer, they stay away.
 
 ### Navigation
 

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -91,6 +91,14 @@ Details about the event:
 - Number of alarm and total frames
 - Monitor name and ID
 
+### Scroll Pad
+
+On a touch screen the player can fill the display, and the video is a zoom and
+pan surface, so a swipe over it does not scroll the page. When that happens and
+there is more page below, four buttons appear on the right edge: jump to the top,
+up one screen, down one screen, and jump to the bottom. On a computer they never
+appear, since the wheel and the scrollbar already scroll from anywhere.
+
 ### Navigation
 
 - **Previous/Next** buttons to move between events without going back to the list

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -47,8 +47,8 @@ For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode*
 #### Scroll Pad
 
 The live view is a zoom and pan surface, so a swipe over it zooms or pans rather
-than scrolling the page. On a tablet in landscape it covers everything below the
-header, which leaves nowhere to start a scroll while the status, zones, and recent
+than scrolling the page. On a tablet in landscape it covers most of the screen,
+leaving only thin strips at the top and bottom while the status, zones, and recent
 events sit below the fold. When that happens, four buttons appear on the right
 edge: jump to the top, up one screen, down one screen, and jump to the bottom.
 They are the same buttons montage edit mode uses.

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -55,7 +55,8 @@ They are the same buttons montage edit mode uses.
 
 In portrait, or wherever the page leaves room to drag, the buttons stay away, as
 they do on a computer where the wheel and the scrollbar already scroll from
-anywhere.
+anywhere. To call them up at any time on a touch screen, tap the up/down arrows
+in the header; tapping again puts them away.
 
 #### Digital Zoom and Pan
 

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -46,12 +46,16 @@ For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode*
 
 #### Scroll Pad
 
-On a touch screen the live view and its controls can fill the display, and the
-video itself is a zoom and pan surface, so a swipe over it does not scroll the
-page. When that happens and there is more page below, four buttons appear on the
-right edge: jump to the top, up one screen, down one screen, and jump to the
-bottom. They are the same buttons the montage edit mode uses. On a computer, where
-the wheel and the scrollbar already scroll from anywhere, they never appear.
+The live view is a zoom and pan surface, so a swipe over it zooms or pans rather
+than scrolling the page. On a tablet in landscape it covers everything below the
+header, which leaves nowhere to start a scroll while the status, zones, and recent
+events sit below the fold. When that happens, four buttons appear on the right
+edge: jump to the top, up one screen, down one screen, and jump to the bottom.
+They are the same buttons montage edit mode uses.
+
+In portrait, or wherever the page leaves room to drag, the buttons stay away, as
+they do on a computer where the wheel and the scrollbar already scroll from
+anywhere.
 
 #### Digital Zoom and Pan
 

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -44,6 +44,15 @@ The protocol label (enabled in {doc}`settings`) shows which streaming protocol i
 
 For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode* setting does apply, see {doc}`settings` for details.
 
+#### Scroll Pad
+
+On a touch screen the live view and its controls can fill the display, and the
+video itself is a zoom and pan surface, so a swipe over it does not scroll the
+page. When that happens and there is more page below, four buttons appear on the
+right edge: jump to the top, up one screen, down one screen, and jump to the
+bottom. They are the same buttons the montage edit mode uses. On a computer, where
+the wheel and the scrollbar already scroll from anywhere, they never appear.
+
 #### Digital Zoom and Pan
 
 The zoom controls in the corner of the live view zoom into the streamed image (this is digital zoom in the app, not camera PTZ). You can also zoom with the mouse:

--- a/docs/user-guide/montage.md
+++ b/docs/user-guide/montage.md
@@ -49,6 +49,10 @@ sits on the right edge for as long as you are editing, with four buttons: jump
 to the top, up one screen, down one screen, and jump to the bottom. It goes
 away when you tap **Done**.
 
+Outside edit mode you can call it up yourself: **Scroll buttons** in the ⋮ menu
+shows and hides it. That is worth doing on a tablet where the tiles fill the
+screen, since a swipe there lands on a tile rather than the page.
+
 Tap **Done** to leave edit mode.
 
 ## Fullscreen Mode

--- a/docs/user-guide/timeline.md
+++ b/docs/user-guide/timeline.md
@@ -10,6 +10,14 @@ Events are drawn as colored bars on a horizontal time axis. Each monitor gets it
 - **Pan** left and right to move through time
 - **Tap an event bar** to jump to that event's detail view
 
+The canvas owns touch gestures for panning and zooming, so a swipe over it moves
+through time rather than scrolling the page. It also grows one row per monitor,
+which on a tablet can leave nothing to swipe when the filters and event list sit
+below the fold. When that happens, the up/down arrows in the toolbar show a
+column of scroll buttons on the right edge: jump to the top, up one screen, down
+one screen, and jump to the bottom. Tapping the arrows again puts them away. On a
+computer they never appear, since the wheel already scrolls from anywhere.
+
 ## Filtering
 
 Open the **Filters** panel at the top of the page to narrow what the timeline shows. Filter selections are saved per profile.


### PR DESCRIPTION
Integration branch for the edge-to-edge work. Carries PRs #360-364, #366 and #367, with conflicts between them already resolved (both #360 and #363 add a `:root` block to `index.css`).

Closes nothing by keyword — issues #355-359 and #365 stay open until the device pass confirms them.

## What lands

- **#355** — `--sai-*` resolves from Capacitor's injected `--safe-area-inset-*`, so app chrome stops drawing under the status bar on Android 15/16. Landscape bar-hide is posted after SystemBars' queued `show()`.
- **#356** — bar icon style driven through `SystemBars.setStyle`, applied *before* the window background (its last act repaints the decor), and the background restored after each rotation so a dark app under a light OS theme stops flashing white.
- **#357** — sticky safe-area strip on the `md:` layout, with `MonitorDetail` and `EventDetail` headers pinned below it.
- **#358** — one `--fullscreen-toolbar-h` variable for the toolbar row and its clearance.
- **#359** — overlay header excluded from fullscreen tile heights.
- **#365** — scroll pad on monitor/event detail when the video covers >70% of the scrollport, plus manual toggles: header buttons on the detail pages, the ⋮ menu on montage, the toolbar on timeline.
- **R8** — release builds use `proguard-android-optimize.txt`; APK drops ~978KB.

## Verification

`npm run gates`: 4155 passed / 2 skipped, build clean, three lints pass, ratchet at 201 (unchanged). `npm run test:e2e -- montage.feature`: 13 passed.

Release APK installed and launched clean on a Pixel Tablet API 36 emulator, R8 on, no crashes in logcat.

**Not verified on hardware.** The Lenovo TB373FU that reported #355/#356 has not run this build, and R8 has never shipped in this app — reflective paths (Capacitor bridge, Firebase messaging, ML Kit GenAI) deserve a real-device pass. `git revert` of the R8 commit isolates that half if anything surfaces.

Posted by Claude, assisting @pliablepixels.