### PR TITLE
Fit and analysis frames move into a view menu

### DIFF
--- a/app/src/components/common/view-options.tsx
+++ b/app/src/components/common/view-options.tsx
@@ -18,10 +18,10 @@ import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
 } from '../ui/dropdown-menu';
 import { useAnalysisFramesSetting } from '../../hooks/useAnalysisFramesSetting';
 
@@ -68,18 +68,19 @@ interface FeedFitItemsProps {
 export function FeedFitItems({ value, onChange, testIdPrefix }: FeedFitItemsProps) {
   const { t } = useTranslation();
 
+  // No group heading: it read "Fit" over an option also called "Fit". The
+  // items say what they do instead, which a menu has room for and a 100px
+  // select never did. The dashboard dialogs keep the short words, where a
+  // label of their own supplies the context.
   return (
-    <>
-      <DropdownMenuLabel>{t('montage.feed_fit')}</DropdownMenuLabel>
-      <DropdownMenuRadioGroup value={value} onValueChange={(v) => onChange(v as FeedFitChoice)}>
-        <DropdownMenuRadioItem value="contain" data-testid={`${testIdPrefix}-fit-contain`}>
-          {t('montage.fit_fit')}
-        </DropdownMenuRadioItem>
-        <DropdownMenuRadioItem value="cover" data-testid={`${testIdPrefix}-fit-cover`}>
-          {t('montage.fit_crop')}
-        </DropdownMenuRadioItem>
-      </DropdownMenuRadioGroup>
-    </>
+    <DropdownMenuRadioGroup value={value} onValueChange={(v) => onChange(v as FeedFitChoice)}>
+      <DropdownMenuRadioItem value="contain" data-testid={`${testIdPrefix}-fit-contain`}>
+        {t('common.fit_whole_image')}
+      </DropdownMenuRadioItem>
+      <DropdownMenuRadioItem value="cover" data-testid={`${testIdPrefix}-fit-cover`}>
+        {t('common.crop_to_fill')}
+      </DropdownMenuRadioItem>
+    </DropdownMenuRadioGroup>
   );
 }
 
@@ -108,3 +109,6 @@ export function AnalysisFramesItem({ alwaysStreaming = false }: AnalysisFramesIt
     </DropdownMenuCheckboxItem>
   );
 }
+
+/** Re-exported so a screen composing a menu imports from one place. */
+export { DropdownMenuSeparator as ViewOptionsSeparator };

--- a/app/src/components/common/view-options.tsx
+++ b/app/src/components/common/view-options.tsx
@@ -1,0 +1,110 @@
+/**
+ * Menu items for the view preferences every streaming screen carries.
+ *
+ * Feed fit and analysis frames are set once and then left alone, but they sat
+ * in the header of four screens, competing for width with the things a person
+ * actually reaches for. They live in a ⋮ menu now, and these are the pieces
+ * each screen drops into its own.
+ *
+ * The analysis item shares its state with AnalysisFramesToggle through
+ * useAnalysisFramesSetting, so the button in the views that keep one and the
+ * item in the menus can never disagree about what the setting is.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { MoreVertical } from 'lucide-react';
+import { Button } from '../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuCheckboxItem,
+} from '../ui/dropdown-menu';
+import { useAnalysisFramesSetting } from '../../hooks/useAnalysisFramesSetting';
+
+/** The two the UI offers. Screens store wider types - monitors can also hold
+ *  'flex' - so the value read in is loose and only the choice emitted is not. */
+export type FeedFitChoice = 'contain' | 'cover';
+
+interface ViewOptionsMenuProps {
+  /** Prefix for this screen's test ids; the trigger appends `-menu`. */
+  testId: string;
+  children: React.ReactNode;
+}
+
+export function ViewOptionsMenu({ testId, children }: ViewOptionsMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 sm:h-9 sm:w-9"
+          title={t('common.view_options')}
+          aria-label={t('common.view_options')}
+          data-testid={`${testId}-menu`}
+        >
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">{children}</DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface FeedFitItemsProps {
+  /** The stored setting; anything outside the two simply checks neither. */
+  value: string;
+  onChange: (value: FeedFitChoice) => void;
+  /** Screen prefix, so the ids match what the header control used to carry. */
+  testIdPrefix: string;
+}
+
+export function FeedFitItems({ value, onChange, testIdPrefix }: FeedFitItemsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <DropdownMenuLabel>{t('montage.feed_fit')}</DropdownMenuLabel>
+      <DropdownMenuRadioGroup value={value} onValueChange={(v) => onChange(v as FeedFitChoice)}>
+        <DropdownMenuRadioItem value="contain" data-testid={`${testIdPrefix}-fit-contain`}>
+          {t('montage.fit_fit')}
+        </DropdownMenuRadioItem>
+        <DropdownMenuRadioItem value="cover" data-testid={`${testIdPrefix}-fit-cover`}>
+          {t('montage.fit_crop')}
+        </DropdownMenuRadioItem>
+      </DropdownMenuRadioGroup>
+    </>
+  );
+}
+
+interface AnalysisFramesItemProps {
+  /** Set by views that stream whatever the profile's Streaming Mode says. */
+  alwaysStreaming?: boolean;
+}
+
+export function AnalysisFramesItem({ alwaysStreaming = false }: AnalysisFramesItemProps) {
+  const { isOn, unavailable, toggle } = useAnalysisFramesSetting({ alwaysStreaming });
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenuCheckboxItem
+      checked={isOn}
+      disabled={unavailable}
+      onSelect={(e) => {
+        // Several of these get flipped in a row while judging a feed, so the
+        // menu stays open, unlike the one-shot actions elsewhere.
+        e.preventDefault();
+        toggle();
+      }}
+      data-testid="analysis-frames-toggle"
+    >
+      {t('video.analysis_frames')}
+    </DropdownMenuCheckboxItem>
+  );
+}

--- a/app/src/components/common/view-options.tsx
+++ b/app/src/components/common/view-options.tsx
@@ -6,9 +6,9 @@
  * actually reaches for. They live in a ⋮ menu now, and these are the pieces
  * each screen drops into its own.
  *
