### PR TITLE
fix(zones): decide a zone's coordinate space the way ZoneMinder does

### DIFF
--- a/agents/project/domain-context.md
+++ b/agents/project/domain-context.md
@@ -34,13 +34,19 @@ matching reality, fixing it is a protocol change like any rule edit.
 - Event Server v7.0.22 and later always sends a real `eid` in pushes. The
   historical fake-eid bug (a `Date.now()` value where an event id belongs)
   was app-side tray handling, not the ES.
-- A zone's `Coords` are pixels or percent of the frame, and the zone's own
-  `Units` field (`Pixels` / `Percent`) says which. 1.39.18 writes `Percent`
-  for every zone, so a full-frame zone reads `0,0 100,0 100,100 0,100` with
-  `Area: 10000` regardless of the monitor's resolution; older servers wrote
-  pixels and may omit `Units`, which means pixels. Percent values carry two
-  decimals, so parse them as floats. Anything drawing zone coordinates scales
-  by `Units` first, and rotation is applied after, in pixel space.
+- A zone's `Coords` are pixels or percent of the frame and no field says
+  which. The zone's `Units` column (`Pixels` / `Percent`) describes the
+  analysis parameters (`MinAlarmPixels` and friends), not the coordinates, and
+  its column default is now `Percent`, so a zone carried over from an older
+  server reads `Units: Percent` over pixel coords. Trusting that field scales
+  those coords by a hundred and throws the polygon off the frame. ZoneMinder's
+  own renderer decides by magnitude, in `web/includes/Zone.php`'s
+  `svg_polygon`: any point above 100 makes the whole zone pixels, everything
+  at or below is percent. Match it, corner included (a pixel zone inside the
+  top-left 100x100 reads as percent), so a zone looks the same here as in
+  ZoneMinder's zone editor. 1.39.18 writes percent, so a full-frame zone reads
+  `0,0 100,0 100,100 0,100`; percent values carry two decimals, so parse them
+  as floats, and scale before rotation, which works in pixel space.
 
 ## Streaming and media
 

