### PR TITLE
Ninjii in the page toolbar, on request

### DIFF
--- a/app/src/components/assistant/AssistantWidget.tsx
+++ b/app/src/components/assistant/AssistantWidget.tsx
@@ -33,6 +33,11 @@ export function AssistantWidget() {
         <Button
           type="button"
           onClick={open}
+          // size="icon" for the padding, not the box: the default size carries
+          // px-4, which in a 48px circle leaves 16px of content width and
+          // squeezed the logo narrower than it is tall before object-contain
+          // letterboxed it back.
+          size="icon"
           aria-label={t('assistant.reopen')}
           data-testid="assistant-fab"
           // bottom-20 (not bottom-4) offsets this above BackgroundTaskDrawer's
@@ -40,7 +45,11 @@ export function AssistantWidget() {
           className="fixed bottom-20 right-4 z-50 h-12 w-12 rounded-full shadow-lg"
         >
           {/* decorative: the button's own aria-label already names Ninjii */}
-          <img src={NINJII_LOGO_URL} alt="" className="h-7 w-7 rounded-full object-contain" />
+          <img
+            src={NINJII_LOGO_URL}
+            alt=""
+            className="h-full w-full rounded-full object-contain p-1.5"
+          />
         </Button>
       )}
 

--- a/app/src/components/assistant/NinjiiToolbarButton.tsx
+++ b/app/src/components/assistant/NinjiiToolbarButton.tsx
@@ -1,0 +1,45 @@
+/**
+ * Ninjii's place in a page toolbar (refs #246).
+ *
+ * The assistant answers from the command palette and a keyboard shortcut, and
+ * from its own floating button once minimized - none of which announce
+ * themselves on a tablet, where there is no keyboard and the palette is a
+ * glyph. This puts it where a hand already is, beside the view menu.
+ *
+ * Two gates, both required: the assistant has to be configured in this scope
+ * (useAssistantEnabled resolves that across a group's members, not from an
+ * aggregate's own bucket, refs #337), and the profile has to have asked for it
+ * in the toolbar. Off by default - a toolbar shared with per-page controls is
+ * the one place a global tool has to earn its spot.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useAssistantEnabled } from '../../hooks/useAssistantEnabled';
+import { useAssistantPanelStore } from '../../stores/assistantPanel';
+import { useCurrentProfile } from '../../hooks/useCurrentProfile';
+import { NINJII_LOGO_URL } from '../../lib/assistant/ninjii-logo';
+import { Button } from '../ui/button';
+
+export function NinjiiToolbarButton() {
+  const { t } = useTranslation();
+  const { enabled } = useAssistantEnabled();
+  const { settings } = useCurrentProfile();
+  const open = useAssistantPanelStore((s) => s.open);
+
+  if (!enabled || !settings.assistantInToolbar) return null;
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      className="h-8 w-8 sm:h-9 sm:w-9"
+      onClick={open}
+      title={t('assistant.ask_ninjii')}
+      aria-label={t('assistant.ask_ninjii')}
+      data-testid="ninjii-toolbar-button"
+    >
+      {/* Decorative: the button's own label already names Ninjii. */}
+      <img src={NINJII_LOGO_URL} alt="" className="h-5 w-5 rounded-full object-contain" />
+    </Button>
+  );
+}

--- a/app/src/components/assistant/NinjiiToolbarButton.tsx
+++ b/app/src/components/assistant/NinjiiToolbarButton.tsx
@@ -38,8 +38,18 @@ export function NinjiiToolbarButton() {
       aria-label={t('assistant.ask_ninjii')}
       data-testid="ninjii-toolbar-button"
     >
-      {/* Decorative: the button's own label already names Ninjii. */}
-      <img src={NINJII_LOGO_URL} alt="" className="h-5 w-5 rounded-full object-contain" />
+      {/*
+        Fills the control rather than taking a fixed size: `size="icon"` sets
+        only a box and no padding, and the base class's `size-4` rule matches
+        svg, not img, so a pinned 20px logo sat small in a 32px button and
+        smaller still in the 36px one. Padding rather than a size keeps it
+        right at both. Decorative: the button's own label names Ninjii.
+      */}
+      <img
+        src={NINJII_LOGO_URL}
+        alt=""
+        className="h-full w-full rounded-full object-contain p-1"
+      />
     </Button>
   );
 }