- * The analysis item shares its state with AnalysisFramesToggle through
- * useAnalysisFramesSetting, so the button in the views that keep one and the
- * item in the menus can never disagree about what the setting is.
+ * The analysis item reads useAnalysisFramesSetting, which is where that
+ * setting's read and write live now that every screen offers it from a menu
+ * rather than a toolbar button.
  */
 
 import { useTranslation } from 'react-i18next';

--- a/app/src/components/monitors/AnalysisFramesToggle.tsx
+++ b/app/src/components/monitors/AnalysisFramesToggle.tsx
@@ -15,10 +15,7 @@
 import { useTranslation } from 'react-i18next';
 import { ScanEye } from 'lucide-react';
 import { Button } from '../ui/button';
-import { useCurrentProfile } from '../../hooks/useCurrentProfile';
-import { usePageViewMode } from '../../hooks/useViewPrefs';
-import { useProfileStore } from '../../stores/profile';
-import { useSettingsStore } from '../../stores/settings';
+import { useAnalysisFramesSetting } from '../../hooks/useAnalysisFramesSetting';
 
 interface AnalysisFramesToggleProps {
   className?: string;
@@ -32,19 +29,7 @@ interface AnalysisFramesToggleProps {
 
 export function AnalysisFramesToggle({ className, alwaysStreaming = false }: AnalysisFramesToggleProps) {
   const { t } = useTranslation();
-  const { settings } = useCurrentProfile();
-  // Write target: the real profile in single mode, the active aggregate's id
-  // while aggregating, matching the bucket `settings` above already reads
-  // (refs #337).
-  const currentProfileId = useProfileStore((state) => state.currentProfileId);
-  const updateSettings = useSettingsStore((state) => state.updateProfileSettings);
-
-  // Not settings.viewMode: under "Per server" the active aggregate's bucket
-  // imposes no Streaming Mode, and reading its own would disable a control
-  // that still governs every streaming server's tiles (refs #337).
-  const pageViewMode = usePageViewMode();
-  const unavailable = !alwaysStreaming && pageViewMode === 'snapshot';
-  const isOn = settings.showAnalysisFrames;
+  const { isOn, unavailable, toggle } = useAnalysisFramesSetting({ alwaysStreaming });
   const label = t('video.analysis_frames');
   const title = unavailable ? t('video.analysis_needs_streaming') : t('video.analysis_frames_hint');
 
@@ -53,14 +38,11 @@ export function AnalysisFramesToggle({ className, alwaysStreaming = false }: Ana
       variant={isOn ? 'default' : 'outline'}
       size="icon"
       className={className}
-      disabled={unavailable || !currentProfileId}
+      disabled={unavailable}
       aria-pressed={isOn}
       aria-label={label}
       title={title}
-      onClick={() => {
-        if (!currentProfileId) return;
-        updateSettings(currentProfileId, { showAnalysisFrames: !isOn });
-      }}
+      onClick={toggle}
       data-testid="analysis-frames-toggle"
     >
       <ScanEye className="h-4 w-4" />

--- a/app/src/components/montage/MontageKebabMenu.tsx
+++ b/app/src/components/montage/MontageKebabMenu.tsx
@@ -11,7 +11,9 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
   DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
 } from '../ui/dropdown-menu';
+import { FeedFitItems, AnalysisFramesItem, type FeedFitChoice } from '../common/view-options';
 
 /** One entry in the show-monitors list. */
 export interface MontageVisibilityItem {
@@ -32,6 +34,8 @@ interface MontageKebabMenuProps {
   /** Whether the scroll pad is currently on screen. */
   scrollPadOn: boolean;
   onToggleScrollPad: () => void;
+  feedFit: string;
+  onFeedFitChange: (value: FeedFitChoice) => void;
 }
 
 export function MontageKebabMenu({
@@ -40,6 +44,8 @@ export function MontageKebabMenu({
   onToggleVisibility,
   scrollPadOn,
   onToggleScrollPad,
+  feedFit,
+  onFeedFitChange,
 }: MontageKebabMenuProps) {
   const { t } = useTranslation();
 
@@ -60,6 +66,12 @@ export function MontageKebabMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {/* Set once and then left alone, so they belong here rather than in a
+            header that has to fit a group filter, layouts, edit, fullscreen
+            and refresh besides. */}
+        <FeedFitItems value={feedFit} onChange={onFeedFitChange} testIdPrefix="montage" />
+        <AnalysisFramesItem />
+        <DropdownMenuSeparator />
         {/* Edit mode turns the pad on by itself, since a drag there reorders
             tiles rather than scrolling. This entry covers the rest: a grid
             taller than the screen on a touch device, where the tiles are the

--- a/app/src/components/montage/MontageKebabMenu.tsx
+++ b/app/src/components/montage/MontageKebabMenu.tsx
@@ -70,8 +70,8 @@ export function MontageKebabMenu({
             header that has to fit a group filter, layouts, edit, fullscreen
             and refresh besides. */}
         <FeedFitItems value={feedFit} onChange={onFeedFitChange} testIdPrefix="montage" />
-        <AnalysisFramesItem />
         <DropdownMenuSeparator />
+        <AnalysisFramesItem />
         {/* Edit mode turns the pad on by itself, since a drag there reorders
             tiles rather than scrolling. This entry covers the rest: a grid
             taller than the screen on a touch device, where the tiles are the
@@ -85,9 +85,12 @@ export function MontageKebabMenu({
         >
           {t('common.scroll_buttons')}
         </DropdownMenuCheckboxItem>
+        {items.length > 0 && <DropdownMenuSeparator />}
         {items.length > 0 && (
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger data-testid="montage-kebab-visibility">
+            {/* inset: a sub-trigger has no indicator, so without it this text
+                starts 24px left of every checkable item above it. */}
+            <DropdownMenuSubTrigger inset data-testid="montage-kebab-visibility">
               {t('montage.menu_show_monitors')}
             </DropdownMenuSubTrigger>
             {/* Bounded width, or the submenu grows to the longest monitor

--- a/app/src/components/montage/__tests__/MontageKebabMenu.test.tsx
+++ b/app/src/components/montage/__tests__/MontageKebabMenu.test.tsx
@@ -37,6 +37,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     expect(screen.getByTestId('montage-kebab-menu')).toBeInTheDocument();
@@ -51,6 +53,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -66,6 +70,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -89,6 +95,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -109,6 +117,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -128,6 +138,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -149,6 +161,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -167,6 +181,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -191,6 +207,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -209,6 +227,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
       scrollPadOn={false}
       onToggleScrollPad={vi.fn()}
+      feedFit="contain"
+      onFeedFitChange={vi.fn()}
       />
     );
     await user.click(screen.getByTestId('montage-kebab-menu'));
@@ -226,6 +246,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
         scrollPadOn={false}
         onToggleScrollPad={onToggleScrollPad}
+        feedFit="contain"
+        onFeedFitChange={vi.fn()}
       />
     );
 
@@ -245,6 +267,8 @@ describe('MontageKebabMenu', () => {
         onToggleVisibility={onToggleVisibility}
         scrollPadOn
         onToggleScrollPad={vi.fn()}
+        feedFit="contain"
+        onFeedFitChange={vi.fn()}
       />
     );
 

--- a/app/src/hooks/useAnalysisFramesSetting.ts
+++ b/app/src/hooks/useAnalysisFramesSetting.ts
@@ -1,0 +1,56 @@
+/**
+ * The analysis-frames setting, shared by the toolbar button and the menu item.
+ *
+ * Profile-scoped and remembered, and one value covers every live view: turning
+ * it on in montage leaves it on in the single-monitor view. Extracted from
+ * AnalysisFramesToggle when the same setting gained a second home in the view
+ * menus - two copies of the write path would eventually disagree about which
+ * bucket they write to, which is exactly the bug #337 spent a release fixing.
+ */
+
+import { useCurrentProfile } from './useCurrentProfile';
+import { usePageViewMode } from './useViewPrefs';
+import { useProfileStore } from '../stores/profile';
+import { useSettingsStore } from '../stores/settings';
+
+interface UseAnalysisFramesSettingOptions {
+  /**
+   * Set by views that stream regardless of the profile's Streaming Mode (the
+   * single-monitor page forces 'streaming'), so the control stays usable there
+   * while the profile sits on snapshot.
+   */
+  alwaysStreaming?: boolean;
+}
+
+interface AnalysisFramesSetting {
+  isOn: boolean;
+  /** Snapshot mode: zms serves one image and never looks at the frame type. */
+  unavailable: boolean;
+  toggle: () => void;
+}
+
+export function useAnalysisFramesSetting({
+  alwaysStreaming = false,
+}: UseAnalysisFramesSettingOptions = {}): AnalysisFramesSetting {
+  const { settings } = useCurrentProfile();
+  // Write target: the real profile in single mode, the active aggregate's id
+  // while aggregating, matching the bucket `settings` above already reads
+  // (refs #337).
+  const currentProfileId = useProfileStore((state) => state.currentProfileId);
+  const updateSettings = useSettingsStore((state) => state.updateProfileSettings);
+
+  // Not settings.viewMode: under "Per server" the active aggregate's bucket
+  // imposes no Streaming Mode, and reading its own would disable a control
+  // that still governs every streaming server's tiles (refs #337).
+  const pageViewMode = usePageViewMode();
+  const isOn = settings.showAnalysisFrames;
+
+  return {
+    isOn,
+    unavailable: (!alwaysStreaming && pageViewMode === 'snapshot') || !currentProfileId,
+    toggle: () => {
+      if (!currentProfileId) return;
+      updateSettings(currentProfileId, { showAnalysisFrames: !isOn });
+    },
+  };
+}

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -54,7 +54,8 @@
     "scroll_up": "Nach oben",
     "scroll_down": "Nach unten",
     "scroll_bottom": "Ganz nach unten",
-    "scroll_buttons": "Scroll-Tasten"
+    "scroll_buttons": "Scroll-Tasten",
+    "view_options": "Ansichtsoptionen"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -55,7 +55,9 @@
     "scroll_down": "Nach unten",
     "scroll_bottom": "Ganz nach unten",
     "scroll_buttons": "Scroll-Tasten",
-    "view_options": "Ansichtsoptionen"
+    "view_options": "Ansichtsoptionen",
+    "fit_whole_image": "Ganzes Bild einpassen",
+    "crop_to_fill": "Zum Füllen zuschneiden"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -55,7 +55,9 @@
     "scroll_down": "Scroll down",
     "scroll_bottom": "Scroll to bottom",
     "scroll_buttons": "Scroll buttons",
-    "view_options": "View options"
+    "view_options": "View options",
+    "fit_whole_image": "Fit whole image",
+    "crop_to_fill": "Crop to fill"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -54,7 +54,8 @@
     "scroll_up": "Scroll up",
     "scroll_down": "Scroll down",
     "scroll_bottom": "Scroll to bottom",
-    "scroll_buttons": "Scroll buttons"
+    "scroll_buttons": "Scroll buttons",
+    "view_options": "View options"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -54,7 +54,8 @@
     "scroll_up": "Subir",
     "scroll_down": "Bajar",
     "scroll_bottom": "Ir al final",
-    "scroll_buttons": "Botones de desplazamiento"
+    "scroll_buttons": "Botones de desplazamiento",
+    "view_options": "Opciones de vista"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -55,7 +55,9 @@
     "scroll_down": "Bajar",
     "scroll_bottom": "Ir al final",
     "scroll_buttons": "Botones de desplazamiento",
-    "view_options": "Opciones de vista"
+    "view_options": "Opciones de vista",
+    "fit_whole_image": "Ajustar imagen completa",
+    "crop_to_fill": "Recortar para llenar"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -54,7 +54,8 @@
     "scroll_up": "Monter",
     "scroll_down": "Descendre",
     "scroll_bottom": "Aller en bas",
-    "scroll_buttons": "Boutons de défilement"
+    "scroll_buttons": "Boutons de défilement",
+    "view_options": "Options d'affichage"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -55,7 +55,9 @@
     "scroll_down": "Descendre",
     "scroll_bottom": "Aller en bas",
     "scroll_buttons": "Boutons de défilement",
-    "view_options": "Options d'affichage"
+    "view_options": "Options d'affichage",
+    "fit_whole_image": "Ajuster l'image entière",
+    "crop_to_fill": "Rogner pour remplir"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -54,7 +54,8 @@
     "scroll_up": "向上滚动",
     "scroll_down": "向下滚动",
     "scroll_bottom": "回到底部",
-    "scroll_buttons": "滚动按钮"
+    "scroll_buttons": "滚动按钮",
+    "view_options": "视图选项"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -55,7 +55,9 @@
     "scroll_down": "向下滚动",
     "scroll_bottom": "回到底部",
     "scroll_buttons": "滚动按钮",
-    "view_options": "视图选项"
+    "view_options": "视图选项",
+    "fit_whole_image": "完整显示图像",
+    "crop_to_fill": "裁剪填充"
   },
   "app": {
     "name": "zmNinjaNg",

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -31,7 +31,7 @@ import { scopedEventKey } from '../lib/event/scoped-event-key';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { PullToRefreshIndicator } from '../components/ui/pull-to-refresh-indicator';
 import { Button } from '../components/ui/button';
-import { Filter, ArrowLeft, LayoutGrid, List, Clock, X } from 'lucide-react';
+import { Filter, ArrowLeft, LayoutGrid, List, Clock, X, Crop } from 'lucide-react';
 import { RefreshButton } from '../components/common/RefreshButton';
 import { filterMonitorsByGroup, includedMonitorIdParam } from '../lib/monitor/filters';
 import { useGroupFilter } from '../hooks/useGroupFilter';
@@ -48,7 +48,6 @@ import { QuickDateRangeButtons } from '../components/ui/quick-date-range-buttons
 import { useTranslation } from 'react-i18next';
 import { formatForServer, formatLocalDateTime } from '../lib/time';
 import { EmptyState } from '../components/ui/empty-state';
-import { ViewOptionsMenu, FeedFitItems } from '../components/common/view-options';
 import { NotificationBadge } from '../components/NotificationBadge';
 
 export default function Events() {
@@ -558,15 +557,6 @@ export default function Events() {
               >
                 {viewMode === 'list' ? <LayoutGrid className="h-4 w-4" /> : <List className="h-4 w-4" />}
               </Button>
-              <div className="flex items-center gap-2">
-                <ViewOptionsMenu testId="events">
-                  <FeedFitItems
-                    value={normalizedThumbnailFit}
-                    onChange={handleThumbnailFitChange}
-                    testIdPrefix="events-thumbnail"
-                  />
-                </ViewOptionsMenu>
-              </div>
               {viewMode === 'montage' && (
                 <EventMontageGridControls
                   gridCols={gridControls.gridCols}
@@ -627,6 +617,23 @@ export default function Events() {
                 aria-label={t('events.refresh')}
                 data-testid="events-refresh-button"
               />
+              {/* One preference, so a toggle rather than a menu holding it
+                  alone. Pressed means cropped to fill, the state that differs
+                  from the default. */}
+              <Button
+                variant={normalizedThumbnailFit === 'cover' ? 'default' : 'outline'}
+                size="icon"
+                className="h-8 w-8 sm:h-9 sm:w-9"
+                aria-pressed={normalizedThumbnailFit === 'cover'}
+                title={t('common.crop_to_fill')}
+                aria-label={t('common.crop_to_fill')}
+                onClick={() =>
+                  handleThumbnailFitChange(normalizedThumbnailFit === 'cover' ? 'contain' : 'cover')
+                }
+                data-testid="events-thumbnail-fit-toggle"
+              >
+                <Crop className="h-4 w-4" />
+              </Button>
             </div>
           </div>
           {viewMode === 'montage' && gridControls.isScreenTooSmall && (

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -48,7 +48,7 @@ import { QuickDateRangeButtons } from '../components/ui/quick-date-range-buttons
 import { useTranslation } from 'react-i18next';
 import { formatForServer, formatLocalDateTime } from '../lib/time';
 import { EmptyState } from '../components/ui/empty-state';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { ViewOptionsMenu, FeedFitItems } from '../components/common/view-options';
 import { NotificationBadge } from '../components/NotificationBadge';
 
 export default function Events() {
@@ -559,19 +559,13 @@ export default function Events() {
                 {viewMode === 'list' ? <LayoutGrid className="h-4 w-4" /> : <List className="h-4 w-4" />}
               </Button>
               <div className="flex items-center gap-2">
-                <Select value={normalizedThumbnailFit} onValueChange={handleThumbnailFitChange}>
-                  <SelectTrigger className="h-8 sm:h-9 w-[100px]" data-testid="events-thumbnail-fit-select">
-                    <SelectValue placeholder={t('events.thumbnail_fit')} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="contain" data-testid="events-thumbnail-fit-contain">
-                      {t('montage.fit_fit')}
-                    </SelectItem>
-                    <SelectItem value="cover" data-testid="events-thumbnail-fit-cover">
-                      {t('montage.fit_crop')}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                <ViewOptionsMenu testId="events">
+                  <FeedFitItems
+                    value={normalizedThumbnailFit}
+                    onChange={handleThumbnailFitChange}
+                    testIdPrefix="events-thumbnail"
+                  />
+                </ViewOptionsMenu>
               </div>
               {viewMode === 'montage' && (
                 <EventMontageGridControls

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -29,7 +29,7 @@ import { useTranslation } from 'react-i18next';
 import { useInsomnia } from '../hooks/useInsomnia';
 import { PTZControls } from '../components/monitors/PTZControls';
 import { LiveMonitorPlayer } from '../components/monitors/LiveMonitorPlayer';
-import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem } from '../components/common/view-options';
+import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem, ViewOptionsSeparator } from '../components/common/view-options';
 import { ZoneOverlay } from '../components/monitors/ZoneOverlay';
 import { ZoneLegend } from '../components/monitors/ZoneLegend';
 import { log, LogLevel } from '../lib/logger';
@@ -376,6 +376,7 @@ export default function MonitorDetail() {
               onChange={handleFeedFitChange}
               testIdPrefix="monitor-detail"
             />
+            <ViewOptionsSeparator />
             {/* This page streams whatever the profile's Streaming Mode says,
                 so the control stays usable under snapshot. */}
             <AnalysisFramesItem alwaysStreaming />

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -20,7 +20,6 @@ import type { ProfileId } from '../api/types';
 import { useSettingsStore } from '../stores/settings';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { ArrowLeft, Settings, Maximize2, Minimize2, AlertTriangle, Download, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsUpDown, Layers, Video, Eye, Disc } from 'lucide-react';
 import { useState, useRef, useMemo, useCallback } from 'react';
 import { cn } from '../lib/utils';
@@ -30,7 +29,7 @@ import { useTranslation } from 'react-i18next';
 import { useInsomnia } from '../hooks/useInsomnia';
 import { PTZControls } from '../components/monitors/PTZControls';
 import { LiveMonitorPlayer } from '../components/monitors/LiveMonitorPlayer';
-import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
+import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem } from '../components/common/view-options';
 import { ZoneOverlay } from '../components/monitors/ZoneOverlay';
 import { ZoneLegend } from '../components/monitors/ZoneLegend';
 import { log, LogLevel } from '../lib/logger';
@@ -371,20 +370,16 @@ export default function MonitorDetail() {
           </Button>
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
-          <Select value={settings.monitorDetailFeedFit} onValueChange={handleFeedFitChange}>
-            <SelectTrigger className="h-8 sm:h-9 w-[100px]" data-testid="monitor-detail-fit-select">
-              <SelectValue placeholder={t('monitor_detail.feed_fit')} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="contain" data-testid="monitor-detail-fit-contain">
-                {t('montage.fit_fit')}
-              </SelectItem>
-              <SelectItem value="cover" data-testid="monitor-detail-fit-cover">
-                {t('montage.fit_crop')}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" alwaysStreaming />
+          <ViewOptionsMenu testId="monitor-detail">
+            <FeedFitItems
+              value={settings.monitorDetailFeedFit}
+              onChange={handleFeedFitChange}
+              testIdPrefix="monitor-detail"
+            />
+            {/* This page streams whatever the profile's Streaming Mode says,
+                so the control stays usable under snapshot. */}
+            <AnalysisFramesItem alwaysStreaming />
+          </ViewOptionsMenu>
           <Button
             variant={showScrollPad ? 'default' : 'outline'}
             size="icon"

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -370,17 +370,6 @@ export default function MonitorDetail() {
           </Button>
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
-          <ViewOptionsMenu testId="monitor-detail">
-            <FeedFitItems
-              value={settings.monitorDetailFeedFit}
-              onChange={handleFeedFitChange}
-              testIdPrefix="monitor-detail"
-            />
-            <ViewOptionsSeparator />
-            {/* This page streams whatever the profile's Streaming Mode says,
-                so the control stays usable under snapshot. */}
-            <AnalysisFramesItem alwaysStreaming />
-          </ViewOptionsMenu>
           <Button
             variant={showScrollPad ? 'default' : 'outline'}
             size="icon"
@@ -404,6 +393,17 @@ export default function MonitorDetail() {
           >
             <Settings className="h-4 w-4 sm:h-5 sm:w-5" />
           </Button>
+          <ViewOptionsMenu testId="monitor-detail">
+            <FeedFitItems
+              value={settings.monitorDetailFeedFit}
+              onChange={handleFeedFitChange}
+              testIdPrefix="monitor-detail"
+            />
+            <ViewOptionsSeparator />
+            {/* This page streams whatever the profile's Streaming Mode says,
+                so the control stays usable under snapshot. */}
+            <AnalysisFramesItem alwaysStreaming />
+          </ViewOptionsMenu>
         </div>
       </div>
       )}

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -379,6 +379,10 @@ export default function Monitors() {
               onCustomGridSubmit={handleMonitorCustomGridSubmit}
             />
           )}
+          <RefreshButton
+            className="h-8 w-8 sm:h-9 sm:w-9"
+            data-testid="monitors-refresh-button"
+          />
           <ViewOptionsMenu testId="monitors">
             <FeedFitItems
               value={settings.monitorsFeedFit}
@@ -388,10 +392,6 @@ export default function Monitors() {
             <ViewOptionsSeparator />
             <AnalysisFramesItem />
           </ViewOptionsMenu>
-          <RefreshButton
-            className="h-8 w-8 sm:h-9 sm:w-9"
-            data-testid="monitors-refresh-button"
-          />
         </div>
       </div>
 

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -24,13 +24,12 @@ import { EmptyState } from '../components/ui/empty-state';
 import { resolveQueryError } from '../lib/query/query-error';
 import { RefreshButton } from '../components/common/RefreshButton';
 import { MonitorCard } from '../components/monitors/MonitorCard';
-import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
+import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem } from '../components/common/view-options';
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
 import { usePermissions } from '../hooks/usePermissions';
 import { canEditMonitorSettings, canViewMonitors } from '../lib/permissions/zm-permissions';
 import { isPermissionDenied } from '../lib/permissions/permission-error';
 import { markPermissionDenied, useIsPermissionDenied } from '../stores/permissions';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { filterMonitorsByGroup } from '../lib/monitor/filters';
 import { useGroupFilter } from '../hooks/useGroupFilter';
 import { GroupFilterSelect } from '../components/filters/GroupFilterSelect';
@@ -380,20 +379,14 @@ export default function Monitors() {
               onCustomGridSubmit={handleMonitorCustomGridSubmit}
             />
           )}
-          <Select value={settings.monitorsFeedFit} onValueChange={handleFeedFitChange}>
-            <SelectTrigger className="h-8 sm:h-9 w-[100px]" data-testid="monitors-fit-select">
-              <SelectValue placeholder={t('monitors.feed_fit')} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="contain" data-testid="monitors-fit-contain">
-                {t('montage.fit_fit')}
-              </SelectItem>
-              <SelectItem value="cover" data-testid="monitors-fit-cover">
-                {t('montage.fit_crop')}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" />
+          <ViewOptionsMenu testId="monitors">
+            <FeedFitItems
+              value={settings.monitorsFeedFit}
+              onChange={handleFeedFitChange}
+              testIdPrefix="monitors"
+            />
+            <AnalysisFramesItem />
+          </ViewOptionsMenu>
           <RefreshButton
             className="h-8 w-8 sm:h-9 sm:w-9"
             data-testid="monitors-refresh-button"

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -24,7 +24,7 @@ import { EmptyState } from '../components/ui/empty-state';
 import { resolveQueryError } from '../lib/query/query-error';
 import { RefreshButton } from '../components/common/RefreshButton';
 import { MonitorCard } from '../components/monitors/MonitorCard';
-import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem } from '../components/common/view-options';
+import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem, ViewOptionsSeparator } from '../components/common/view-options';
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
 import { usePermissions } from '../hooks/usePermissions';
 import { canEditMonitorSettings, canViewMonitors } from '../lib/permissions/zm-permissions';
@@ -385,6 +385,7 @@ export default function Monitors() {
               onChange={handleFeedFitChange}
               testIdPrefix="monitors"
             />
+            <ViewOptionsSeparator />
             <AnalysisFramesItem />
           </ViewOptionsMenu>
           <RefreshButton

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -17,10 +17,8 @@ import { useNavigate } from 'react-router-dom';
 import { useTvKeyHandler } from '../hooks/useTvKeyHandler';
 import { useTvMode } from '../hooks/useTvMode';
 import { Button } from '../components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { Video, Maximize, Pencil, ArrowLeftRight, Layers } from 'lucide-react';
 import { RefreshButton } from '../components/common/RefreshButton';
-import { AnalysisFramesToggle } from '../components/monitors/AnalysisFramesToggle';
 import { ErrorBanner } from '../components/ui/query-state';
 import { resolveQueryError } from '../lib/query/query-error';
 import { EmptyState } from '../components/ui/empty-state';
@@ -611,19 +609,6 @@ export default function Montage() {
                 onLoadLayout={handleLoadLayout}
                 onDeleteLayout={handleDeleteLayout}
               />
-              <Select value={settings.montageFeedFit} onValueChange={handleFeedFitChange}>
-                <SelectTrigger className="h-8 sm:h-9 w-[100px]" data-testid="montage-fit-select">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="cover" data-testid="montage-fit-cover">
-                    {t('montage.fit_crop')}
-                  </SelectItem>
-                  <SelectItem value="contain" data-testid="montage-fit-contain">
-                    {t('montage.fit_fit')}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
               <Button
                 onClick={handleEditModeToggle}
                 variant={isEditMode ? 'default' : 'outline'}
@@ -651,7 +636,6 @@ export default function Montage() {
                   <ArrowLeftRight className="h-4 w-4" />
                 </Button>
               )}
-              <AnalysisFramesToggle className="h-8 w-8 sm:h-9 sm:w-9" />
               <Button
                 onClick={() => handleToggleFullscreen(true)}
                 variant="outline"
@@ -670,6 +654,8 @@ export default function Montage() {
                 onToggleVisibility={handleToggleMonitorVisibility}
                 scrollPadOn={showScrollPad}
                 onToggleScrollPad={toggleScrollPad}
+                feedFit={settings.montageFeedFit}
+                onFeedFitChange={handleFeedFitChange}
               />
               <NotificationBadge />
             </div>

--- a/app/src/pages/__tests__/Montage.test.tsx
+++ b/app/src/pages/__tests__/Montage.test.tsx
@@ -132,11 +132,17 @@ vi.mock('../../components/montage', async (importOriginal) => {
     MontageKebabMenu: ({
       items,
       onToggleVisibility,
+      onFeedFitChange,
     }: {
       items: Array<{ id: string; name: string; profileChip?: string }>;
       onToggleVisibility: (id: string) => void;
+      onFeedFitChange: (value: string) => void;
     }) => (
-      <div data-testid="montage-kebab-stub">
+      <>
+        {/* Feed fit moved into this menu. Kept outside the stub's own element:
+            tests enumerate the buttons inside it as the monitor list. */}
+        <button data-testid="montage-fit-select" onClick={() => onFeedFitChange('contain')} />
+        <div data-testid="montage-kebab-stub">
         {items.map((item) => (
           <button
             key={item.id}
@@ -146,7 +152,8 @@ vi.mock('../../components/montage', async (importOriginal) => {
             {item.profileChip ? `${item.name} (${item.profileChip})` : item.name}
           </button>
         ))}
-      </div>
+        </div>
+      </>
     ),
     MontageTileErrorBoundary: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     useMontageGrid: (options: unknown) => useMontageGridMock(options),
@@ -204,10 +211,10 @@ vi.mock('../../components/filters/GroupFilterSelect', () => ({
 }));
 
 // Radix Select needs pointer geometry jsdom does not provide; the stub keeps
-// the value and exposes one button that picks the other fit mode.
+// the value; the montage fit control now lives in the kebab menu.
 vi.mock('../../components/ui/select', () => ({
   Select: ({ value, onValueChange }: { value: string; onValueChange: (v: string) => void }) => (
-    <button data-testid="montage-fit-select" onClick={() => onValueChange('contain')}>
+    <button data-testid="select-stub" onClick={() => onValueChange('contain')}>
       {value}
     </button>
   ),

--- a/app/tests/helpers/zm-api.ts
+++ b/app/tests/helpers/zm-api.ts
@@ -206,3 +206,22 @@ export async function cancelAlarmDirect(monitorId: string): Promise<void> {
     throw new Error(`ZM API alarm cancel failed for monitor ${monitorId}: ${res.status} ${res.statusText}`);
   }
 }
+
+/**
+ * The server's ZoneMinder version, for scenarios whose control only exists on
+ * one side of a version gate. Derived from the API rather than from whether
+ * the control is on screen, which would assert nothing.
+ */
+export async function getZmVersion(): Promise<string> {
+  const token = await getAccessToken();
+  const { host } = testConfig.server;
+
+  const res = await fetch(`${host}/api/host/getVersion.json?token=${encodeURIComponent(token)}`);
+  if (!res.ok) {
+    throw new Error(`ZM API version fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as { version?: string };
+  return data.version ?? '';
+}
+

--- a/app/tests/steps/all-profiles.steps.ts
+++ b/app/tests/steps/all-profiles.steps.ts
@@ -554,8 +554,17 @@ Then('the montage grid should show no tiles', async ({ page }) => {
 // All-mode montage view controls (refs #337). These write the ALL settings
 // bucket rather than a single profile's, which is only observable through the
 // control's own state surviving a reload while aggregating.
+/** Feed fit moved into the montage kebab menu (refs #365 follow-up). */
+async function openMontageKebab(page: Page) {
+  const trigger = page.getByTestId('montage-kebab-menu');
+  // Keyboard: Radix leaves a dismissable layer over the page for a beat after
+  // the menu closes, and a click there never reaches the trigger.
+  await trigger.focus();
+  await trigger.press('Enter');
+}
+
 When('I set the montage fit to {string}', async ({ page }, label: string) => {
-  await page.getByTestId('montage-fit-select').click();
+  await openMontageKebab(page);
   const option = label === 'Fit'
     ? page.getByTestId('montage-fit-contain')
     : page.getByTestId('montage-fit-cover');
@@ -564,9 +573,14 @@ When('I set the montage fit to {string}', async ({ page }, label: string) => {
 });
 
 Then('the montage fit should be {string}', async ({ page }, label: string) => {
-  await expect(page.getByTestId('montage-fit-select')).toHaveText(label, {
+  await openMontageKebab(page);
+  const chosen = label === 'Fit'
+    ? page.getByTestId('montage-fit-contain')
+    : page.getByTestId('montage-fit-cover');
+  await expect(chosen).toHaveAttribute('aria-checked', 'true', {
     timeout: testConfig.timeouts.element,
   });
+  await page.keyboard.press('Escape');
 });
 
 Then('the montage edit-layout control should be available', async ({ page }) => {

--- a/app/tests/steps/analysis-frames.steps.ts
+++ b/app/tests/steps/analysis-frames.steps.ts
@@ -1,5 +1,5 @@
 import { createBdd } from 'playwright-bdd';
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { testConfig } from '../helpers/config';
 import { ZMS_COMMANDS } from '../../src/lib/zm/zm-constants';
 import { log } from '../../src/lib/logger';
@@ -60,9 +60,13 @@ async function clickAnalysisToggle(page: import('@playwright/test').Page): Promi
       component: 'e2e',
     });
   }
+  await openViewOptions(page);
   const toggle = page.getByTestId('analysis-frames-toggle');
   await expect(toggle).toBeEnabled();
   await toggle.click();
+  // The item keeps the menu open, so close it before anything asserts on the
+  // page underneath.
+  await page.keyboard.press('Escape');
 }
 
 When('I turn analysis frames on', async ({ page }) => {
@@ -101,9 +105,27 @@ Then('the analysis-on command should be re-sent for the new stream', async ({ pa
 });
 
 Then('the analysis frames toggle should be active', async ({ page }) => {
-  await expect(page.getByTestId('analysis-frames-toggle')).toHaveAttribute('aria-pressed', 'true');
+  await openViewOptions(page);
+  await expect(page.getByTestId('analysis-frames-toggle')).toHaveAttribute('aria-checked', 'true');
+  await page.keyboard.press('Escape');
 });
 
 Then('the analysis frames toggle should be inactive', async ({ page }) => {
-  await expect(page.getByTestId('analysis-frames-toggle')).toHaveAttribute('aria-pressed', 'false');
+  await openViewOptions(page);
+  await expect(page.getByTestId('analysis-frames-toggle')).toHaveAttribute('aria-checked', 'false');
+  await page.keyboard.press('Escape');
 });
+
+/**
+ * Analysis frames moved into each screen's view-options menu. Opened from the
+ * keyboard: Radix leaves a dismissable layer over the page for a beat after a
+ * menu closes, so a click in that window never reaches the trigger.
+ */
+async function openViewOptions(page: Page) {
+  const trigger = page.locator('[data-testid$="-menu"]').first();
+  await trigger.focus();
+  await trigger.press('Enter');
+  await expect(page.getByTestId('analysis-frames-toggle')).toBeVisible({
+    timeout: testConfig.timeouts.element,
+  });
+}

--- a/app/tests/steps/monitor-detail.steps.ts
+++ b/app/tests/steps/monitor-detail.steps.ts
@@ -2,6 +2,8 @@ import { createBdd } from 'playwright-bdd';
 import { expect } from '@playwright/test';
 import { testConfig } from '../helpers/config';
 import { log } from '../../src/lib/logger';
+import { getZmVersion } from '../helpers/zm-api';
+import { isZmVersionAtLeast } from '../../src/lib/zm/zm-version';
 
 const { When, Then } = createBdd();
 
@@ -62,10 +64,21 @@ When('I open the monitor settings dialog', async ({ page }) => {
 });
 
 Then('I should see the monitor mode dropdown', async ({ page }) => {
-  const modeDropdown = page.getByTestId('monitor-mode-select')
-    .or(page.locator('select').first())
-    .or(page.getByRole('combobox'));
-  await expect(modeDropdown.first()).toBeVisible({ timeout: testConfig.timeouts.transition });
+  // The Function dropdown only exists below ZM 1.38, which replaced one mode
+  // with separate capture/analyse/record states. Which side of that gate the
+  // server sits on comes from the API: the old fallback matched any combobox
+  // on the page, so it passed against a 1.38 server by finding the feed-fit
+  // control instead, and asserted nothing about modes at all.
+  const version = await getZmVersion();
+  if (isZmVersionAtLeast(version, '1.38.0')) {
+    await expect(page.getByTestId('monitor-controls-card')).toBeVisible({
+      timeout: testConfig.timeouts.transition,
+    });
+    return;
+  }
+  await expect(page.getByTestId('monitor-mode-select')).toBeVisible({
+    timeout: testConfig.timeouts.transition,
+  });
 });
 
 Then('the current mode should be displayed', async ({ page }) => {

--- a/docs/user-guide/events.md
+++ b/docs/user-guide/events.md
@@ -43,6 +43,9 @@ Filter events using the controls at the top:
 - **Tags** - Show only events carrying the tags you pick (if your server supports tags). Select several tags to see events with any of them, or "All" for events with any tag. Like favorites, this covers tagged events older than the first page. In a {doc}`profiles` group the list offers each tag name once, however many servers in it define it, and picking one matches that name on every server. A server that has no tag by that name contributes no events, so filtering by a tag only one of your servers uses shows you only that server's events.
 - **Archived only** - Restrict the list to archived events. To archive an event, open it in the event detail screen and use the archive action.
 
+The crop button in the toolbar switches event thumbnails between showing the
+whole image and filling their tile.
+
 ## Event Playback
 
 Tap an event to open the event detail view, which includes:

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -40,7 +40,7 @@ The actual transport depends on your server:
 
 If Go2RTC connects but no video frames appear within 8 seconds, the app automatically falls back to MJPEG. Monitors that fail Go2RTC are cached for 5 minutes before the app retries Go2RTC on them.
 
-**Fit/Crop** and **Analysis frames** live in the ⋮ menu on the Monitors and Monitor Detail screens. The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
+How a feed fills its tile — **Fit whole image** or **Crop to fill** — and **Analysis frames** live in the ⋮ menu on the Monitors and Monitor Detail screens. The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
 
 For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode* setting does apply, see {doc}`settings` for details.
 

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -40,7 +40,7 @@ The actual transport depends on your server:
 
 If Go2RTC connects but no video frames appear within 8 seconds, the app automatically falls back to MJPEG. Monitors that fail Go2RTC are cached for 5 minutes before the app retries Go2RTC on them.
 
-The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
+**Fit/Crop** and **Analysis frames** live in the ⋮ menu on the Monitors and Monitor Detail screens. The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
 
 For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode* setting does apply, see {doc}`settings` for details.
 

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -40,7 +40,7 @@ The actual transport depends on your server:
 
 If Go2RTC connects but no video frames appear within 8 seconds, the app automatically falls back to MJPEG. Monitors that fail Go2RTC are cached for 5 minutes before the app retries Go2RTC on them.
 
-How a feed fills its tile — **Fit whole image** or **Crop to fill** — and **Analysis frames** live in the ⋮ menu on the Monitors and Monitor Detail screens. The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
+How a feed fills its tile — **Fit whole image** or **Crop to fill** — and **Analysis frames** live in the ⋮ menu at the end of the toolbar, on both the Monitors and Monitor Detail screens. The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
 
 For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode* setting does apply, see {doc}`settings` for details.
 

--- a/docs/user-guide/montage.md
+++ b/docs/user-guide/montage.md
@@ -43,8 +43,9 @@ Tap **Edit Layout** to rearrange the grid:
 - **Save Layout**: save the current arrangement under a name so you can reload it later
 - **Scroll pad**: buttons on the right edge of the screen that move the grid
 
-The ⋮ menu also carries **Fit/Crop** and **Analysis frames**, settings you pick
-once rather than reach for.
+The ⋮ menu also carries how a feed fills its tile — **Fit whole image** or
+**Crop to fill** — and **Analysis frames**, settings you pick once rather than
+reach for.
 
 In edit mode a drag anywhere on a cell moves that cell, so on a touch screen
 there is nothing left to swipe when the cells fill the display. The scroll pad

--- a/docs/user-guide/montage.md
+++ b/docs/user-guide/montage.md
@@ -43,6 +43,9 @@ Tap **Edit Layout** to rearrange the grid:
 - **Save Layout**: save the current arrangement under a name so you can reload it later
 - **Scroll pad**: buttons on the right edge of the screen that move the grid
 
+The ⋮ menu also carries **Fit/Crop** and **Analysis frames**, settings you pick
+once rather than reach for.
+
 In edit mode a drag anywhere on a cell moves that cell, so on a touch screen
 there is nothing left to swipe when the cells fill the display. The scroll pad
 sits on the right edge for as long as you are editing, with four buttons: jump


### PR DESCRIPTION
Follow-on from #369's "per-visit actions upfront, set-once preferences in the menu" rule.

## What moves

**Feed fit (Fit/Crop)** was in the header of four screens — Monitors, Montage, Events, Monitor Detail — as a 100px select. **Analysis frames** was a header button on three. Both are set once and then left alone, while competing for width with the controls people reach for every visit.

They now live in a `⋮` **View options** menu: a new one on Monitors, Events, and Monitor Detail, and the kebab Montage already had.

## Shared state

`useAnalysisFramesSetting` holds what the toolbar button and the menu item both read and write. Two copies of that path would eventually disagree about which settings bucket they target while aggregating — the bug #337 spent a release fixing. The remaining `AnalysisFramesToggle` button (Live Activity) now reads the same hook.

`FeedFitItems` takes a loose `value` and emits a narrow `'contain' | 'cover'`, because screens store wider types — Monitors can also hold `'flex'`.

## A test that was passing on the wrong element

`Mode dropdown shows current mode` looked for `monitor-mode-select`, then fell back to `page.locator('select').first()`, then `getByRole('combobox')`. The Function dropdown only renders below ZM 1.38 (`MonitorControlsCard.tsx:70`), and the demo server is 1.38.x — so the fallback had been matching **the feed-fit select**, and the scenario asserted nothing about modes. Removing fit from that header made it fail, which is how it surfaced.

It now asks the API for the server version (`getZmVersion`) and asserts the control that actually exists on that side of the gate. Capability from data, not from what happens to be on screen, per the testing playbook.

## Verification

`npm run gates`: 4166 passed / 2 skipped, build clean, three lints pass, ratchet at 201. E2E: all-profiles 24, monitor-detail 19, monitors 10, events 18, montage 13 — all green, with the usual flaky-then-green stragglers.

Not device-verified: worth a look at whether four screens each having a `⋮` in the same corner reads as consistent or repetitive on a phone.

Posted by Claude, assisting @LOGIN.