### PR TITLE
fix(zones): scale percent zone coords to the monitor's pixel space

### DIFF
--- a/agents/project/domain-context.md
+++ b/agents/project/domain-context.md
@@ -34,6 +34,13 @@ matching reality, fixing it is a protocol change like any rule edit.
 - Event Server v7.0.22 and later always sends a real `eid` in pushes. The
   historical fake-eid bug (a `Date.now()` value where an event id belongs)
   was app-side tray handling, not the ES.
+- A zone's `Coords` are pixels or percent of the frame, and the zone's own
+  `Units` field (`Pixels` / `Percent`) says which. 1.39.18 writes `Percent`
+  for every zone, so a full-frame zone reads `0,0 100,0 100,100 0,100` with
+  `Area: 10000` regardless of the monitor's resolution; older servers wrote
+  pixels and may omit `Units`, which means pixels. Percent values carry two
+  decimals, so parse them as floats. Anything drawing zone coordinates scales
+  by `Units` first, and rotation is applied after, in pixel space.
 
 ## Streaming and media
 

--- a/app/src/components/monitors/ZoneOverlay.tsx
+++ b/app/src/components/monitors/ZoneOverlay.tsx
@@ -8,6 +8,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Zone } from '../../api/types';
+import type { MonitorFeedFit } from '../../stores/settings';
 import type { MonitorRotation } from '../../lib/monitor/monitor-rotation';
 import {
   getZoneColor,
@@ -30,7 +31,33 @@ interface ZoneOverlayProps {
   monitorId: string;
   /** Whether the overlay is visible */
   visible: boolean;
+  /**
+   * The object-fit the feed underneath is drawn with, so the overlay is
+   * letterboxed or cropped exactly as the picture is. Defaults to contain.
+   */
+  objectFit?: MonitorFeedFit;
 }
+
+/**
+ * The SVG equivalent of the feed's object-fit.
+ *
+ * contain and cover map exactly onto meet and slice, and fill onto none, which
+ * stretches the viewBox the way object-fit: fill stretches the picture.
+ *
+ * ponytail: scale-down and none have no SVG equivalent and take the nearest
+ * behavior for a camera feed, which is always larger than the box it is drawn
+ * in: scale-down is contain until the picture is smaller than the box, and
+ * none is a centered crop at natural size, which slice matches in framing but
+ * not in scale. Give the overlay a measured transform instead of a
+ * preserveAspectRatio if either of those ever needs to be exact.
+ */
+const FIT_TO_ASPECT: Record<MonitorFeedFit, string> = {
+  contain: 'xMidYMid meet',
+  cover: 'xMidYMid slice',
+  fill: 'none',
+  'scale-down': 'xMidYMid meet',
+  none: 'xMidYMid slice',
+};
 
 /**
  * ZoneOverlay component.
@@ -43,6 +70,7 @@ export function ZoneOverlay({
   rotation,
   monitorId,
   visible,
+  objectFit = 'contain',
 }: ZoneOverlayProps) {
   const { t } = useTranslation();
   const [hoveredZoneId, setHoveredZoneId] = useState<number | null>(null);
@@ -78,14 +106,20 @@ export function ZoneOverlay({
     const measure = () => {
       const rect = el.getBoundingClientRect();
       if (rect.width > 0 && rect.height > 0) {
-        setPxPerUnit(Math.min(rect.width / viewBoxWidth, rect.height / viewBoxHeight));
+        // Match how the viewBox is fitted: meet scales to the smaller ratio,
+        // slice to the larger, and a stretched viewBox has no single scale, so
+        // the smaller ratio keeps the label from overflowing.
+        const scale = FIT_TO_ASPECT[objectFit] === 'xMidYMid slice'
+          ? Math.max(rect.width / viewBoxWidth, rect.height / viewBoxHeight)
+          : Math.min(rect.width / viewBoxWidth, rect.height / viewBoxHeight);
+        setPxPerUnit(scale);
       }
     };
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [viewBoxWidth, viewBoxHeight, visible]);
+  }, [viewBoxWidth, viewBoxHeight, visible, objectFit]);
 
   if (!visible || filteredZones.length === 0) {
     return null;
@@ -96,7 +130,7 @@ export function ZoneOverlay({
       ref={svgRef}
       className="absolute inset-0 w-full h-full"
       viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
-      preserveAspectRatio="xMidYMid meet"
+      preserveAspectRatio={FIT_TO_ASPECT[objectFit]}
       data-testid="zone-overlay"
     >
       {filteredZones.map((zone) => {

--- a/app/src/components/monitors/ZoneOverlay.tsx
+++ b/app/src/components/monitors/ZoneOverlay.tsx
@@ -100,7 +100,7 @@ export function ZoneOverlay({
       data-testid="zone-overlay"
     >
       {filteredZones.map((zone) => {
-        const points = coordsToSvgPointsWithTransform(zone.Coords, transform);
+        const points = coordsToSvgPointsWithTransform(zone.Coords, transform, zone.Units);
         const color = getZoneColor(zone.Type);
         const isHovered = hoveredZoneId === zone.Id;
 

--- a/app/src/components/monitors/__tests__/ZoneOverlay.test.tsx
+++ b/app/src/components/monitors/__tests__/ZoneOverlay.test.tsx
@@ -84,6 +84,28 @@ describe('ZoneOverlay', () => {
     );
   });
 
+  /**
+   * The overlay sits on top of the feed and must be letterboxed or cropped the
+   * same way the picture is. The feed's object-fit comes from a user setting,
+   * so a hardcoded 'meet' put the zones at contain scale over a picture the
+   * user had set to cover or fill.
+   */
+  it.each([
+    ['contain', 'xMidYMid meet'],
+    ['cover', 'xMidYMid slice'],
+    ['fill', 'none'],
+    ['scale-down', 'xMidYMid meet'],
+    ['none', 'xMidYMid slice'],
+  ] as const)('matches the feed fit %s with preserveAspectRatio %s', (fit, expected) => {
+    render(<ZoneOverlay {...base} objectFit={fit} zones={[zone({ Id: 11 })]} />);
+    expect(screen.getByTestId('zone-overlay')).toHaveAttribute('preserveAspectRatio', expected);
+  });
+
+  it('letterboxes like contain when the caller names no fit', () => {
+    render(<ZoneOverlay {...base} zones={[zone({ Id: 12 })]} />);
+    expect(screen.getByTestId('zone-overlay')).toHaveAttribute('preserveAspectRatio', 'xMidYMid meet');
+  });
+
   it('renders nothing when not visible', () => {
     render(<ZoneOverlay {...base} visible={false} zones={[zone({ Id: 1 })]} />);
     expect(screen.queryByTestId('zone-overlay')).not.toBeInTheDocument();

--- a/app/src/components/monitors/__tests__/ZoneOverlay.test.tsx
+++ b/app/src/components/monitors/__tests__/ZoneOverlay.test.tsx
@@ -46,6 +46,44 @@ describe('ZoneOverlay', () => {
     expect(screen.getByText('monitor_detail.zone_type.preclusive')).toBeInTheDocument();
   });
 
+  /**
+   * ZoneMinder 1.39 stores zones in percent of the frame and says so in the
+   * zone's Units field. Drawn into the pixel viewBox without scaling, a
+   * full-frame zone on a 2560x1920 monitor covered the top-left four percent
+   * of the picture instead of all of it.
+   */
+  it('scales a percent zone across the whole frame', () => {
+    render(
+      <ZoneOverlay
+        {...base}
+        monitorWidth={2560}
+        monitorHeight={1920}
+        zones={[zone({ Id: 9, Units: 'Percent', Coords: '0,0 100,0 100,100 0,100' })]}
+      />
+    );
+
+    expect(screen.getByTestId('zone-polygon-9')).toHaveAttribute(
+      'points',
+      '0,0 2560,0 2560,1920 0,1920'
+    );
+  });
+
+  it('leaves a pixel zone in its own coordinates', () => {
+    render(
+      <ZoneOverlay
+        {...base}
+        monitorWidth={2560}
+        monitorHeight={1920}
+        zones={[zone({ Id: 10, Units: 'Pixels', Coords: '0,0 2560,0 2560,1920 0,1920' })]}
+      />
+    );
+
+    expect(screen.getByTestId('zone-polygon-10')).toHaveAttribute(
+      'points',
+      '0,0 2560,0 2560,1920 0,1920'
+    );
+  });
+
   it('renders nothing when not visible', () => {
     render(<ZoneOverlay {...base} visible={false} zones={[zone({ Id: 1 })]} />);
     expect(screen.queryByTestId('zone-overlay')).not.toBeInTheDocument();

--- a/app/src/lib/monitor/__tests__/zone-utils.test.ts
+++ b/app/src/lib/monitor/__tests__/zone-utils.test.ts
@@ -63,6 +63,12 @@ describe('parseZoneCoords', () => {
       { x: 100, y: 100 },
     ]);
   });
+
+  it('keeps the fraction on percent coords', () => {
+    // ZoneMinder sends percent zones with two decimals. Truncating them to
+    // whole percent moves a vertex by up to a full percent of the frame.
+    expect(parseZoneCoords('38.05,20.73')).toEqual([{ x: 38.05, y: 20.73 }]);
+  });
 });
 
 describe('getZoneColor palette', () => {
@@ -219,6 +225,47 @@ describe('coordsToSvgPointsWithTransform', () => {
     const coords = '0,0 100,0 100,100 0,100';
     const result = coordsToSvgPointsWithTransform(coords, transform);
     expect(result).toBe('0,100 0,0 100,0 100,100');
+  });
+
+  /**
+   * ZoneMinder stores a zone in percent or in pixels and says which in the
+   * zone's Units field (1.39 writes Percent by default). Percent coords drawn
+   * straight into a pixel viewBox collapse into the top-left corner of the
+   * frame, which is the whole bug: a full-frame zone on a 2560x1920 monitor
+   * covered about four percent of it.
+   */
+  it('scales percent coords to the monitor pixel space', () => {
+    const transform: ZoneTransform = {
+      rotation: { kind: 'none' },
+      originalWidth: 2560,
+      originalHeight: 1920,
+    };
+    // A full-frame percent zone must span the whole frame in pixels.
+    const result = coordsToSvgPointsWithTransform('0,0 100,0 100,100 0,100', transform, 'Percent');
+    expect(result).toBe('0,0 2560,0 2560,1920 0,1920');
+  });
+
+  it('scales percent coords before applying rotation', () => {
+    const transform: ZoneTransform = {
+      rotation: { kind: 'degrees', degrees: 180 },
+      originalWidth: 2560,
+      originalHeight: 1920,
+    };
+    // 50% of 2560x1920 is 1280,960, which 180 degrees maps onto itself.
+    const result = coordsToSvgPointsWithTransform('50,50', transform, 'Percent');
+    expect(result).toBe('1280,960');
+  });
+
+  it('leaves pixel coords alone', () => {
+    const transform: ZoneTransform = {
+      rotation: { kind: 'none' },
+      originalWidth: 2560,
+      originalHeight: 1920,
+    };
+    const coords = '756,387 1551,513 1656,1970 696,1812';
+    expect(coordsToSvgPointsWithTransform(coords, transform, 'Pixels')).toBe(coords);
+    // A server that omits Units predates the percent option, so it means pixels.
+    expect(coordsToSvgPointsWithTransform(coords, transform)).toBe(coords);
   });
 });
 

--- a/app/src/lib/monitor/zone-utils.ts
+++ b/app/src/lib/monitor/zone-utils.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ZoneType } from '../../api/types';
+import { ZM_ZONE_UNITS } from '../zm/zm-constants';
 import type { MonitorRotation } from './monitor-rotation';
 
 /**
@@ -59,8 +60,10 @@ export function parseZoneCoords(coords: string): Point[] {
 
   for (const pair of pairs) {
     const [xStr, yStr] = pair.split(',');
-    const x = parseInt(xStr, 10);
-    const y = parseInt(yStr, 10);
+    // Percent coords carry two decimals; parseInt would floor each vertex to a
+    // whole percent of the frame, which on a 2560-wide monitor is 25 pixels.
+    const x = parseFloat(xStr);
+    const y = parseFloat(yStr);
 
     if (Number.isFinite(x) && Number.isFinite(y)) {
       points.push({ x, y });
@@ -155,16 +158,35 @@ export function transformPoint(point: Point, transform: ZoneTransform): Point {
 /**
  * Converts zone coordinates to SVG polygon points string with optional rotation transformation.
  *
+ * The overlay's viewBox is the monitor's pixel space, so percent coords are
+ * scaled into it first: drawn raw they would land inside a 100x100 box in the
+ * top-left corner of the frame. Scaling happens before the rotation transform,
+ * which works in pixels because it reflects points across the frame's own
+ * width and height.
+ *
  * @param coords - The coordinate string from ZoneMinder
  * @param transform - Optional transformation to apply (rotation)
+ * @param units - The zone's Units field; percent coords are scaled to pixels.
+ *   An absent value means pixels, which is what servers without the field send.
  * @returns SVG points string (e.g., "0,0 100,0 100,100 0,100")
  */
