### PR TITLE
Open a monitor from a Live Activity tile, and preview it on hover

### DIFF
--- a/app/src/components/live-activity/LiveActivityGridBody.tsx
+++ b/app/src/components/live-activity/LiveActivityGridBody.tsx
@@ -36,6 +36,8 @@ interface LiveActivityGridBodyProps {
   resolveOwnerProfile: (profileId: ProfileId | undefined) => Profile | null;
   accessToken: string | null;
   navigate: NavigateFunction;
+  /** Whether a tile's video opens the enlarged preview on hover. */
+  hoverPreview: boolean;
   now: number;
   onDismiss: (monitorId: string) => void;
   /** Tiles beyond liveActivityMaxTiles, collapsed into a count. */
@@ -60,6 +62,7 @@ export function LiveActivityGridBody({
   resolveOwnerProfile,
   accessToken,
   navigate,
+  hoverPreview,
   now,
   onDismiss,
   overflowCount,
@@ -132,6 +135,7 @@ export function LiveActivityGridBody({
                 profileChip={monitorData.profileChip}
                 accessToken={accessToken}
                 navigate={navigate}
+                hoverPreview={hoverPreview}
                 now={now}
                 // Recomputed per render, but it only ever changes with the
                 // grid width, the column count or the camera's own shape, so

--- a/app/src/components/live-activity/LiveActivityTile.tsx
+++ b/app/src/components/live-activity/LiveActivityTile.tsx
@@ -7,7 +7,7 @@
  * already near its size limit.
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import type { NavigateFunction } from 'react-router-dom';
@@ -85,6 +85,17 @@ export function LiveActivityTile({
     getMonitorAspectRatio(monitor.Width, monitor.Height, monitor.Orientation) ??
     MONITOR_UI.fallbackAspectRatio;
 
+  // Stable identity: the elapsed label re-renders this component every second,
+  // and a fresh function here would defeat MontageMonitor's memo and re-render
+  // live video with it. Deep route while aggregating, so the monitor opens
+  // against its own server without switching the active profile (refs #337).
+  const openMonitor = useCallback(() => {
+    navigate(
+      profileId ? `/all/monitors/${profileId}/${monitor.Id}` : `/monitors/${monitor.Id}`,
+      { state: { from: '/live-activity' } },
+    );
+  }, [navigate, profileId, monitor.Id]);
+
   return (
     <div
       // Enter: a tile fades and scales up over 200ms instead of popping into
@@ -139,6 +150,11 @@ export function LiveActivityTile({
         titleIcon={titleIcon}
         mediaAspectRatio={mediaAspectRatio}
         fromRoute="/live-activity"
+        // Montage opens a monitor from a wrapper around the whole tile; this
+        // page has none, so the media area is the target. Deep route while
+        // aggregating, so the monitor opens against its own server without
+        // switching the active profile first (refs #337).
+        onMediaActivate={openMonitor}
       />
       {/* Sits where the alarm-count badge used to, clear of the tile header's
           own buttons. stopPropagation so clearing a tile never doubles as a

--- a/app/src/components/live-activity/LiveActivityTile.tsx
+++ b/app/src/components/live-activity/LiveActivityTile.tsx
@@ -29,6 +29,8 @@ interface LiveActivityTileProps {
   currentProfile: Profile | null;
   accessToken: string | null;
   navigate: NavigateFunction;
+  /** Whether a tile's video opens the enlarged preview on hover. */
+  hoverPreview: boolean;
   /** All mode only: the owning profile's id/display name, threaded straight
    *  through to MontageMonitor (its LiveMonitorPlayer cache-key scoping,
    *  events watermark, and profile chip). Undefined in single mode. */
@@ -54,6 +56,7 @@ export function LiveActivityTile({
   currentProfile,
   accessToken,
   navigate,
+  hoverPreview,
   profileId,
   profileChip,
   now,
@@ -150,6 +153,7 @@ export function LiveActivityTile({
         titleIcon={titleIcon}
         mediaAspectRatio={mediaAspectRatio}
         fromRoute="/live-activity"
+        hoverPreview={hoverPreview}
         // Montage opens a monitor from a wrapper around the whole tile; this
         // page has none, so the media area is the target. Deep route while
         // aggregating, so the monitor opens against its own server without

--- a/app/src/components/live-activity/__tests__/LiveActivityTile.test.tsx
+++ b/app/src/components/live-activity/__tests__/LiveActivityTile.test.tsx
@@ -64,6 +64,7 @@ function renderTile(now: number, entry: ActiveMonitorEntry = ENTRY) {
       now={now}
       rowSpan={ROW_SPAN}
       onDismiss={onDismiss}
+      hoverPreview={false}
     />
   );
 }
@@ -114,6 +115,7 @@ describe('LiveActivityTile', () => {
         now={EPISODE_START + 5_000}
         rowSpan={ROW_SPAN}
         onDismiss={onDismiss}
+        hoverPreview={false}
       />
     );
 
@@ -150,6 +152,7 @@ describe('LiveActivityTile', () => {
         now={EPISODE_START}
         rowSpan={undefined}
         onDismiss={onDismiss}
+        hoverPreview={false}
       />
     );
     expect(screen.getByTestId('live-activity-tile').style.gridRowEnd).toBe('');
@@ -188,6 +191,7 @@ describe('LiveActivityTile', () => {
         now={EPISODE_START}
         rowSpan={ROW_SPAN}
         onDismiss={onDismiss}
+        hoverPreview={false}
       />
     );
     const [w, h] = String(propCalls[0].mediaAspectRatio).split('/').map(Number);
@@ -236,6 +240,7 @@ describe('LiveActivityTile', () => {
         now={EPISODE_START + 1_000}
         rowSpan={ROW_SPAN}
         onDismiss={onDismiss}
+        hoverPreview={false}
       />
     );
 
@@ -265,6 +270,7 @@ describe('LiveActivityTile', () => {
         now={EPISODE_START}
         rowSpan={ROW_SPAN}
         onDismiss={onDismiss}
+        hoverPreview={false}
         profileId={'p2' as ProfileId}
       />
     );
@@ -275,5 +281,26 @@ describe('LiveActivityTile', () => {
     expect(navigate).toHaveBeenCalledWith('/all/monitors/p2/3', {
       state: { from: '/live-activity' },
     });
+  });
+
+  it('passes the hover-preview setting through to the monitor', () => {
+    render(
+      <LiveActivityTile
+        entry={ENTRY}
+        monitor={MONITOR}
+        status={undefined}
+        currentProfile={PROFILE}
+        accessToken="t"
+        navigate={navigate}
+        now={EPISODE_START}
+        rowSpan={ROW_SPAN}
+        onDismiss={onDismiss}
+        hoverPreview
+      />
+    );
+
+    // A four-link prop chain from the page's settings to the player is where
+    // a wire quietly comes loose.
+    expect(propCalls.at(-1)!.hoverPreview).toBe(true);
   });
 });

--- a/app/src/components/live-activity/__tests__/LiveActivityTile.test.tsx
+++ b/app/src/components/live-activity/__tests__/LiveActivityTile.test.tsx
@@ -13,6 +13,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { LiveActivityTile } from '../LiveActivityTile';
 import type { ActiveMonitorEntry } from '../../../lib/monitor/live-activity';
 import type { Monitor, Profile } from '../../../api/types';
+import type { ProfileId } from '../../../api/types';
 
 const propCalls = vi.hoisted(() => [] as Record<string, unknown>[]);
 
@@ -239,5 +240,40 @@ describe('LiveActivityTile', () => {
     );
 
     expect(Object.is(propCalls[0].titleIcon, propCalls[1].titleIcon)).toBe(false);
+  });
+
+  it('opens the monitor when its media is activated', () => {
+    renderTile(EPISODE_START);
+
+    // Montage navigates from a wrapper around the whole tile; this page has no
+    // such wrapper, so the media area carries it.
+    const props = propCalls.at(-1)!;
+    (props.onMediaActivate as () => void)();
+
+    expect(navigate).toHaveBeenCalledWith('/monitors/3', { state: { from: '/live-activity' } });
+  });
+
+  it('opens the owning server monitor while aggregating', () => {
+    render(
+      <LiveActivityTile
+        entry={ENTRY}
+        monitor={MONITOR}
+        status={undefined}
+        currentProfile={PROFILE}
+        accessToken="t"
+        navigate={navigate}
+        now={EPISODE_START}
+        rowSpan={ROW_SPAN}
+        onDismiss={onDismiss}
+        profileId={'p2' as ProfileId}
+      />
+    );
+
+    const props = propCalls.at(-1)!;
+    (props.onMediaActivate as () => void)();
+
+    expect(navigate).toHaveBeenCalledWith('/all/monitors/p2/3', {
+      state: { from: '/live-activity' },
+    });
   });
 });

--- a/app/src/components/monitors/MontageMonitor.tsx
+++ b/app/src/components/monitors/MontageMonitor.tsx
@@ -104,6 +104,15 @@ interface MontageMonitorProps {
    */
   fromRoute?: string;
   /**
+   * Opens this monitor. Montage puts the same navigation on its grid wrapper,
+   * which gives one tab stop per tile; Live Activity has no such wrapper, so
+   * the media area itself becomes the target. It holds only the player and
+   * pointer-events-none labels, so nothing interactive ends up nested inside
+   * a button - unlike the whole-tile version, which wraps the header's own
+   * buttons.
+   */
+  onMediaActivate?: () => void;
+  /**
    * Ask ZM for a cheaper stream for this tile (All-mode "reduced" stream
    * tuning, refs #337). Decided by the page - Montage sets it while
    * aggregating, Live Activity does not - and forwarded untouched to the
@@ -143,6 +152,7 @@ function MontageMonitorComponent({
   titleIcon,
   mediaAspectRatio,
   fromRoute = '/montage',
+  onMediaActivate,
   reduceStream = false,
   paused = false,
   forceViewMode,
@@ -362,9 +372,10 @@ function MontageMonitorComponent({
         </div>
       </div>
 
-      {/* Video Content. Click/keyboard navigation to monitor detail lives on
-          the tile wrapper in Montage.tsx (one tab stop per tile, not two);
-          this div just needs the pointer cursor hint. refs #217. */}
+      {/* Video Content. In Montage the click and keyboard navigation live on
+          the tile wrapper (one tab stop per tile, not two) and this div only
+          needs the pointer cursor hint; where there is no such wrapper, the
+          caller passes onMediaActivate and this becomes the target. refs #217 */}
       <div
         className={cn(
           "relative overflow-hidden",
@@ -374,9 +385,26 @@ function MontageMonitorComponent({
           // own. Without one nothing changes for Montage.
           mediaAspectRatio ? "w-full shrink-0" : "flex-1",
           isFullscreen ? "bg-black" : "bg-black/90",
-          !isFullscreen && "cursor-pointer"
+          !isFullscreen && "cursor-pointer",
+          // Hover and focus both say "this opens", since a wall of tiles gives
+          // no other clue that one is a link.
+          onMediaActivate &&
+            "ring-inset hover:ring-2 hover:ring-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         )}
         style={mediaAspectRatio ? { aspectRatio: mediaAspectRatio } : undefined}
+        role={onMediaActivate ? 'button' : undefined}
+        tabIndex={onMediaActivate ? 0 : undefined}
+        aria-label={onMediaActivate ? monitor.Name : undefined}
+        onClick={onMediaActivate}
+        onKeyDown={
+          onMediaActivate
+            ? (e) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                e.preventDefault();
+                onMediaActivate();
+              }
+            : undefined
+        }
         data-testid="montage-monitor-media"
       >
         <LiveMonitorPlayer

--- a/app/src/components/monitors/MontageMonitor.tsx
+++ b/app/src/components/monitors/MontageMonitor.tsx
@@ -25,6 +25,7 @@ import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { ProfileChip } from '../ui/profile-chip';
 import { LiveMonitorPlayer } from './LiveMonitorPlayer';
+import { MonitorHoverPreview } from './MonitorHoverPreview';
 import { Clock, ChartGantt, Download, Volume2, VolumeX, Pin, MoreVertical } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { downloadSnapshotFromElement } from '../../services/download';
@@ -113,6 +114,11 @@ interface MontageMonitorProps {
    */
   onMediaActivate?: () => void;
   /**
+   * Wraps the player in the enlarged hover preview, as the monitor cards do.
+   * The caller decides, because the setting that gates it is per surface.
+   */
+  hoverPreview?: boolean;
+  /**
    * Ask ZM for a cheaper stream for this tile (All-mode "reduced" stream
    * tuning, refs #337). Decided by the page - Montage sets it while
    * aggregating, Live Activity does not - and forwarded untouched to the
@@ -153,6 +159,7 @@ function MontageMonitorComponent({
   mediaAspectRatio,
   fromRoute = '/montage',
   onMediaActivate,
+  hoverPreview = false,
   reduceStream = false,
   paused = false,
   forceViewMode,
@@ -407,19 +414,32 @@ function MontageMonitorComponent({
         }
         data-testid="montage-monitor-media"
       >
-        <LiveMonitorPlayer
-          monitor={monitor}
-          profile={currentProfile}
-          profileId={profileId}
-          externalMediaRef={mediaRef}
-          objectFit={resolvedFit}
-          muted={isMuted}
-          className="w-full h-full"
-          onProtocolChange={setProtocol}
-          reduceStream={reduceStream}
-          paused={paused}
-          forceViewMode={forceViewMode}
-        />
+        {(() => {
+          const player = (
+            <LiveMonitorPlayer
+              monitor={monitor}
+              profile={currentProfile}
+              profileId={profileId}
+              externalMediaRef={mediaRef}
+              objectFit={resolvedFit}
+              muted={isMuted}
+              className="w-full h-full"
+              onProtocolChange={setProtocol}
+              reduceStream={reduceStream}
+              paused={paused}
+              forceViewMode={forceViewMode}
+            />
+          );
+          // Same wrapper the monitor cards use, so the preview behaves the
+          // same everywhere: desktop only, its own connkey, torn down on close.
+          return hoverPreview ? (
+            <MonitorHoverPreview monitor={monitor} profileId={profileId}>
+              {player}
+            </MonitorHoverPreview>
+          ) : (
+            player
+          );
+        })()}
         {settings.montageShowToolbar && settings.showProtocolLabel && (
           <span className="absolute bottom-1.5 right-1.5 z-30 text-[10px] px-1.5 py-0.5 rounded bg-black/50 text-white/90 font-medium pointer-events-none">
             {protocol}

--- a/app/src/components/monitors/__tests__/MontageMonitor.test.tsx
+++ b/app/src/components/monitors/__tests__/MontageMonitor.test.tsx
@@ -102,11 +102,25 @@ vi.mock('../../../hooks/useServerUrls', () => ({
   }),
 }));
 
-vi.mock('../../../stores/auth', () => ({
-  useAuthStore: (selector: (state: { version: string }) => unknown) =>
-    selector({ version: '1.38.0' }),
-  useAuthSlice: () => ({ version: '1.38.0' }),
-}));
+// Partial: the hover preview this component can now wrap its player in pulls
+// in the stream lifecycle, which registers its resolver against this module on
+// import. A hand-listed mock drops that export and the whole file fails to
+// load rather than any one test failing.
+// The hover preview this component can now wrap its player in pulls in the
+// stream lifecycle, which registers a resolver against this module and
+// subscribes to the store. Keep the hand-written selector shape the tests
+// rely on, and add what the new import path needs.
+vi.mock('../../../stores/auth', () => {
+  const useAuthStore = Object.assign(
+    (selector: (state: { version: string }) => unknown) => selector({ version: '1.38.0' }),
+    { subscribe: () => () => {}, getState: () => ({ version: '1.38.0' }) },
+  );
+  return {
+    useAuthStore,
+    useAuthSlice: () => ({ version: '1.38.0' }),
+    registerAuthClientResolver: () => {},
+  };
+});
 
 vi.mock('../../../stores/notifications', () => {
   const state = { profileEvents: {} };

--- a/app/src/components/settings/AppearanceSection.tsx
+++ b/app/src/components/settings/AppearanceSection.tsx
@@ -284,6 +284,7 @@ function HoverPreviewEditor({ value, onChange, playbackRate, onPlaybackRateChang
     { key: 'timeline', labelKey: 'settings.appearance.hover_preview.timeline' },
     { key: 'notifications', labelKey: 'settings.appearance.hover_preview.notifications' },
     { key: 'assistant', labelKey: 'settings.appearance.hover_preview.assistant' },
+    { key: 'liveActivity', labelKey: 'settings.appearance.hover_preview.live_activity' },
   ];
 
   return (

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -615,7 +615,8 @@
         "notifications": "Benachrichtigungen",
         "assistant": "Assistent-Karten",
         "playback_speed": "Geschwindigkeit",
-        "playback_speed_desc": "Tempo der Ereignis-Vorschau bei Hover/Druck."
+        "playback_speed_desc": "Tempo der Ereignis-Vorschau bei Hover/Druck.",
+        "live_activity": "Live-Aktivität-Kacheln"
       }
     }
   },

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -615,7 +615,8 @@
         "notifications": "Notifications",
         "assistant": "Assistant cards",
         "playback_speed": "Playback speed",
-        "playback_speed_desc": "Speed for event hover/long-press previews."
+        "playback_speed_desc": "Speed for event hover/long-press previews.",
+        "live_activity": "Live Activity tiles"
       }
     }
   },

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -615,7 +615,8 @@
         "notifications": "Notificaciones",
         "assistant": "Tarjetas del asistente",
         "playback_speed": "Velocidad",
-        "playback_speed_desc": "Velocidad de previsualización de eventos."
+        "playback_speed_desc": "Velocidad de previsualización de eventos.",
+        "live_activity": "Mosaicos de Actividad en vivo"
       }
     }
   },

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -615,7 +615,8 @@
         "notifications": "Notifications",
         "assistant": "Cartes de l'assistant",
         "playback_speed": "Vitesse",
-        "playback_speed_desc": "Vitesse des aperçus d'événement."
+        "playback_speed_desc": "Vitesse des aperçus d'événement.",
+        "live_activity": "Tuiles d'activité en direct"
       }
     }
   },

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -615,7 +615,8 @@
         "notifications": "通知",
         "assistant": "助手卡片",
         "playback_speed": "播放速度",
-        "playback_speed_desc": "事件悬停预览的播放速度。"
+        "playback_speed_desc": "事件悬停预览的播放速度。",
+        "live_activity": "实时活动图块"
       }
     }
   },

--- a/app/src/pages/LiveActivity.tsx
+++ b/app/src/pages/LiveActivity.tsx
@@ -355,6 +355,7 @@ export default function LiveActivity() {
   // treatments below so fullscreen cannot drift from the normal page.
   const body = (
     <LiveActivityGridBody
+        hoverPreview={settings.hoverPreview.liveActivity}
       error={error}
       showSkeleton={showSkeleton}
       showEmptyState={showEmptyState}

--- a/app/src/pages/__tests__/LiveActivity.test.tsx
+++ b/app/src/pages/__tests__/LiveActivity.test.tsx
@@ -57,12 +57,21 @@ vi.mock('../../components/monitors/AnalysisFramesToggle', () => ({
   AnalysisFramesToggle: () => <div data-testid="analysis-frames-toggle-stub" />,
 }));
 
-vi.mock('../../hooks/useCurrentProfile', () => ({
-  useCurrentProfile: () => ({
-    currentProfile: { id: 'p1', portalUrl: 'https://zm.test' },
-    settings: env.settings,
-  }),
-}));
+// Async so the real defaults can be pulled in: `env` is vi.hoisted and runs
+// before imports, so it cannot name one itself. The page reads nested settings
+// such as hoverPreview, and a fixture listing only what today's tests touch
+// breaks on the next key that lands (testing playbook).
+vi.mock('../../hooks/useCurrentProfile', async () => {
+  const { DEFAULT_SETTINGS } = await vi.importActual<typeof import('../../stores/settings')>(
+    '../../stores/settings',
+  );
+  return {
+    useCurrentProfile: () => ({
+      currentProfile: { id: 'p1', portalUrl: 'https://zm.test' },
+      settings: { ...DEFAULT_SETTINGS, ...env.settings },
+    }),
+  };
+});
 
 // LiveActivity.tsx reads currentProfileId via useProfileStore directly (not
 // through useCurrentProfile, which resolves to null in All mode) - same
@@ -610,10 +619,15 @@ describe('LiveActivity', () => {
     // needs a fresh module graph: reset it, doMock the override, then
     // re-import both the page and the mocked API functions it will resolve to.
     vi.resetModules();
-    vi.doMock('../../hooks/useCurrentProfile', () => ({
+    vi.doMock('../../hooks/useCurrentProfile', async () => {
+      const { DEFAULT_SETTINGS } = await vi.importActual<typeof import('../../stores/settings')>(
+        '../../stores/settings',
+      );
+      return {
       useCurrentProfile: () => ({
         currentProfile: { id: 'p1', portalUrl: 'https://zm.test' },
         settings: {
+          ...DEFAULT_SETTINGS,
           liveActivityPollSeconds: 5,
           liveActivityDwellSeconds: 30,
           liveActivityMaxTiles: 12,
@@ -622,7 +636,8 @@ describe('LiveActivity', () => {
           monitorGridCols: 2,
         },
       }),
-    }));
+      };
+    });
 
     const { default: LiveActivityWithIgnore } = await import('../LiveActivity');
     const { getMonitors: reimportedGetMonitors, getAlarmStatus: reimportedGetAlarmStatus } =
@@ -672,10 +687,15 @@ describe('LiveActivity', () => {
     // tail: exactly the window before a tile dwells out. Winding down is
     // signalled by the state icon dropping out of the header instead. refs #313
     vi.resetModules();
-    vi.doMock('../../hooks/useCurrentProfile', () => ({
+    vi.doMock('../../hooks/useCurrentProfile', async () => {
+      const { DEFAULT_SETTINGS } = await vi.importActual<typeof import('../../stores/settings')>(
+        '../../stores/settings',
+      );
+      return {
       useCurrentProfile: () => ({
         currentProfile: { id: 'p1', portalUrl: 'https://zm.test' },
         settings: {
+          ...DEFAULT_SETTINGS,
           liveActivityPollSeconds: 5,
           liveActivityDwellSeconds: 30,
           liveActivityMaxTiles: 12,
@@ -684,7 +704,8 @@ describe('LiveActivity', () => {
           monitorGridCols: 2,
         },
       }),
-    }));
+      };
+    });
     vi.doMock('../../stores/notifications', () => ({
       resolvePollIntervalMs: () => 20,
       useNotificationStore: (selector: (s: { profileEvents: Record<string, unknown[]> }) => unknown) =>
@@ -727,10 +748,15 @@ describe('LiveActivity', () => {
     // back to a plain update). A tile that stopped alarming still has to
     // leave, which is what proves the fallback path publishes anything at all.
     vi.resetModules();
-    vi.doMock('../../hooks/useCurrentProfile', () => ({
+    vi.doMock('../../hooks/useCurrentProfile', async () => {
+      const { DEFAULT_SETTINGS } = await vi.importActual<typeof import('../../stores/settings')>(
+        '../../stores/settings',
+      );
+      return {
       useCurrentProfile: () => ({
         currentProfile: { id: 'p1', portalUrl: 'https://zm.test' },
         settings: {
+          ...DEFAULT_SETTINGS,
           liveActivityPollSeconds: 5,
           // 10ms of dwell, so the window closes between two fast polls.
           liveActivityDwellSeconds: 0.01,
@@ -740,7 +766,8 @@ describe('LiveActivity', () => {
           monitorGridCols: 2,
         },
       }),
-    }));
+      };
+    });
     vi.doMock('../../stores/notifications', () => ({
       resolvePollIntervalMs: () => 20,
       useNotificationStore: (selector: (s: { profileEvents: Record<string, unknown[]> }) => unknown) =>

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -55,6 +55,8 @@ export interface HoverPreviewSettings {
   notifications: boolean;
   /** Event cards in an assistant answer (refs #270). */
   assistant: boolean;
+  /** Alarm tiles on Live Activity. */
+  liveActivity: boolean;
 }
 
 export const DEFAULT_HOVER_PREVIEW: HoverPreviewSettings = {
@@ -66,6 +68,10 @@ export const DEFAULT_HOVER_PREVIEW: HoverPreviewSettings = {
   timeline: true,
   notifications: true,
   assistant: true,
+  // Off by default: a Live Activity tile is already streaming this camera at
+  // size, so a hover preview opens a second connection for a bigger copy of
+  // what is on screen. Worth having on a wall of small tiles, not by default.
+  liveActivity: false,
 };
 
 /** ZMS rate parameter (percentage). 100 = 1x real time. */

--- a/docs/user-guide/live-activity.md
+++ b/docs/user-guide/live-activity.md
@@ -2,6 +2,8 @@
 
 Live Activity shows only the cameras that ZoneMinder currently reports as alarming, as live video tiles. Instead of scanning a full grid of quiet monitors, you see just the ones that need attention right now.
 
+Tapping a tile's video opens that camera's monitor page, the same as tapping one in Montage; on a computer the tile outlines itself as you hover to show it will. The X in the corner dismisses a tile instead, and the buttons in its header still do their own jobs.
+
 ## Why a monitor lingers after its alarm clears
 
 A monitor does not disappear the instant its alarm clears. It stays on screen for a short dwell window (30 seconds by default) after its last alarm, then leaves. This is not just to avoid a jarring flicker: each tile that appears or disappears opens or closes a live video connection to the server. A monitor that flickered in and out of alarm every few seconds would open and close that connection just as fast, which is unnecessary load on the server. The dwell window smooths that out.

--- a/docs/user-guide/live-activity.md
+++ b/docs/user-guide/live-activity.md
@@ -4,6 +4,8 @@ Live Activity shows only the cameras that ZoneMinder currently reports as alarmi
 
 Tapping a tile's video opens that camera's monitor page, the same as tapping one in Montage; on a computer the tile outlines itself as you hover to show it will. The X in the corner dismisses a tile instead, and the buttons in its header still do their own jobs.
 
+On a computer, hovering a tile can also open an enlarged live preview, the same one the monitor and event lists offer. It is off here by default, since a tile is already streaming that camera at size and the preview opens a second connection for a bigger copy; turn it on under Settings ▸ Appearance ▸ Hover preview ▸ **Live Activity tiles**.
+
 ## Why a monitor lingers after its alarm clears
 
 A monitor does not disappear the instant its alarm clears. It stays on screen for a short dwell window (30 seconds by default) after its last alarm, then leaves. This is not just to avoid a jarring flicker: each tile that appears or disappears opens or closes a live video connection to the server. A monitor that flickered in and out of alarm every few seconds would open and close that connection just as fast, which is unnecessary load on the server. The dwell window smooths that out.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -40,6 +40,7 @@ Hover preview enlarges a feed or event in place when you hover over it on deskto
 - Timeline
 - Notifications
 - Assistant cards (the event cards under a Ninjii answer)
+- Live Activity tiles (off by default: the tile already streams that camera, so the preview opens a second connection for a larger copy)
 
 The **playback speed** control (0.5x, 1x, 1.5x, 2x, 4x) sets how fast an event preview plays. Live monitor previews open a fresh stream while the preview is on screen and close it when you move away.
 


### PR DESCRIPTION
Live Activity tiles took a tap and did nothing. Montage opens a monitor from a wrapper around the whole tile; Live Activity renders the same tile component without that wrapper, so nothing ever handled the click.

## Click

The media area carries it, not the whole tile. That area holds only the player and `pointer-events-none` labels, so nothing interactive ends up nested inside a button — unlike the whole-tile version, which wraps the header's own buttons and is the invalid nesting the profiles work removed. Hover and focus both outline it, since a wall of live video gives no other clue that a tile leads anywhere.

Deep route while aggregating, so a tile opens against its own server without switching the active profile first.

The callback is memoized. The elapsed label re-renders the tile every second, and a fresh function each time would defeat `MontageMonitor`'s memo and re-render live video with it — which the existing prop-identity test caught when I first wrote it inline.

## Hover preview

The monitor and event lists have offered an enlarged preview on hover for a while; Live Activity had no way to ask for one. Hover preview is a per-surface setting, so the tiles get their own entry rather than borrowing another screen's answer, and `MontageMonitor` takes a flag rather than reading the setting itself — which surface it is drawn on is the caller's business.

**Off by default.** A tile is already streaming that camera at size, so the preview opens a second connection to show a larger copy of what is on screen. Worth having on a wall of small tiles; not worth a connection by default.

Teardown is already correct: when a dwell window closes mid-hover, the tile unmounts, `hover-preview.tsx:308-316` releases the inert lock and clears the timer, and the preview's own player unmounts and sends `CMD_QUIT` for its connkey. What it does *not* do is pause the dwell — the tile still vanishes under the cursor and the grid reflows, which can open a neighbour's preview. Noted, not fixed here.

## Two fixtures that were hiding

`LiveActivity`'s mocked settings listed only the keys its own tests touched, so reading a new nested one threw across six tests. It spreads `DEFAULT_SETTINGS` now, which is what the testing playbook says to do and why that trap is written down. `MontageMonitor`'s auth mock dropped exports that the preview's stream lifecycle registers on import, taking the whole file down rather than one test.

## Verification

`npm run gates`: 4169 passed / 2 skipped, build clean, three lints pass, ratchet at 201. E2E: live-activity 4, montage 13.

No e2e for the click itself: tiles only exist while a monitor is alarming, which is the demo server's live state rather than something a scenario can arrange. Unit tests cover the callback and both routes, and the hover flag's path from page to player.

Posted by Claude, assisting @pliablepixels.