### PR TITLE
fix(ptz): treat a non-capable axis flag as non-capable

### DIFF
--- a/AGENTS.project.md
+++ b/AGENTS.project.md
@@ -123,7 +123,6 @@ Gate: `app/src/tests/agents-contracts.test.ts`; review.
 - Flex text uses `min-w-0`, `truncate`, and a `title`; multi-line text uses `line-clamp-N`.
 - Do not commit incidental native build-number bumps. Commit intended bumps alone as `chore:`.
 - GitHub comments end with `Posted by Claude, assisting @<login>.`, where `<login>` comes from `gh api user --jq .login`. Never hardcode a username. Commits carry no such line.
-- Label issues and PRs `core` (behavior changes) or `refactor` (behavior-preserving) by hand.
 - Test builds use a matching GitHub workflow; add one only when none fits.
 - Developer docs teach React where they first rely on it.
 

--- a/app/src/components/monitors/PTZControls.tsx
+++ b/app/src/components/monitors/PTZControls.tsx
@@ -149,11 +149,14 @@ export function PTZControls({ onCommand, profileId, className, disabled, control
   // The driver decides which axes exist. ZoneMinder hides the up/down arrows
   // without CanTilt and left/right without CanPan (skins/classic/includes/
   // control_functions.php), so a pan-only driver never gets tilt buttons whose
-  // commands it would reject. Only an explicit '0' hides an axis: a control
-  // definition that omits the field predates the column, and losing every arrow
-  // there would be worse than showing one that does nothing.
-  const canPan = control?.CanPan !== '0';
-  const canTilt = control?.CanTilt !== '0';
+  // commands it would reject. Present means '1', as everywhere else here: the
+  // schema coerces the field to a string, so a server answering with a JSON
+  // boolean or an empty column would slip past a `!== '0'` test. An absent
+  // field is the one case treated as capable, since losing every arrow on a
+  // control definition that never sent the column is worse than showing one
+  // that does nothing.
+  const canPan = control?.CanPan === undefined || control.CanPan === '1';
+  const canTilt = control?.CanTilt === undefined || control.CanTilt === '1';
   // Diagonals need both axes, matching $hasDiag in control_functions.php.
   const canMoveDiag = canPan && canTilt && control?.CanMoveDiag === '1';
   const canMoveCon = control?.CanMoveCon === '1';

--- a/app/src/components/monitors/__tests__/PTZControls.test.tsx
+++ b/app/src/components/monitors/__tests__/PTZControls.test.tsx
@@ -184,8 +184,10 @@ describe('PTZControls without control permission', () => {
  * were already handled.
  */
 describe('PTZControls axis capabilities', () => {
-  const isHidden = (testId: string) =>
-    screen.getByTestId(testId).className.includes('invisible');
+  const expectHidden = (testId: string) =>
+    expect(screen.getByTestId(testId)).toHaveClass('invisible');
+  const expectShown = (testId: string) =>
+    expect(screen.getByTestId(testId)).not.toHaveClass('invisible');
 
   it('hides the tilt arrows and keeps pan when the driver cannot tilt', () => {
     const panOnly = {
@@ -194,10 +196,10 @@ describe('PTZControls axis capabilities', () => {
 
     render(<PTZControls onCommand={vi.fn()} control={panOnly} />);
 
-    expect(isHidden('ptz-up')).toBe(true);
-    expect(isHidden('ptz-down')).toBe(true);
-    expect(isHidden('ptz-left')).toBe(false);
-    expect(isHidden('ptz-right')).toBe(false);
+    expectHidden('ptz-up');
+    expectHidden('ptz-down');
+    expectShown('ptz-left');
+    expectShown('ptz-right');
   });
 
   it('hides the pan arrows and keeps tilt when the driver cannot pan', () => {
@@ -207,10 +209,10 @@ describe('PTZControls axis capabilities', () => {
 
     render(<PTZControls onCommand={vi.fn()} control={tiltOnly} />);
 
-    expect(isHidden('ptz-left')).toBe(true);
-    expect(isHidden('ptz-right')).toBe(true);
-    expect(isHidden('ptz-up')).toBe(false);
-    expect(isHidden('ptz-down')).toBe(false);
+    expectHidden('ptz-left');
+    expectHidden('ptz-right');
+    expectShown('ptz-up');
+    expectShown('ptz-down');
   });
 
   it('hides the diagonals when an axis is missing, even with CanMoveDiag', () => {
@@ -221,7 +223,7 @@ describe('PTZControls axis capabilities', () => {
     render(<PTZControls onCommand={vi.fn()} control={panOnlyDiag} />);
 
     for (const id of ['ptz-up-left', 'ptz-up-right', 'ptz-down-left', 'ptz-down-right']) {
-      expect(isHidden(id)).toBe(true);
+      expectHidden(id);
     }
   });
 
@@ -231,7 +233,24 @@ describe('PTZControls axis capabilities', () => {
     render(<PTZControls onCommand={vi.fn()} control={legacy} />);
 
     for (const id of ['ptz-up', 'ptz-down', 'ptz-left', 'ptz-right', 'ptz-up-left']) {
-      expect(isHidden(id)).toBe(false);
+      expectShown(id);
     }
+  });
+
+  it('hides an axis the server reports as anything other than capable', () => {
+    // ZMControlSchema coerces the field to a string, so a server that answers
+    // with a JSON boolean or an empty column arrives here as 'false' or ''.
+    // Those mean the same as '0' and must hide the axis; only an absent field
+    // is treated as capable.
+    const coercedFalse = {
+      CanMove: '1', CanMoveCon: '1', CanPan: 'false', CanTilt: '',
+    } as unknown as ZMControl;
+
+    render(<PTZControls onCommand={vi.fn()} control={coercedFalse} />);
+
+    expectHidden('ptz-left');
+    expectHidden('ptz-right');
+    expectHidden('ptz-up');
+    expectHidden('ptz-down');
   });
 });

--- a/docs/developer-guide/14-agent-development-model.rst
+++ b/docs/developer-guide/14-agent-development-model.rst
@@ -94,9 +94,6 @@ Every workflow, and what fires it:
      - every PR, push to main
      - version guard, lints, build, unit tests (full-history checkout for
        the evidence gate), web e2e
-   * - ``label-guard.yml``
-     - PR open/sync/label events
-     - requires or auto-assigns the ``core``/``refactor`` label
    * - ``claude.yml``
      - @claude mention on issues and PRs
      - summons an agent into the thread
@@ -227,8 +224,7 @@ whole-branch review runs before the PR. The
 records the practices that make this reliable, down to the trap that a
 piped gate command hides a red exit status.
 
-The PR itself is mostly ceremony by this point: the label guard derives
-``core`` or ``refactor`` from the commit types, branch protection holds
+The PR itself is mostly ceremony by this point: branch protection holds
 the merge until every required check passes, and the merge is queued with
 GitHub auto-merge rather than polled for. What the gates cannot prove,
 the maintainer checks by hand where it matters: UI work gets a real
@@ -266,10 +262,7 @@ A **gate** is a script that enforces a rule. Rule M1 requires one for any
 rule a script could check, added in the same change as the rule; an audit
 here once found every ungated rule violated while every gated rule held,
 which is the entire argument. Current gates: the unit suite, three
-blocking lints, the ratcheted lint baseline, a CI
-`label guard <https://github.com/ZoneMinder/zmNinjaNg/blob/main/.github/workflows/label-guard.yml>`__
-that requires a ``core`` or ``refactor`` label on every PR (derived from
-commit types when absent), and
+blocking lints, the ratcheted lint baseline, and
 `agents-contracts.test.ts <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/tests/agents-contracts.test.ts>`__,
 which checks the instruction files themselves: symbols named in contracts
 exist in the code, the core file contains no project names, the
@@ -316,8 +309,7 @@ How the pieces fit
      PP === GATE
      GP === GATE
      CL === GATE
-     PR["every PR"] === LG["label-guard.yml<br/>core / refactor label"]
-     PR === CI["ci.yml<br/>tests, lints, build, web e2e"]
+     PR["every PR"] === CI["ci.yml<br/>tests, lints, build, web e2e"]
      GATE --> CI
      FAIL["breakage or review finding"] -- "fix PR proposes rule + gate<br/>(self-improvement protocol)" --> AG
      FAIL -- "durable fact (M5)" --> PP
@@ -496,9 +488,8 @@ here are structural rather than tooling:
   recorded maintainer decision, not a silent bump.
 - Ceremony is priced: implementation delegates to subagents on the
   cheapest model that fits the task, trivial gate-covered edits skip the
-  dispatch entirely, independent review runs only where judgment is
-  involved, and the label guard classifies PRs from commit types instead
-  of spending a model call on it. Plans that embed their tests verbatim
+  dispatch entirely, and independent review runs only where judgment is
+  involved. Plans that embed their tests verbatim
   are part of the same economics: transcription is the cheapest work a
   model does, so the expensive thinking happens once, at planning time.
 
@@ -514,9 +505,9 @@ this repo; it shapes the maintainer's sessions, not the repository.
 
 Two honest observations from using the stack on this project. Ponytail's
 bias shows up in decisions that are visible in the history: two
-instruction files instead of a template hierarchy, one gate file instead
-of a test per rule, a shell heuristic instead of a model call in the
-label guard. And output compression is the reason rule P6 exists: in one
+instruction files instead of a template hierarchy, and one gate file
+instead of a test per rule. And output compression is the reason rule P6
+exists: in one
 working session the rtk wrapper capped a commit count at 50 on a
 2254-commit repo, hid a failing test behind a log-file path, and masked a
 red gate's exit status through a pipeline, each caught only by rerunning
@@ -552,8 +543,7 @@ produces most of the seed content.
 Claude Code needs a two-line
 `CLAUDE.md <https://github.com/ZoneMinder/zmNinjaNg/blob/main/CLAUDE.md>`__
 importing the two instruction files; other harnesses read ``AGENTS.md``
-directly. The labels, the label-guard workflow, and the two periodic
-reviews are all optional.
+directly. The two periodic reviews are optional.
 
 Do not start with thirty rules. A handful of contracts plus the core is
 enough, and the protocol grows the rest one incident at a time. Rules
@@ -569,7 +559,6 @@ Where everything lives
 - `agents/project/ <https://github.com/ZoneMinder/zmNinjaNg/tree/main/agents/project>`__, area playbooks and `domain-context.md <https://github.com/ZoneMinder/zmNinjaNg/blob/main/agents/project/domain-context.md>`__
 - `docs/superpowers/ <https://github.com/ZoneMinder/zmNinjaNg/tree/main/docs/superpowers>`__, approved specs and implementation plans
 - `agents-contracts.test.ts <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/tests/agents-contracts.test.ts>`__, the instruction-system gate
-- `label-guard.yml <https://github.com/ZoneMinder/zmNinjaNg/blob/main/.github/workflows/label-guard.yml>`__, the PR label gate
 - `mine-history <https://github.com/ZoneMinder/zmNinjaNg/tree/main/.claude/skills/mine-history>`__, the history mining skill
 - `fable-review <https://github.com/ZoneMinder/zmNinjaNg/tree/main/.claude/skills/fable-review>`__, the scored codebase review skill
 


### PR DESCRIPTION
## What

Two follow-ups to #375, plus one instruction-file change.

1. `PTZControls` gated the pan and tilt axes with `!== '0'`. `ZMControlSchema` runs `z.coerce.string()` over every control field, so a server answering `CanPan` with a JSON boolean, or an empty column, arrives as `'false'` or `''` — both of which passed that test and rendered an arrow the driver rejects. Gate on `'1'` like the surrounding flags, keeping the absent field as the one case treated as capable, so a control definition that never sent the column still gets its arrows.
2. The axis tests asserted `className.includes('invisible')`, which passes for any class merely containing that word. `toHaveClass` instead.
3. Drop the "label issues and PRs `core`/`refactor` by hand" project rule. The `label-guard.yml` workflow that enforced it was removed in 136654f9, which left the rule ungated (M1) and its stale required status check silently blocking every PR merge. The developer-guide passages describing that workflow go with it.

## Tests

One new case in `PTZControls.test.tsx` covering a present-but-not-capable value (`CanPan: 'false'`, `CanTilt: ''`). It fails on `main` and passes here; the four cases from #375 still pass, including the omitted-fields fallback.

`npm run gates` passes: 4179 unit tests, build, three lints, ratchet within baseline.

refs #373