### PR TITLE
ci: stop the e2e job reporting green when it ran nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # The browser e2e suite drives a real ZoneMinder, so without those
+      # secrets there is nothing to run against. The job still has to end
+      # green or it would block every PR on a fork and on any clone that has
+      # no server, which is why it is not a required check: a green tick here
+      # means "ran, or had nothing to run", and only the summary below tells
+      # the two apart. Rule M2: read what a gate measured, not its exit code.
       - name: Check E2E secrets
         id: e2e-secrets
         run: |
@@ -197,6 +203,18 @@ jobs:
           else
             echo "has_secrets=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Report that no E2E test ran
+        if: steps.e2e-secrets.outputs.has_secrets != 'true'
+        run: |
+          echo "::warning title=E2E skipped::No ZM_HOST_1/ZM_USER_1/ZM_PASSWORD_1 secret is configured, so no browser e2e test ran. This job is green because it had nothing to run, not because the suite passed."
+          {
+            echo "### Browser e2e did not run"
+            echo
+            echo "No \`ZM_HOST_1\` / \`ZM_USER_1\` / \`ZM_PASSWORD_1\` secret is configured."
+            echo "The suite drives a real ZoneMinder, so it had nothing to run against."
+            echo "This job is green because it was skipped, **not** because the tests passed."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Node.js
         if: steps.e2e-secrets.outputs.has_secrets == 'true'

--- a/agents/generic/claude-workflows.md
+++ b/agents/generic/claude-workflows.md
@@ -75,6 +75,10 @@ named fleet.
   pipeline exits with the last command's status and a failing suite reads
   as success. Run the gate bare, check its exit, then filter output
   separately. This shipped a red commit here once.
+- A CI job that skips its own steps still reports green. Before trusting a
+  required check, read what it ran: two required checks here passed on every
+  PR for months, one whose workflow had been deleted and one that skipped
+  itself for a missing secret (M2).
 - Merging waits for green CI, but never by polling: queue it with
   `gh pr merge --auto` at PR creation and GitHub merges when checks pass.
   Caution: if the repo's auto-merge setting is off, `--auto` silently

--- a/docs/developer-guide/14-agent-development-model.rst
+++ b/docs/developer-guide/14-agent-development-model.rst
@@ -65,9 +65,9 @@ That breadth is the reason the guardrails exist: a change to a shared
 component can misbehave on **five platforms at once**, and no single
 machine can verify all of them. Platform divergence is therefore written
 down where agents will find it (the Native contract, the native playbook,
-the platform quirks in domain-context), web e2e runs in CI, and device
-e2e (Android emulator, iOS simulator and tablet) is run manually from
-scripts, never by agents.
+the platform quirks in domain-context), web e2e runs in CI wherever a
+ZoneMinder is configured to point it at, and device e2e (Android emulator,
+iOS simulator and tablet) is run manually from scripts, never by agents.
 
 Releases follow the same posture. Android and desktop binaries are built
 by the GitHub workflows, not on a laptop: the ``build-*`` workflows are
@@ -93,7 +93,7 @@ Every workflow, and what fires it:
    * - ``ci.yml``
      - every PR, push to main
      - version guard, lints, build, unit tests (full-history checkout for
-       the evidence gate), web e2e
+       the evidence gate), and web e2e when the ZM secrets are set
    * - ``claude.yml``
      - @claude mention on issues and PRs
      - summons an agent into the thread
@@ -309,7 +309,7 @@ How the pieces fit
      PP === GATE
      GP === GATE
      CL === GATE
-     PR["every PR"] === CI["ci.yml<br/>tests, lints, build, web e2e"]
+     PR["every PR"] === CI["ci.yml<br/>tests, lints, build"]
      GATE --> CI
      FAIL["breakage or review finding"] -- "fix PR proposes rule + gate<br/>(self-improvement protocol)" --> AG
      FAIL -- "durable fact (M5)" --> PP


### PR DESCRIPTION
## What was wrong

`e2e-tests` was a required status check on `main` that executed nothing. Every step is guarded on the ZM secrets:

```yaml
- name: Check E2E secrets
  run: if [ -n "${{ secrets.ZM_HOST_1 }}" ] ... else has_secrets=false
```

This repository has no such secret, so all seven steps ran in 0s and the job reported `pass`. Job step timings from today's run:

```
Set up job: 0s   Checkout: 4s   Check E2E secrets: 0s   Setup Node.js: 0s
Install dependencies: 0s   Install Playwright browsers: 0s   Run E2E tests: 0s
```

Four PRs merged today behind that green tick. Rule M2 is exactly this: check what a gate measured, not its exit code. It is the second hollow required check found today, after `label-guard`, whose workflow had been deleted while branch protection still demanded it.

## What changes

The job still ends green when it has nothing to run — failing would block every fork PR and every clone without a server. What changes is that it stops being silent about it: a `::warning` annotation and a run-summary block saying the suite did not execute. And it is no longer a required status check, because a check that cannot run cannot gate anything. Required checks on `main` are now `unit-tests`, `lint`, `build`, `lint-a11y`, `lint-react-correctness`, `native-version-guard` — each of which does real work; the native guard was verified to re-run its script over the PR's commit range.

If the ZM secrets are ever configured, the job runs the suite exactly as before and can go back to being required.

## Docs

The developer guide asserted in three places that web e2e runs in CI — the guardrails paragraph, the workflow inventory table, and the system diagram. It runs where a server is configured to point it at, which is what all three now say.

## Playbook

`agents/generic/claude-workflows.md` gains the general lesson under trust boundaries: a CI job that skips its own steps still reports green, so read what a required check ran before trusting it.

No behavior change in the app, so no unit test moves; `agents-contracts.test.ts` passes over the edited instruction files.

Posted by Claude, assisting @pliablepixels.