--- a/app/src/components/monitors/ZoneOverlay.tsx
+++ b/app/src/components/monitors/ZoneOverlay.tsx
@@ -134,7 +134,7 @@ export function ZoneOverlay({
       data-testid="zone-overlay"
     >
       {filteredZones.map((zone) => {
-        const points = coordsToSvgPointsWithTransform(zone.Coords, transform, zone.Units);
+        const points = coordsToSvgPointsWithTransform(zone.Coords, transform);
         const color = getZoneColor(zone.Type);
         const isHovered = hoveredZoneId === zone.Id;
 

--- a/app/src/components/monitors/__tests__/ZoneOverlay.test.tsx
+++ b/app/src/components/monitors/__tests__/ZoneOverlay.test.tsx
@@ -58,7 +58,7 @@ describe('ZoneOverlay', () => {
         {...base}
         monitorWidth={2560}
         monitorHeight={1920}
-        zones={[zone({ Id: 9, Units: 'Percent', Coords: '0,0 100,0 100,100 0,100' })]}
+        zones={[zone({ Id: 9, Coords: '0,0 100,0 100,100 0,100' })]}
       />
     );
 
@@ -81,6 +81,28 @@ describe('ZoneOverlay', () => {
     expect(screen.getByTestId('zone-polygon-10')).toHaveAttribute(
       'points',
       '0,0 2560,0 2560,1920 0,1920'
+    );
+  });
+
+  /**
+   * A zone's Units field describes its analysis parameters, not its
+   * coordinates, and the column now defaults to Percent. A zone carried over
+   * from an older server can therefore say Percent over pixel coords, and
+   * scaling those would throw the polygon far off the frame.
+   */
+  it('keeps a pixel zone that claims Percent units', () => {
+    render(
+      <ZoneOverlay
+        {...base}
+        monitorWidth={2560}
+        monitorHeight={1920}
+        zones={[zone({ Id: 13, Units: 'Percent', Coords: '756,387 1551,513 1656,1970 696,1812' })]}
+      />
+    );
+
+    expect(screen.getByTestId('zone-polygon-13')).toHaveAttribute(
+      'points',
+      '756,387 1551,513 1656,1970 696,1812'
     );
   });
 

--- a/app/src/lib/monitor/__tests__/zone-utils.test.ts
+++ b/app/src/lib/monitor/__tests__/zone-utils.test.ts
@@ -241,7 +241,7 @@ describe('coordsToSvgPointsWithTransform', () => {
       originalHeight: 1920,
     };
     // A full-frame percent zone must span the whole frame in pixels.
-    const result = coordsToSvgPointsWithTransform('0,0 100,0 100,100 0,100', transform, 'Percent');
+    const result = coordsToSvgPointsWithTransform('0,0 100,0 100,100 0,100', transform);
     expect(result).toBe('0,0 2560,0 2560,1920 0,1920');
   });
 
@@ -252,10 +252,17 @@ describe('coordsToSvgPointsWithTransform', () => {
       originalHeight: 1920,
     };
     // 50% of 2560x1920 is 1280,960, which 180 degrees maps onto itself.
-    const result = coordsToSvgPointsWithTransform('50,50', transform, 'Percent');
+    const result = coordsToSvgPointsWithTransform('50,50', transform);
     expect(result).toBe('1280,960');
   });
 
+  /**
+   * Units names the units of the analysis parameters (MinAlarmPixels and its
+   * friends), not of the coordinates, and its column default flipped to
+   * Percent. A pre-existing zone can therefore read Units: 'Percent' while its
+   * Coords are still pixels, and scaling those would throw the polygon off the
+   * frame. ZoneMinder's own renderer ignores Units and decides by magnitude.
+   */
   it('leaves pixel coords alone', () => {
     const transform: ZoneTransform = {
       rotation: { kind: 'none' },
@@ -263,9 +270,29 @@ describe('coordsToSvgPointsWithTransform', () => {
       originalHeight: 1920,
     };
     const coords = '756,387 1551,513 1656,1970 696,1812';
-    expect(coordsToSvgPointsWithTransform(coords, transform, 'Pixels')).toBe(coords);
-    // A server that omits Units predates the percent option, so it means pixels.
     expect(coordsToSvgPointsWithTransform(coords, transform)).toBe(coords);
+  });
+
+  it('reads a zone as pixels when a single point passes 100', () => {
+    const transform: ZoneTransform = {
+      rotation: { kind: 'none' },
+      originalWidth: 2560,
+      originalHeight: 1920,
+    };
+    // Three points would fit percent space; the fourth cannot, so the zone is
+    // pixels and none of it is scaled. This is ZoneMinder's own rule.
+    const coords = '10,10 90,10 90,101 10,90';
+    expect(coordsToSvgPointsWithTransform(coords, transform)).toBe(coords);
+  });
+
+  it('treats a point at exactly 100 as percent', () => {
+    const transform: ZoneTransform = {
+      rotation: { kind: 'none' },
+      originalWidth: 2560,
+      originalHeight: 1920,
+    };
+    // ZoneMinder's test is `> 100`, so the full-frame percent zone stays percent.
+    expect(coordsToSvgPointsWithTransform('100,100', transform)).toBe('2560,1920');
   });
 });
 

--- a/app/src/lib/monitor/zone-utils.ts
+++ b/app/src/lib/monitor/zone-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ZoneType } from '../../api/types';
-import { ZM_ZONE_UNITS } from '../zm/zm-constants';
+import { ZONE_PERCENT_MAX } from '../zm/zm-constants';
 import type { MonitorRotation } from './monitor-rotation';
 
 /**
@@ -156,6 +156,31 @@ export function transformPoint(point: Point, transform: ZoneTransform): Point {
 }
 
 /**
+ * Whether a zone's points are percent of the frame rather than capture pixels.
+ *
+ * ZoneMinder stores a zone either way and gives no reliable field saying which:
+ * the zone's `Units` column names the units of the analysis parameters
+ * (MinAlarmPixels and its friends), not of the coordinates, and its column
+ * default is now Percent, so an old zone can read Units: 'Percent' while its
+ * coordinates are still pixels. ZoneMinder's own renderer decides by magnitude
+ * instead, in `web/includes/Zone.php`:
+ *
+ *     $isPixel = false;
+ *     foreach ($points as $point) {
+ *       if ($point['x'] > 100 || $point['y'] > 100) { $isPixel = true; break; }
+ *     }
+ *
+ * This matches it, including the corner it accepts: a pixel zone contained
+ * entirely within the top-left 100x100 pixels reads as percent. Following the
+ * upstream renderer means a zone looks the same here as in ZoneMinder's own
+ * zone editor, which is the comparison a user actually makes.
+ */
+function isPercentSpace(points: Point[]): boolean {
+  return points.length > 0
+    && points.every(p => p.x <= ZONE_PERCENT_MAX && p.y <= ZONE_PERCENT_MAX);
+}
+
+/**
  * Converts zone coordinates to SVG polygon points string with optional rotation transformation.
  *
  * The overlay's viewBox is the monitor's pixel space, so percent coords are
@@ -166,25 +191,19 @@ export function transformPoint(point: Point, transform: ZoneTransform): Point {
  *
  * @param coords - The coordinate string from ZoneMinder
  * @param transform - Optional transformation to apply (rotation)
- * @param units - The zone's Units field; percent coords are scaled to pixels.
- *   An absent value means pixels, which is what servers without the field send.
  * @returns SVG points string (e.g., "0,0 100,0 100,100 0,100")
  */
-export function coordsToSvgPointsWithTransform(
-  coords: string,
-  transform?: ZoneTransform,
-  units?: string
-): string {
+export function coordsToSvgPointsWithTransform(coords: string, transform?: ZoneTransform): string {
   const parsed = parseZoneCoords(coords);
 
   if (!transform) {
     return parsed.map(p => `${p.x},${p.y}`).join(' ');
   }
 
-  const points = units === ZM_ZONE_UNITS.percent
+  const points = isPercentSpace(parsed)
     ? parsed.map(p => ({
-        x: (p.x / 100) * transform.originalWidth,
-        y: (p.y / 100) * transform.originalHeight,
+        x: (p.x / ZONE_PERCENT_MAX) * transform.originalWidth,
+        y: (p.y / ZONE_PERCENT_MAX) * transform.originalHeight,
       }))
     : parsed;
 

--- a/app/src/lib/zm/zm-constants.ts
+++ b/app/src/lib/zm/zm-constants.ts
@@ -171,17 +171,13 @@ export const TAGS_BATCH_SIZE = 100;
 export const ZM_API_DATETIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
 /**
- * Zone Coordinate Units
+ * Zone Coordinate Space
  *
  * A zone's `Coords` are stored either in capture pixels or in percent of the
- * frame, and the zone's `Units` field says which. ZoneMinder 1.39 writes
- * `Percent` for new zones so a zone survives a resolution change; older
- * servers wrote pixels and may omit the field entirely, which means pixels.
- * Anything drawing zone coordinates has to check this before scaling.
+ * frame, and no field says which: the zone's `Units` column describes the
+ * analysis parameters (MinAlarmPixels and its friends), not the coordinates.
+ * ZoneMinder's own renderer treats a point above this value as pixels and
+ * anything at or below it as percent (`web/includes/Zone.php`, `svg_polygon`),
+ * so anything drawing zone coordinates decides the same way.
  */
-export const ZM_ZONE_UNITS = {
-  pixels: 'Pixels',
-  percent: 'Percent',
-} as const;
-
-export type ZmZoneUnits = typeof ZM_ZONE_UNITS[keyof typeof ZM_ZONE_UNITS];
+export const ZONE_PERCENT_MAX = 100;


### PR DESCRIPTION
Corrects `62b46181` from #379 before it reaches a release.

## The mistake

That commit scaled a zone's coords whenever its `Units` field read `Percent`. `Units` does not describe the coordinates — it names the units of the analysis parameters (`MinAlarmPixels`, `MinBlobPixels`, and the rest), as the [zone documentation](https://zoneminder.readthedocs.io/en/stable/userguide/definezone.html) sets out. Its column default is also now `Percent`:

```sql
`Units` enum('Pixels','Percent') NOT NULL default 'Percent',
```

So a zone carried over from an older server reads `Units: Percent` while its `Coords` are still pixels. The previous fix divided every vertex of those by a hundred, throwing the polygon into the top-left corner — it repaired 1.39 servers by breaking older ones. Exactly the regression this PR exists to undo.

## What ZoneMinder does

Its own renderer never reads `Units`. `web/includes/Zone.php`, `svg_polygon`:

```php
$isPixel = false;
foreach ($points as $point) {
  if ($point['x'] > 100 || $point['y'] > 100) { $isPixel = true; break; }
}
```

Any point above 100 makes the whole zone pixels; everything at or below is percent. This matches it, corner included: a pixel zone contained entirely within the top-left 100x100 pixels reads as percent here, as it does upstream. Bug-for-bug parity is the right trade, because the comparison a user makes is against ZoneMinder's own zone editor.

`ZM_ZONE_UNITS` is replaced by `ZONE_PERCENT_MAX`, the threshold the comparison actually needs.

## Tests

The decisive one is a pixel zone whose `Units` says `Percent`, at both the util and the component level — verified failing before this change, which is the break it prevents. Plus the boundary either side: one point at 101 makes the zone pixels, a point at exactly 100 stays percent.

`npm run gates` passes: 4194 unit tests, build, three lints, ratchet within baseline.

The playbook entry in `agents/project/domain-context.md` is corrected too — it had recorded the wrong rule.

Posted by Claude, assisting @pliablepixels.