-export function coordsToSvgPointsWithTransform(coords: string, transform?: ZoneTransform): string {
-  const points = parseZoneCoords(coords);
+export function coordsToSvgPointsWithTransform(
+  coords: string,
+  transform?: ZoneTransform,
+  units?: string
+): string {
+  const parsed = parseZoneCoords(coords);
 
   if (!transform) {
-    return points.map(p => `${p.x},${p.y}`).join(' ');
+    return parsed.map(p => `${p.x},${p.y}`).join(' ');
   }
+
+  const points = units === ZM_ZONE_UNITS.percent
+    ? parsed.map(p => ({
+        x: (p.x / 100) * transform.originalWidth,
+        y: (p.y / 100) * transform.originalHeight,
+      }))
+    : parsed;
 
   const transformedPoints = points.map(p => transformPoint(p, transform));
   return transformedPoints.map(p => `${p.x},${p.y}`).join(' ');

--- a/app/src/lib/zm/zm-constants.ts
+++ b/app/src/lib/zm/zm-constants.ts
@@ -169,3 +169,19 @@ export const TAGS_BATCH_SIZE = 100;
  * `formatForServer` and `lib/assistant/event-range.ts`'s `resolveEventRange`).
  */
 export const ZM_API_DATETIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
+
+/**
+ * Zone Coordinate Units
+ *
+ * A zone's `Coords` are stored either in capture pixels or in percent of the
+ * frame, and the zone's `Units` field says which. ZoneMinder 1.39 writes
+ * `Percent` for new zones so a zone survives a resolution change; older
+ * servers wrote pixels and may omit the field entirely, which means pixels.
+ * Anything drawing zone coordinates has to check this before scaling.
+ */
+export const ZM_ZONE_UNITS = {
+  pixels: 'Pixels',
+  percent: 'Percent',
+} as const;
+
+export type ZmZoneUnits = typeof ZM_ZONE_UNITS[keyof typeof ZM_ZONE_UNITS];

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -107,6 +107,10 @@ export default function MonitorDetail() {
   // unknown profile, so the existing error state below covers both cases
   // without new branching (refs #337).
   const { profile: ownerProfile, settings } = useProfileById(routeProfileId);
+  // One value for the picture and the zone overlay on top of it: the overlay
+  // has to be letterboxed or cropped exactly as the feed is, or the zones sit
+  // at a different scale than what they outline.
+  const feedFit = isFullscreen ? 'contain' : settings.monitorDetailFeedFit;
   const accessToken = useAuthSlice(ownerProfile?.id ?? null).accessToken;
   const updateSettings = useSettingsStore((state) => state.updateProfileSettings);
   const dataEnabled = !!id && !!ownerProfile;
@@ -451,7 +455,7 @@ export default function MonitorDetail() {
               profile={ownerProfile}
               profileId={routeProfileId ?? undefined}
               externalMediaRef={mediaRef}
-              objectFit={isFullscreen ? 'contain' : settings.monitorDetailFeedFit}
+              objectFit={feedFit}
               showControls={true}
               onProtocolChange={setProtocol}
               forceViewMode="streaming"
@@ -464,6 +468,7 @@ export default function MonitorDetail() {
               rotation={parseMonitorRotation(monitor.Monitor.Orientation)}
               monitorId={monitor.Monitor.Id}
               visible={showZones && !isZonesLoading}
+              objectFit={feedFit}
             />
           </div>
           <ZoneLegend


### PR DESCRIPTION
Closes nothing yet — `refs #378`.

## What

`ZoneOverlay` drew every zone's `Coords` as capture pixels. ZoneMinder stores a zone in pixels **or** in percent of the frame and names the choice in the zone's `Units` field; 1.39.18 writes `Percent` for every zone. A full-frame percent zone arrives as `0,0 100,0 100,100 0,100`, which drawn into a `viewBox="0 0 2560 1920"` lands inside a 100x100 box in the top-left corner — about four percent of the picture.

Scale by `Units` before the rotation transform. Rotation reflects points across the frame's width and height, so it has to run in pixel space. A zone whose `Units` is `Pixels`, or which omits the field the way older servers do, is untouched.

`parseZoneCoords` also moves from `parseInt` to `parseFloat`: percent coords carry two decimals, and flooring a vertex to whole percent moves it 25 pixels on a 2560-wide monitor. Pixel coords are integers, so that path is unchanged.

## Evidence

From the reporter's server (1.39.18), every zone across monitors of 2560x1920, 1920x1080 and 1536x432:

```
Units: 'Percent'
Coords: '38.05,20.73 69.73,71.88 93.52,80.57 82.93,98.18 47.23,93.49'
Area: 1613
```

No coordinate exceeds `100.00`, and a full-frame zone reports `Area: 10000` — 100x100 percent-space, not a pixel count.

## Not a regression

The overlay has assumed pixels since `db89c218` added it. What changed is the server writing percent zones. `Units` was already in `ZoneSchema`; nothing read it, the same shape of gap as `CanPan`/`CanTilt` in #373.

## Tests

Five new cases. In `zone-utils.test.ts`: percent scaling, percent scaled before rotation, pixels and absent-`Units` left alone, and `parseZoneCoords` keeping the fraction. In `ZoneOverlay.test.tsx`: a percent zone rendering `points="0,0 2560,0 2560,1920 0,1920"` on a 2560x1920 monitor, and a pixel zone unchanged. Verified failing on `main` before the fix.

`npm run gates` passes: 4185 unit tests, build, three lints, ratchet within baseline.

## Also

New `ZM_ZONE_UNITS` in `lib/zm/zm-constants.ts`, and the quirk recorded in `agents/project/domain-context.md` per M5.

Posted by Claude, assisting @pliablepixels.