### PR TITLE
fix(ptz): show only the axes the driver has

### DIFF
--- a/app/src/components/monitors/PTZControls.tsx
+++ b/app/src/components/monitors/PTZControls.tsx
@@ -146,7 +146,16 @@ export function PTZControls({ onCommand, profileId, className, disabled, control
   const controlDenied = canUseControl(permissions) === 'denied';
 
   const canMove = control?.CanMove === '1';
-  const canMoveDiag = control?.CanMoveDiag === '1';
+  // The driver decides which axes exist. ZoneMinder hides the up/down arrows
+  // without CanTilt and left/right without CanPan (skins/classic/includes/
+  // control_functions.php), so a pan-only driver never gets tilt buttons whose
+  // commands it would reject. Only an explicit '0' hides an axis: a control
+  // definition that omits the field predates the column, and losing every arrow
+  // there would be worse than showing one that does nothing.
+  const canPan = control?.CanPan !== '0';
+  const canTilt = control?.CanTilt !== '0';
+  // Diagonals need both axes, matching $hasDiag in control_functions.php.
+  const canMoveDiag = canPan && canTilt && control?.CanMoveDiag === '1';
   const canMoveCon = control?.CanMoveCon === '1';
   const canMoveRel = control?.CanMoveRel === '1';
   const canMoveAbs = control?.CanMoveAbs === '1';
@@ -211,7 +220,7 @@ export function PTZControls({ onCommand, profileId, className, disabled, control
             repeatIntervalMs={moveRepeatMs}
             onCommand={onCommand}
             disabled={disabled}
-            className="rounded-full"
+            className={cn("rounded-full", !canTilt && "invisible")}
             title={t('ptz.move_up')}
             testId="ptz-up"
           >
@@ -236,7 +245,7 @@ export function PTZControls({ onCommand, profileId, className, disabled, control
             repeatIntervalMs={moveRepeatMs}
             onCommand={onCommand}
             disabled={disabled}
-            className="rounded-full"
+            className={cn("rounded-full", !canPan && "invisible")}
             title={t('ptz.move_left')}
             testId="ptz-left"
           >
@@ -260,7 +269,7 @@ export function PTZControls({ onCommand, profileId, className, disabled, control
             repeatIntervalMs={moveRepeatMs}
             onCommand={onCommand}
             disabled={disabled}
-            className="rounded-full"
+            className={cn("rounded-full", !canPan && "invisible")}
             title={t('ptz.move_right')}
             testId="ptz-right"
           >
@@ -285,7 +294,7 @@ export function PTZControls({ onCommand, profileId, className, disabled, control
             repeatIntervalMs={moveRepeatMs}
             onCommand={onCommand}
             disabled={disabled}
-            className="rounded-full"
+            className={cn("rounded-full", !canTilt && "invisible")}
             title={t('ptz.move_down')}
             testId="ptz-down"
           >

--- a/app/src/components/monitors/__tests__/PTZControls.test.tsx
+++ b/app/src/components/monitors/__tests__/PTZControls.test.tsx
@@ -172,3 +172,66 @@ describe('PTZControls without control permission', () => {
     expect(screen.getByTestId('ptz-controls')).toBeInTheDocument();
   });
 });
+
+/**
+ * The pad must offer only the axes the driver has. ZoneMinder's own pad hides
+ * up/down without CanTilt and left/right without CanPan
+ * (skins/classic/includes/control_functions.php); a pan-only driver such as a
+ * single-servo mount rejects every tilt command, so an arrow that sends one is
+ * a button that cannot work.
+ *
+ * `invisible` keeps the 3x3 grid from reflowing, which is how the diagonals
+ * were already handled.
+ */
+describe('PTZControls axis capabilities', () => {
+  const isHidden = (testId: string) =>
+    screen.getByTestId(testId).className.includes('invisible');
+
+  it('hides the tilt arrows and keeps pan when the driver cannot tilt', () => {
+    const panOnly = {
+      CanMove: '1', CanMoveCon: '1', CanPan: '1', CanTilt: '0',
+    } as unknown as ZMControl;
+
+    render(<PTZControls onCommand={vi.fn()} control={panOnly} />);
+
+    expect(isHidden('ptz-up')).toBe(true);
+    expect(isHidden('ptz-down')).toBe(true);
+    expect(isHidden('ptz-left')).toBe(false);
+    expect(isHidden('ptz-right')).toBe(false);
+  });
+
+  it('hides the pan arrows and keeps tilt when the driver cannot pan', () => {
+    const tiltOnly = {
+      CanMove: '1', CanMoveCon: '1', CanPan: '0', CanTilt: '1',
+    } as unknown as ZMControl;
+
+    render(<PTZControls onCommand={vi.fn()} control={tiltOnly} />);
+
+    expect(isHidden('ptz-left')).toBe(true);
+    expect(isHidden('ptz-right')).toBe(true);
+    expect(isHidden('ptz-up')).toBe(false);
+    expect(isHidden('ptz-down')).toBe(false);
+  });
+
+  it('hides the diagonals when an axis is missing, even with CanMoveDiag', () => {
+    const panOnlyDiag = {
+      CanMove: '1', CanMoveCon: '1', CanPan: '1', CanTilt: '0', CanMoveDiag: '1',
+    } as unknown as ZMControl;
+
+    render(<PTZControls onCommand={vi.fn()} control={panOnlyDiag} />);
+
+    for (const id of ['ptz-up-left', 'ptz-up-right', 'ptz-down-left', 'ptz-down-right']) {
+      expect(isHidden(id)).toBe(true);
+    }
+  });
+
+  it('shows every arrow when a control definition omits the axis fields', () => {
+    const legacy = { CanMove: '1', CanMoveCon: '1', CanMoveDiag: '1' } as unknown as ZMControl;
+
+    render(<PTZControls onCommand={vi.fn()} control={legacy} />);
+
+    for (const id of ['ptz-up', 'ptz-down', 'ptz-left', 'ptz-right', 'ptz-up-left']) {
+      expect(isHidden(id)).toBe(false);
+    }
+  });
+});

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -98,6 +98,8 @@ Three things to expect. It works on MJPEG streams only, so a monitor served over
 
 If the monitor has PTZ (Pan-Tilt-Zoom) configured in ZoneMinder, directional controls appear below the live view. Use these to pan, tilt, and zoom the camera.
 
+The pad shows only the directions the camera's control definition claims. A mount that pans but cannot tilt gets the left and right arrows without up and down, and the diagonals need both axes, so the arrows you see are the ones the camera will act on.
+
 ### Recent Events
 
 A list of recent events for this specific monitor, with thumbnails and timestamps. You can select and delete multiple events from this list the same way as on the main Events screen, see {doc}`events`.


### PR DESCRIPTION
## What

Gate the PTZ direction pad on the axes the driver actually has, the way
ZoneMinder's own control panel does.

- up/down hidden without `CanTilt`
- left/right hidden without `CanPan`
- diagonals require both axes in addition to `CanMoveDiag`

## Why

`app/src/api/types.ts` already parses `CanPan` and `CanTilt`, but
`PTZControls.tsx` never read them, so every controllable monitor got the full
3x3 pad. On a pan-only driver the tilt arrows send `moveConUp`/`moveConDown`
commands the driver rejects.

ZoneMinder gates the same three cases in
`web/skins/classic/includes/control_functions.php`:

```php
$hasPan  = $control->CanPan();
$hasTilt = $control->CanTilt();
$hasDiag = $hasPan && $hasTilt && $control->CanMoveDiag();
```

```php
class="arrowBtn upBtn<?php echo $hasTilt?'':' invisible' ?>"
class="arrowBtn leftBtn<?php echo $hasPan?'':' invisible' ?>"
```

This reuses the `invisible` class the diagonals already used, so the grid keeps
its shape instead of reflowing when an axis is missing.

## Backward compatibility

Only an explicit `'0'` hides an axis. A control definition that omits the field
renders exactly as it does today — gating on `=== '1'` would have hidden every
arrow for those, which is a worse failure than showing one that does nothing.
The fourth test pins this.

## Tests

Four cases in `PTZControls.test.tsx`: pan-only, tilt-only, diagonals with an
axis missing, and the omitted-fields fallback. The first three fail on `main`
and pass with this change; the fourth passes on both and guards the
compatibility path above.

`npm run gates` passes.

refs #373

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