--- a/app/src/components/assistant/__tests__/NinjiiToolbarButton.test.tsx
+++ b/app/src/components/assistant/__tests__/NinjiiToolbarButton.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NinjiiToolbarButton } from '../NinjiiToolbarButton';
+
+const mocks = vi.hoisted(() => ({
+  enabled: { value: true },
+  inToolbar: { value: true },
+  open: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../hooks/useAssistantEnabled', () => ({
+  useAssistantEnabled: () => ({ enabled: mocks.enabled.value, profileId: 'p1' }),
+}));
+
+vi.mock('../../../hooks/useCurrentProfile', () => ({
+  useCurrentProfile: () => ({ settings: { assistantInToolbar: mocks.inToolbar.value } }),
+}));
+
+vi.mock('../../../stores/assistantPanel', () => ({
+  useAssistantPanelStore: (selector: (s: { open: () => void }) => unknown) =>
+    selector({ open: mocks.open }),
+}));
+
+describe('NinjiiToolbarButton', () => {
+  beforeEach(() => {
+    mocks.enabled.value = true;
+    mocks.inToolbar.value = true;
+    mocks.open.mockClear();
+  });
+
+  it('opens the assistant when tapped', async () => {
+    render(<NinjiiToolbarButton />);
+
+    await userEvent.click(screen.getByTestId('ninjii-toolbar-button'));
+
+    expect(mocks.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays away when the profile has not asked for it in the toolbar', () => {
+    mocks.inToolbar.value = false;
+    render(<NinjiiToolbarButton />);
+
+    expect(screen.queryByTestId('ninjii-toolbar-button')).not.toBeInTheDocument();
+  });
+
+  it('stays away when the assistant is not configured in this scope', () => {
+    // The setting alone is not enough: a group whose members have no assistant
+    // configured would otherwise show a button that opens an empty panel.
+    mocks.enabled.value = false;
+    render(<NinjiiToolbarButton />);
+
+    expect(screen.queryByTestId('ninjii-toolbar-button')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/live-activity/LiveActivityChrome.tsx
+++ b/app/src/components/live-activity/LiveActivityChrome.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { Maximize, Minimize, Settings } from 'lucide-react';
 import { EventMontageGridControls } from '../events/EventMontageGridControls';
 import { AnalysisFramesToggle } from '../monitors/AnalysisFramesToggle';
+import { NinjiiToolbarButton } from '../assistant/NinjiiToolbarButton';
 import { Button } from '../ui/button';
 
 interface LiveActivityHeaderProps {
@@ -54,6 +55,7 @@ export function LiveActivityHeader({
           onCustomGridDialogOpenChange={onCustomGridDialogOpenChange}
           onCustomGridSubmit={onCustomGridSubmit}
         />
+        <NinjiiToolbarButton />
         <AnalysisFramesToggle />
         <Button
           variant="ghost"

--- a/app/src/components/settings/AssistantSection.tsx
+++ b/app/src/components/settings/AssistantSection.tsx
@@ -295,6 +295,19 @@ export function AssistantSection({
 
         {settings.assistantEnabled && (
           <>
+            <SettingsRow>
+              <RowLabel
+                label={t('settings.assistant.in_toolbar')}
+                desc={t('settings.assistant.in_toolbar_desc')}
+              />
+              <Switch
+                id="assistant-in-toolbar"
+                checked={settings.assistantInToolbar}
+                onCheckedChange={(checked) => update('assistantInToolbar', checked)}
+                data-testid="assistant-in-toolbar-toggle"
+              />
+            </SettingsRow>
+
             {/* On-device WebGPU was removed on a phone or tablet: the picker
                 would offer one dead-end option. The native (llama.cpp
                 bridge) backend takes its place there once the device passes

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -431,7 +431,9 @@
       "history_turns_hint": "Wie viele frühere Fragen und Antworten das Modell sieht.",
       "advanced_note": "Temperatur 0 war beim Auswerten Ihrer Kameradaten messbar am genauesten. Höhere Werte führen eher dazu, dass der Assistent eine Anzahl, eine Uhrzeit oder einen Kameranamen nennt, der nicht in den Ergebnissen steht. Erhöhen Sie das Zeitlimit, wenn Ihr Server langsam antwortet. Mehr gemerkte Wortwechsel helfen bei Rückfragen, machen aber jede Antwort langsamer.",
       "backend_gemini_nano": "Auf dem Gerät (AICore)",
-      "gemini_nano_not_ready": "Gemini Nano ist auf diesem Gerät verfügbar, aber noch nicht heruntergeladen."
+      "gemini_nano_not_ready": "Gemini Nano ist auf diesem Gerät verfügbar, aber noch nicht heruntergeladen.",
+      "in_toolbar": "In Symbolleiste anzeigen",
+      "in_toolbar_desc": "Zeigt Ninjii neben dem Menü jeder Seite, für Fragen mit einem Tippen"
     },
     "language": "Sprache",
     "select_language": "Sprache auswählen",
@@ -1525,6 +1527,7 @@
     "timeframe_unclear": "Ich konnte den gemeinten Zeitraum nicht ermitteln. Nenne den Zeitraum, zum Beispiel „heute“ oder „21. Juli“.",
     "gemini_background_blocked": "Gemini Nano läuft nur, solange zmNinja sichtbar ist. Öffne die App erneut und versuche es nochmal.",
     "gemini_quota_exceeded": "Gemini Nano hat das heutige Nutzungslimit auf dem Gerät erreicht. Versuche es später erneut oder nutze einen Ollama-Server.",
-    "gemini_rate_limited": "Gemini Nano ist gerade ausgelastet. Warte kurz und versuche es erneut."
+    "gemini_rate_limited": "Gemini Nano ist gerade ausgelastet. Warte kurz und versuche es erneut.",
+    "ask_ninjii": "Ninjii fragen"
   }
 }

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -431,7 +431,9 @@
       "history_turns_hint": "How many earlier questions and answers the model sees.",
       "advanced_note": "Temperature 0 was measured most accurate for reading your camera data. Higher values make the assistant more likely to state a count, a time, or a camera name that is not in the results. Raise the timeout if your server is slow to answer. Remembering more exchanges helps follow-up questions but makes every answer slower.",
       "backend_gemini_nano": "On-device (AICore)",
-      "gemini_nano_not_ready": "Gemini Nano is available on this device but not downloaded yet."
+      "gemini_nano_not_ready": "Gemini Nano is available on this device but not downloaded yet.",
+      "in_toolbar": "Show in toolbar",
+      "in_toolbar_desc": "Puts Ninjii beside each page’s menu, so a question is one tap away"
     },
     "language": "Language",
     "select_language": "Select Language",
@@ -1525,6 +1527,7 @@
     "timeframe_unclear": "I could not work out the time period you mean. Tell me the period, like \"today\" or \"July 21\".",
     "gemini_background_blocked": "Gemini Nano only runs while zmNinja is on screen. Reopen the app and try again.",
     "gemini_quota_exceeded": "Gemini Nano has reached today's on-device usage limit. Try again later, or use an Ollama server.",
-    "gemini_rate_limited": "Gemini Nano is busy right now. Wait a moment and try again."
+    "gemini_rate_limited": "Gemini Nano is busy right now. Wait a moment and try again.",
+    "ask_ninjii": "Ask Ninjii"
   }
 }

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -431,7 +431,9 @@
       "history_turns_hint": "Cuántas preguntas y respuestas anteriores ve el modelo.",
       "advanced_note": "La temperatura 0 resultó ser la más precisa al leer los datos de tus cámaras. Con valores más altos es más probable que el asistente indique un recuento, una hora o un nombre de cámara que no está en los resultados. Aumenta el tiempo de espera si tu servidor responde despacio. Recordar más intercambios ayuda con las preguntas de seguimiento, pero hace más lenta cada respuesta.",
       "backend_gemini_nano": "En el dispositivo (AICore)",
-      "gemini_nano_not_ready": "Gemini Nano está disponible en este dispositivo, pero aún no se ha descargado."
+      "gemini_nano_not_ready": "Gemini Nano está disponible en este dispositivo, pero aún no se ha descargado.",
+      "in_toolbar": "Mostrar en la barra",
+      "in_toolbar_desc": "Coloca a Ninjii junto al menú de cada página, a un toque de una pregunta"
     },
     "language": "Idioma",
     "select_language": "Seleccionar Idioma",
@@ -1525,6 +1527,7 @@
     "timeframe_unclear": "No pude determinar el período de tiempo al que te refieres. Indica el período, por ejemplo «hoy» o «21 de julio».",
     "gemini_background_blocked": "Gemini Nano solo funciona con zmNinja en pantalla. Vuelve a abrir la app e inténtalo de nuevo.",
     "gemini_quota_exceeded": "Gemini Nano alcanzó el límite de uso de hoy en el dispositivo. Inténtalo más tarde o usa un servidor Ollama.",
-    "gemini_rate_limited": "Gemini Nano está ocupado ahora mismo. Espera un momento e inténtalo de nuevo."
+    "gemini_rate_limited": "Gemini Nano está ocupado ahora mismo. Espera un momento e inténtalo de nuevo.",
+    "ask_ninjii": "Preguntar a Ninjii"
   }
 }

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -431,7 +431,9 @@
       "history_turns_hint": "Combien de questions et réponses précédentes le modèle voit.",
       "advanced_note": "La température 0 s'est révélée la plus fiable pour lire les données de vos caméras. Des valeurs plus élevées augmentent le risque que l'assistant cite un nombre, une heure ou un nom de caméra absent des résultats. Augmentez le délai si votre serveur répond lentement. Mémoriser plus d'échanges aide pour les questions de suivi, mais ralentit chaque réponse.",
       "backend_gemini_nano": "Sur l'appareil (AICore)",
-      "gemini_nano_not_ready": "Gemini Nano est disponible sur cet appareil mais n’est pas encore téléchargé."
+      "gemini_nano_not_ready": "Gemini Nano est disponible sur cet appareil mais n’est pas encore téléchargé.",
+      "in_toolbar": "Afficher dans la barre",
+      "in_toolbar_desc": "Place Ninjii à côté du menu de chaque page, une question à portée de doigt"
     },
     "language": "Langue",
     "select_language": "Sélectionner la langue",
@@ -1525,6 +1527,7 @@
     "timeframe_unclear": "Je n'ai pas pu déterminer la période que vous visez. Indiquez la période, par exemple « aujourd'hui » ou « 21 juillet ».",
     "gemini_background_blocked": "Gemini Nano ne fonctionne que si zmNinja est à l’écran. Rouvrez l’application et réessayez.",
     "gemini_quota_exceeded": "Gemini Nano a atteint la limite d’utilisation du jour sur l’appareil. Réessayez plus tard ou utilisez un serveur Ollama.",
-    "gemini_rate_limited": "Gemini Nano est occupé pour le moment. Patientez un instant et réessayez."
+    "gemini_rate_limited": "Gemini Nano est occupé pour le moment. Patientez un instant et réessayez.",
+    "ask_ninjii": "Demander à Ninjii"
   }
 }

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -431,7 +431,9 @@
       "history_turns_hint": "模型能看到多少条此前的问答。",
       "advanced_note": "实测温度为 0 时读取摄像机数据最准确。数值越高，助手越可能说出结果中并不存在的数量、时间或摄像机名称。若服务器响应缓慢，请调高超时。记住更多轮对话有助于追问，但会让每次回答变慢。",
       "backend_gemini_nano": "设备端（AICore）",
-      "gemini_nano_not_ready": "Gemini Nano 在本设备上可用，但尚未下载。"
+      "gemini_nano_not_ready": "Gemini Nano 在本设备上可用，但尚未下载。",
+      "in_toolbar": "在工具栏中显示",
+      "in_toolbar_desc": "将忍者放在每个页面的菜单旁边，一键提问"
     },
     "language": "语言",
     "select_language": "选择语言",
@@ -1525,6 +1527,7 @@
     "timeframe_unclear": "我无法确定你指的时间段。请说明时间段，例如“今天”或“7月21日”。",
     "gemini_background_blocked": "Gemini Nano 仅在 zmNinja 位于前台时运行。请重新打开应用后再试。",
     "gemini_quota_exceeded": "Gemini Nano 已达到今日设备端用量上限。请稍后再试，或改用 Ollama 服务器。",
-    "gemini_rate_limited": "Gemini Nano 当前繁忙。请稍候再试。"
+    "gemini_rate_limited": "Gemini Nano 当前繁忙。请稍候再试。",
+    "ask_ninjii": "询问忍者"
   }
 }

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -21,6 +21,7 @@ import { asProfileId } from '../api/types';
 import { useShallow } from 'zustand/react/shallow';
 import { useTranslation } from 'react-i18next';
 import { NotificationBadge } from '../components/NotificationBadge';
+import { NinjiiToolbarButton } from '../components/assistant/NinjiiToolbarButton';
 
 export default function Dashboard() {
     const { t } = useTranslation();
@@ -50,6 +51,7 @@ export default function Dashboard() {
                 <div className="flex items-center gap-2">
                     {widgets.length > 0 && (
                         <>
+                            <NinjiiToolbarButton />
                             <RefreshButton size="sm" data-testid="dashboard-refresh-button" />
                             <Button
                                 variant={isEditing ? "default" : "outline"}

--- a/app/src/pages/Events.tsx
+++ b/app/src/pages/Events.tsx
@@ -43,6 +43,7 @@ import { EventMontageView } from '../components/events/EventMontageView';
 import { EventListView, type ScopedEventItem } from '../components/events/EventListView';
 import { EventsAllModeBar } from '../components/events/EventsAllModeBar';
 import { EventMontageGridControls } from '../components/events/EventMontageGridControls';
+import { NinjiiToolbarButton } from '../components/assistant/NinjiiToolbarButton';
 import { EventsFilterPopover } from '../components/events/EventsFilterPopover';
 import { QuickDateRangeButtons } from '../components/ui/quick-date-range-buttons';
 import { useTranslation } from 'react-i18next';
@@ -613,6 +614,7 @@ export default function Events() {
                 />
               </Popover>
 
+              <NinjiiToolbarButton />
               <RefreshButton
                 aria-label={t('events.refresh')}
                 data-testid="events-refresh-button"

--- a/app/src/pages/Monitors.tsx
+++ b/app/src/pages/Monitors.tsx
@@ -25,6 +25,7 @@ import { resolveQueryError } from '../lib/query/query-error';
 import { RefreshButton } from '../components/common/RefreshButton';
 import { MonitorCard } from '../components/monitors/MonitorCard';
 import { ViewOptionsMenu, FeedFitItems, AnalysisFramesItem, ViewOptionsSeparator } from '../components/common/view-options';
+import { NinjiiToolbarButton } from '../components/assistant/NinjiiToolbarButton';
 import { MonitorSettingsDialog } from '../components/monitor-detail/MonitorSettingsDialog';
 import { usePermissions } from '../hooks/usePermissions';
 import { canEditMonitorSettings, canViewMonitors } from '../lib/permissions/zm-permissions';
@@ -379,6 +380,7 @@ export default function Monitors() {
               onCustomGridSubmit={handleMonitorCustomGridSubmit}
             />
           )}
+          <NinjiiToolbarButton />
           <RefreshButton
             className="h-8 w-8 sm:h-9 sm:w-9"
             data-testid="monitors-refresh-button"

--- a/app/src/pages/Montage.tsx
+++ b/app/src/pages/Montage.tsx
@@ -53,6 +53,7 @@ import {
   type MontageGroupedSections,
 } from '../components/montage';
 import { ScrollPad } from '../components/ui/scroll-pad';
+import { NinjiiToolbarButton } from '../components/assistant/NinjiiToolbarButton';
 import { useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { useFullscreenMode } from '../hooks/useFullscreenMode';
 import { tileIdFor } from '../components/montage/hooks/useMontageGrid';
@@ -647,6 +648,7 @@ export default function Montage() {
               >
                 <Maximize className="h-4 w-4" />
               </Button>
+              <NinjiiToolbarButton />
               <RefreshButton size="sm" className="h-8 sm:h-9" data-testid="montage-refresh-button" />
               <MontageKebabMenu
                 items={visibilityItems}

--- a/app/src/pages/Timeline.tsx
+++ b/app/src/pages/Timeline.tsx
@@ -12,6 +12,7 @@ import { Button } from '../components/ui/button';
 import { FilterX, Clock } from 'lucide-react';
 import { PageContainer } from '../components/common/PageContainer';
 import { ScrollPad } from '../components/ui/scroll-pad';
+import { NinjiiToolbarButton } from '../components/assistant/NinjiiToolbarButton';
 import { useScrollAffordance, useScrollPadToggle } from '../hooks/useScrollAffordance';
 import { ErrorBanner } from '../components/ui/query-state';
 import { resolveQueryError } from '../lib/query/query-error';
@@ -415,6 +416,7 @@ export default function Timeline() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <NinjiiToolbarButton />
           <Button onClick={() => { filters.clearFilters(); filters.setActiveQuickRange(null); defaultDates.current = { start: formatLocalDateTime(subDays(new Date(), 1)), end: formatLocalDateTime(new Date()) }; }} variant="outline" size="sm" className="h-8 sm:h-9" data-testid="timeline-clear-button">
             <FilterX className="h-4 w-4 sm:mr-2" />
             <span className="hidden sm:inline">{t('common.clear')}</span>

--- a/app/src/pages/__tests__/Monitors.memo.test.tsx
+++ b/app/src/pages/__tests__/Monitors.memo.test.tsx
@@ -10,6 +10,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import Monitors from '../Monitors';
 
+// Its own tests cover the button's two gates; stubbing keeps useAssistantEnabled's
+// settings-store reads out of this file's mock surface, as with the analysis
+// toggle above.
+vi.mock('../../components/assistant/NinjiiToolbarButton', () => ({
+  NinjiiToolbarButton: () => null,
+}));
+
+
 const mockState = vi.hoisted(() => ({
   renderCount: new Map<string, number>(),
   settingsProps: [] as Array<(monitor: unknown) => void>,

--- a/app/src/pages/__tests__/Monitors.test.tsx
+++ b/app/src/pages/__tests__/Monitors.test.tsx
@@ -2,6 +2,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import Monitors from '../Monitors';
 
+// Its own tests cover the button's two gates; stubbing keeps useAssistantEnabled's
+// settings-store reads out of this file's mock surface, as with the analysis
+// toggle above.
+vi.mock('../../components/assistant/NinjiiToolbarButton', () => ({
+  NinjiiToolbarButton: () => null,
+}));
+
+
 const useScopedMonitorsMock = vi.fn();
 const useCurrentProfileMock = vi.fn();
 const useProfileScopeMock = vi.fn();

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -328,6 +328,8 @@ export interface ProfileSettings {
   // stored here (rule 7 settings are plaintext-persisted); it lives in
   // secureStorage under `${ASSISTANT.apiKeyStoragePrefix}${profileId}`.
   assistantEnabled: boolean;
+  /** Show Ninjii in each page's toolbar, beside the view menu (refs #246). */
+  assistantInToolbar: boolean;
   assistantBackend: AssistantBackend;
   assistantModelId: string;
   assistantOllamaBaseUrl: string;
@@ -495,6 +497,10 @@ export const DEFAULT_SETTINGS: ProfileSettings = {
   hoverPreview: DEFAULT_HOVER_PREVIEW,
   hoverPreviewPlaybackRate: DEFAULT_HOVER_PREVIEW_PLAYBACK_RATE,
   assistantEnabled: false,
+  // Off by default: the assistant already answers from the command palette and
+  // the keyboard, and a toolbar it shares with per-page controls is the one
+  // place a global tool has to earn its spot.
+  assistantInToolbar: false,
   assistantBackend: 'on-device',
   assistantModelId: ASSISTANT.defaultModelId,
   // Empty, not localhost: an unset URL is resolved against the profile's own

--- a/app/tests/features/assistant.feature
+++ b/app/tests/features/assistant.feature
@@ -15,6 +15,16 @@ Feature: In-app assistant
     When I click the example prompt "Summarize my day"
     Then the assistant input should contain "Summarize my day"
 
+  Scenario: The toolbar button opens Ninjii, and only once asked for
+    Given I am logged into zmNinjaNg
+    And the assistant is enabled with the mock backend
+    When I navigate to the "Monitors" page
+    Then the Ninjii toolbar button should be absent
+    When I turn on the assistant toolbar button
+    And I navigate to the "Monitors" page
+    And I tap the Ninjii toolbar button
+    Then the assistant panel should open
+
   Scenario: Ask a question that counts events
     Given I am logged into zmNinjaNg
     And the assistant is enabled with the mock backend

--- a/app/tests/steps/assistant.steps.ts
+++ b/app/tests/steps/assistant.steps.ts
@@ -278,3 +278,26 @@ Then('the Apple Intelligence backend should be selected', async ({ page }) => {
   });
 });
 
+When('I turn on the assistant toolbar button', async ({ page }) => {
+  await page.getByTestId('nav-item-settings').first().click();
+  await page.waitForURL(/#\/settings$/, { timeout: testConfig.timeouts.transition });
+
+  const toggle = page.getByTestId('assistant-in-toolbar-toggle');
+  await toggle.scrollIntoViewIfNeeded();
+  await expect(toggle).toBeVisible({ timeout: testConfig.timeouts.element });
+  if ((await toggle.getAttribute('aria-checked')) !== 'true') {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute('aria-checked', 'true', {
+    timeout: testConfig.timeouts.transition,
+  });
+});
+
+Then('the Ninjii toolbar button should be absent', async ({ page }) => {
+  await expect(page.getByTestId('ninjii-toolbar-button')).toHaveCount(0);
+});
+
+When('I tap the Ninjii toolbar button', async ({ page }) => {
+  await page.getByTestId('ninjii-toolbar-button').first().click();
+});
+

--- a/docs/user-guide/assistant.md
+++ b/docs/user-guide/assistant.md
@@ -6,6 +6,14 @@ Ninjii answers questions about your cameras and events. It is read-only: it cann
 
 Go to **Settings > Ninjii** and turn on **Enable Ninjii**.
 
+Underneath it, **Show in toolbar** puts the Ninjii icon in the toolbar of the
+Dashboard, Monitors, Montage, Events, Timeline, and Live Activity screens,
+beside their menu, so a question is one tap away. It is off by default: Ninjii
+already answers from the command palette and the keyboard, and a toolbar shared
+with each page's own controls is the one place a global tool has to earn its
+spot. The setting only appears once Ninjii is enabled, and the icon only shows
+where the assistant is actually configured.
+
 Underneath, **Backend** picks where the model runs:
 
 - **Ollama (remote)**: the model runs on an [Ollama](https://ollama.com) server (or anything else speaking the OpenAI-compatible chat API) that you point the app at. The only option where the question leaves this device, and it goes to your server, not to anyone else's.
@@ -37,6 +45,7 @@ Once enabled, there are three ways to start a conversation:
 - Press `?` on a keyboard (desktop, web).
 - Open the command palette (`/`, the sidebar button, or the mobile header icon) and tap **Ask**.
 - Type a leading `?` directly into the command palette's search field.
+- Tap the Ninjii icon in a page's toolbar, if you have turned that on.
 
 Before you have typed anything, Ninjii shows a few example prompts as tappable chips (one of them is "Summarize my day"). Tapping a chip drops its text into the input so you can send it as-is or edit it first.
 


### PR DESCRIPTION
Ninjii answers from the command palette, a keyboard shortcut, and its own floating button once minimized. None of those announce themselves on a tablet: there is no keyboard, and the palette is a glyph. This puts the icon where a hand already is.

## The setting

**Settings ▸ Ninjii ▸ Show in toolbar**, which only appears once Ninjii itself is enabled. Off by default — Ninjii already has three ways in, and a toolbar shared with each page's own controls is the one place a global tool has to earn its spot.

## The button

Ninjii's logo at the top right of Dashboard, Monitors, Montage, Events, Timeline, and Live Activity, first in the action group so it lands before refresh and the ⋮. Tapping opens the panel.

Two gates, both required: the assistant has to be configured **in the active scope**, and the profile has to have asked for the button. The scope half matters — `useAssistantEnabled` resolves across a group's members rather than an aggregate's own bucket, so inside a virtual profile group the button appears exactly where the palette's **Ask** does. Reading the flag directly would have shown a button that opens an unconfigured panel, which is the bug #337 fixed for the other entry points.

## Sizing

Both Ninjii buttons had the logo pinned to a literal pixel size. `size="icon"` sets only a box and no padding, and the base class's `size-4` rule matches `svg`, not `img`, so nothing else was sizing them. The floating button additionally never set a size at all, so it took the default `px-4`: in a 48px circle that leaves 16px of content width, and flex squeezed the logo narrower than it was tall before `object-contain` letterboxed it back. Both now fill their control and inset by padding, so they stay proportional at either button size.

## Verification

`npm run gates`: 4172 passed / 2 skipped, build clean, three lints pass, ratchet at 201. `assistant.feature`: 11 passed.

Three unit tests on the button (opens the panel, hidden when the profile has not asked, hidden when the assistant is unconfigured in scope) and an e2e that enables the assistant, confirms **no** button on Monitors, turns the setting on, then taps it to open the panel — so the default-off half is asserted, not just the happy path.

The Monitors tests stub the button, as they already stub the analysis toggle: it reads the settings store through `useAssistantEnabled`, and those files mock that store with a hand-listed surface.

refs #246

Posted by Claude, assisting @pliablepixels.