### PR TITLE
fix(streaming): keep snapshots alive on on-demand decoding monitors

### DIFF
--- a/agents/project/domain-context.md
+++ b/agents/project/domain-context.md
@@ -65,6 +65,18 @@ matching reality, fixing it is a protocol change like any rule edit.
   client-side signal is the status query, which a connkey with no process
   behind it answers without `progress`/`duration`. Monitors that store video
   without JPEGs hit this most, since `zms` then has to decode the video.
+- `zms` serves `mode=single` out of shared memory without calling
+  `setLastViewed()`, so `zmc` sees no viewer. A monitor whose `Decoding` is
+  not `Always` stops decoding ten seconds later, and every later snapshot
+  repeats the same frozen frame (#383). `mode=jpeg&frames=1` runs one pass
+  of the streaming loop, which does mark the monitor viewed, so snapshot
+  polling uses it for those monitors and keeps `mode=single` for `Always`.
+  A missing `Decoding` field means a server older than the field, which is
+  also older than `frames=`: unknown parameters are only logged, so such a
+  request would stream forever. `frames=` reached `zms` during 1.37.61
+  development (January 2024), after `Decoding` did, hence the version floor
+  as well. Snapshot requests carry no connkey: nothing commands them, and a
+  connkey makes a `frames=1` request open a socket per poll.
 - `zms` answers 503 once its streaming daemon is saturated, and a profile
   switch is when that happens: the outgoing profile's quits are awaited but
   their replies time out at 3s (`cmdQuitTimeoutSeconds`), so the incoming

--- a/app/src/api/monitors.ts
+++ b/app/src/api/monitors.ts
@@ -297,6 +297,7 @@ export function getStreamUrl(
   monitorId: string,
   options: {
     mode?: 'jpeg' | 'single' | 'stream';
+    frames?: number;
     scale?: number;
     width?: number;
     height?: number;

--- a/app/src/api/types.ts
+++ b/app/src/api/types.ts
@@ -149,6 +149,8 @@ export const MonitorSchema = z.object(
   Capturing: z.string().optional(),
   Analysing: z.string().optional(),
   Recording: z.string().optional(),
+  /** 'None' | 'Ondemand' | 'KeyFrames' | 'KeyFrames+Ondemand' | 'Always'. Absent before ZM 1.37. */
+  Decoding: z.string().optional(),
   Enabled: z.coerce.string(),
   LinkedMonitors: z.string().nullable(),
   Triggers: z.string().nullable(),
@@ -708,6 +710,8 @@ export interface Profile {
 // Stream options types
 export interface StreamOptions {
   mode?: 'jpeg' | 'single' | 'stream';
+  /** Stop a jpeg stream after this many frames (ZM 1.38+). */
+  frames?: number;
   scale?: number;
   width?: number;
   height?: number;

--- a/app/src/components/monitors/LiveMonitorPlayer.tsx
+++ b/app/src/components/monitors/LiveMonitorPlayer.tsx
@@ -526,6 +526,7 @@ export function LiveMonitorPlayer({
     enabled: (effectiveStreamingMethod === 'mjpeg' || showMjpegPlaceholder) && !paused && !streamDenied,
     viewModeOverride: forceViewMode,
     profileId,
+    decoding: monitor.Decoding,
   });
 
   // Track MJPEG image error state. Clear it whenever a new connection is minted

--- a/app/src/hooks/__tests__/useMonitorStream.frame.test.tsx
+++ b/app/src/hooks/__tests__/useMonitorStream.frame.test.tsx
@@ -55,6 +55,7 @@ vi.mock('../../lib/zm/url-builder', () => ({
 
 vi.mock('../../lib/zm/zm-constants', () => ({
   ZMS_COMMANDS: { cmdQuit: 'quit' },
+  ZMS_FRAMES_PARAM_MIN_VERSION: '1.38.0',
 }));
 
 // Captured so a test can fire the resume the way returning to the foreground

--- a/app/src/hooks/__tests__/useMonitorStream.test.ts
+++ b/app/src/hooks/__tests__/useMonitorStream.test.ts
@@ -41,6 +41,7 @@ vi.mock('../../api/monitors', () => ({
     const params = new URLSearchParams();
     params.set('monitor', monitorId);
     if (options.mode) params.set('mode', options.mode);
+    if (options.frames) params.set('frames', options.frames.toString());
     if (options.connkey) params.set('connkey', options.connkey.toString());
     if (options.scale) params.set('scale', options.scale.toString());
     if (options.maxfps) params.set('maxfps', options.maxfps.toString());
@@ -67,6 +68,8 @@ vi.mock('../../lib/zm/zm-constants', () => ({
     cmdAnalyzeOn: 'analyzeOn',
     cmdAnalyzeOff: 'analyzeOff',
   },
+  ZMS_FRAMES_PARAM_MIN_VERSION: '1.37.61',
+  ZM_DECODING_ALWAYS: 'Always',
 }));
 
 describe('useMonitorStream', () => {
@@ -214,10 +217,101 @@ describe('useMonitorStream', () => {
     // Check snapshot mode parameters
     // Note: Normal bandwidth mode uses 100% image scale
     expect(result.current.streamUrl).toContain('mode=single');
-    expect(result.current.streamUrl).toContain('connkey=12345');
+    // No connkey in snapshot: zms never opens a command socket for a
+    // single-frame request, and nothing ever sends CMD_QUIT for it (refs #383).
+    expect(result.current.streamUrl).not.toContain('connkey');
     expect(result.current.streamUrl).toContain('scale=100');
     expect(result.current.streamUrl).not.toContain('maxfps'); // No maxfps in snapshot
     expect(result.current.streamUrl).toContain('rand='); // cacheBuster in snapshot
+  });
+
+  describe('snapshot request shape by monitor decoding', () => {
+    // mode=single reads shared memory without marking the monitor as viewed, so
+    // a monitor that decodes on demand stops decoding and the snapshot freezes
+    // (refs #383). mode=jpeg&frames=1 runs one pass of the streaming loop, which
+    // does mark the monitor as viewed, then stops after a single frame.
+    const snapshotOn = (version: string | null) => {
+      useSettingsStore.setState({
+        profileSettings: {
+          'profile-1': {
+            ...DEFAULT_SETTINGS,
+            viewMode: 'snapshot',
+          },
+        },
+      });
+      useAuthStore.setState({
+        slices: {
+          [mockProfile.id]: {
+            ...useAuthStore.getState().slices[mockProfile.id],
+            version,
+          },
+        },
+      });
+    };
+
+    it('polls a one-frame jpeg stream for a monitor that decodes on demand', async () => {
+      snapshotOn('1.38.0');
+
+      const { result } = renderHook(() =>
+        useMonitorStream({ monitorId: '1', decoding: 'Ondemand' }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.streamUrl).toBeTruthy();
+      });
+
+      expect(result.current.streamUrl).toContain('mode=jpeg');
+      expect(result.current.streamUrl).toContain('frames=1');
+      expect(result.current.streamUrl).not.toContain('connkey');
+      expect(result.current.streamUrl).not.toContain('maxfps');
+      expect(result.current.streamUrl).toContain('rand=');
+    });
+
+    it('keeps mode=single for a monitor on Decoding=Always', async () => {
+      // It never stops decoding, so the cheaper single-image request is enough.
+      snapshotOn('1.38.0');
+
+      const { result } = renderHook(() =>
+        useMonitorStream({ monitorId: '1', decoding: 'Always' }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.streamUrl).toBeTruthy();
+      });
+
+      expect(result.current.streamUrl).toContain('mode=single');
+      expect(result.current.streamUrl).not.toContain('frames=');
+    });
+
+    it('keeps mode=single when the server reports no decoding value', async () => {
+      // Pre-1.37 servers have no Decoding field and no frames= either; their zms
+      // logs unknown parameters and would stream forever on every poll.
+      snapshotOn('1.36.35');
+
+      const { result } = renderHook(() => useMonitorStream({ monitorId: '1' }));
+
+      await waitFor(() => {
+        expect(result.current.streamUrl).toBeTruthy();
+      });
+
+      expect(result.current.streamUrl).toContain('mode=single');
+      expect(result.current.streamUrl).not.toContain('frames=');
+    });
+
+    it('keeps mode=single on 1.37 builds that have Decoding but no frames=', async () => {
+      snapshotOn('1.37.44');
+
+      const { result } = renderHook(() =>
+        useMonitorStream({ monitorId: '1', decoding: 'Ondemand' }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.streamUrl).toBeTruthy();
+      });
+
+      expect(result.current.streamUrl).toContain('mode=single');
+      expect(result.current.streamUrl).not.toContain('frames=');
+    });
   });
 
   it('on web, snapshot mode mirrors streamUrl into imageSrc without fetching frames', async () => {

--- a/app/src/hooks/useMonitorStream.ts
+++ b/app/src/hooks/useMonitorStream.ts
@@ -23,10 +23,12 @@ import { useAnalysisFrames } from './useAnalysisFrames';
 import { useFreshAccessToken } from './useFreshAccessToken';
 import { useServerUrls } from './useServerUrls';
 import { useVisibilityResume } from './useVisibilityResume';
-import { useAuthStore } from '../stores/auth';
+import { useAuthStore, useAuthSlice } from '../stores/auth';
 import { log, LogLevel } from '../lib/logger';
 import { planReconnect } from '../lib/monitor/reconnect-backoff';
 import { ZM_INTEGRATION } from '../lib/zmninja-ng-constants';
+import { ZMS_FRAMES_PARAM_MIN_VERSION, ZM_DECODING_ALWAYS } from '../lib/zm/zm-constants';
+import { isZmVersionAtLeast } from '../lib/zm/zm-version';
 import type { StreamOptions, ProfileId } from '../api/types';
 
 interface UseMonitorStreamOptions {
@@ -47,6 +49,12 @@ interface UseMonitorStreamOptions {
    * instead of the globally-selected profile.
    */
   profileId?: ProfileId | null;
+  /**
+   * The monitor's ZM `Decoding` value, when the server reports one. Only
+   * snapshot polling reads it: a monitor that decodes on demand needs a
+   * different request shape (see snapshotSendsOneJpeg below).
+   */
+  decoding?: string;
 }
 
 interface UseMonitorStreamReturn {
@@ -96,6 +104,7 @@ export function useMonitorStream({
   enabled = true,
   viewModeOverride,
   profileId,
+  decoding,
 }: UseMonitorStreamOptions): UseMonitorStreamReturn {
   const { profile: currentProfile, settings } = useProfileById(profileId);
   // Streaming Mode and analysis frames are view preferences, so the active
@@ -109,6 +118,22 @@ export function useMonitorStream({
   const resolvedPortalUrl = portalPath ? portalPath.replace(/\/index\.php$/, '') : currentProfile?.portalUrl;
 
   const effectiveViewMode = viewModeOverride ?? viewPrefs.viewMode;
+  // Snapshot polling shape. mode=single reads the shared-memory image without
+  // marking the monitor as viewed, so a monitor that only decodes on demand
+  // stops decoding between polls and its picture freezes (refs #383). A jpeg
+  // stream capped at one frame runs one pass of the streaming loop, which does
+  // mark the monitor viewed, so those monitors poll that way instead. Monitors
+  // on Decoding=Always never stop decoding and stay on the cheaper mode=single,
+  // as do servers that report no Decoding at all: no Decoding field means a ZM
+  // too old to understand frames=, which it would log as unknown and then
+  // stream forever. The version check covers the 1.37 development builds that
+  // grew Decoding before zms grew frames=.
+  const zmVersion = useAuthSlice(currentProfile?.id ?? null).version;
+  const snapshotSendsOneJpeg =
+    effectiveViewMode === 'snapshot' &&
+    !!decoding &&
+    decoding !== ZM_DECODING_ALWAYS &&
+    isZmVersionAtLeast(zmVersion, ZMS_FRAMES_PARAM_MIN_VERSION);
   // Multi-port only applies in streaming mode, and only when not force-disabled.
   const effectiveMinStreamingPort =
     effectiveViewMode === 'streaming'
@@ -201,14 +226,17 @@ export function useMonitorStream({
   // can mount an <img> on a connkey the disable teardown has already quit.
   const streamUrl = enabled && currentProfile && connKey !== 0 && isAccessTokenFresh
     ? getStreamUrl(recordingUrl || currentProfile.cgiUrl, monitorId, {
-      mode: effectiveViewMode === 'snapshot' ? 'single' : 'jpeg',
+      mode: effectiveViewMode === 'snapshot' && !snapshotSendsOneJpeg ? 'single' : 'jpeg',
+      frames: snapshotSendsOneJpeg ? 1 : undefined,
       scale: bandwidth.imageScale,
       maxfps:
         effectiveViewMode === 'streaming'
           ? settings.streamMaxFps
           : undefined,
       token: accessToken || undefined,
-      connkey: connKey,
+      // Streaming only: a snapshot request has no command channel to name, and
+      // zms opens a socket per connkey once the request is a jpeg stream.
+      connkey: effectiveViewMode === 'snapshot' ? undefined : connKey,
       // Only use cacheBuster in snapshot mode to force refresh; streaming mode uses only connkey
       cacheBuster: effectiveViewMode === 'snapshot' ? cacheBuster : undefined,
       // Only use multi-port in streaming mode, not snapshot (and not force-disabled)

--- a/app/src/lib/zm/url-builder.ts
+++ b/app/src/lib/zm/url-builder.ts
@@ -122,6 +122,8 @@ export function getMonitorStreamUrl(
   monitorId: string,
   options: {
     mode?: 'jpeg' | 'single' | 'stream';
+    /** Stop a jpeg stream after this many frames (ZM 1.38+). */
+    frames?: number;
     scale?: number;
     width?: number;
     height?: number;
@@ -138,6 +140,7 @@ export function getMonitorStreamUrl(
     mode: options.mode || 'jpeg',
   };
 
+  if (options.frames) params.frames = options.frames.toString();
   if (options.scale) params.scale = options.scale.toString();
   if (options.width) params.width = `${options.width}px`;
   if (options.height) params.height = `${options.height}px`;

--- a/app/src/lib/zm/zm-constants.ts
+++ b/app/src/lib/zm/zm-constants.ts
@@ -120,6 +120,20 @@ export const ZMS_MODES = {
 } as const;
 
 /**
+ * First ZoneMinder release whose zms understands `frames=`, the parameter that
+ * stops a jpeg stream after N frames. Older zms logs it as unknown and streams
+ * forever, so snapshots stay on mode=single there (refs #383).
+ */
+export const ZMS_FRAMES_PARAM_MIN_VERSION = '1.37.61';
+
+/**
+ * Monitor `Decoding` value that keeps zmc decoding whether or not anyone is
+ * watching. The others ('None', 'Ondemand', 'KeyFrames', 'KeyFrames+Ondemand')
+ * decode on demand or not at all. Absent before ZM 1.37.
+ */
+export const ZM_DECODING_ALWAYS = 'Always';
+
+/**
  * Monitor Function States
  *
  * Valid states for a ZoneMinder monitor's function setting.

--- a/docs/developer-guide/07-api-and-data-fetching.rst
+++ b/docs/developer-guide/07-api-and-data-fetching.rst
@@ -405,7 +405,7 @@ Why stream URLs carry a cache buster, a port, and a mode
 Cache busting (``_t``)
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Browsers cache image URLs aggressively. In ``mode=single`` (snapshot)
+Browsers cache image URLs aggressively. In snapshot mode
 or after a stream reconnects, the same URL would yield a stale frame.
 ``src/lib/zm/url-builder.ts`` appends a ``_t=<timestamp>`` cache buster:
 
@@ -427,14 +427,38 @@ Streaming vs snapshot
 
 - **Streaming** (``mode=jpeg``), long-lived MJPEG connection. Low
   latency, high bandwidth, holds an HTTP slot.
-- **Snapshot** (``mode=single``), single JPEG fetched every
-  ``snapshotRefreshInterval`` seconds. Lower resource use, lower
-  frame rate.
+- **Snapshot**, single JPEG fetched every ``snapshotRefreshInterval``
+  seconds. Lower resource use, lower frame rate.
+
+Snapshot has two request shapes, picked per monitor. ``zms`` serves
+``mode=single`` straight out of shared memory and never calls
+``setLastViewed()``, so ``zmc`` sees no viewer. A monitor whose ``Decoding``
+is anything but ``Always`` then stops decoding ten seconds after the last
+real viewer, and every later snapshot returns the same frozen frame.
+``mode=jpeg&frames=1`` runs one pass of the streaming loop instead, which
+marks the monitor as viewed and keeps ``zmc`` decoding.
+
+``useMonitorStream`` therefore sends ``mode=jpeg&frames=1`` only when the
+monitor reports a ``Decoding`` other than ``ZM_DECODING_ALWAYS``, and
+``mode=single`` otherwise: a monitor on ``Always`` never stops decoding and
+does not need a stream, and a server that reports no ``Decoding`` at all is
+older than the field. That fallback matters because ``frames=`` arrived
+later than ``Decoding`` did: ``zms`` logs unknown parameters and keeps
+streaming, so a ``frames=1`` request to a server without it would leave an
+unbounded MJPEG connection open on every poll. The version check against
+``ZMS_FRAMES_PARAM_MIN_VERSION`` closes the gap for the 1.37 development
+builds that have ``Decoding`` but not ``frames=``.
+
+Snapshot requests carry no ``connkey``. A connection key names a live
+stream so the client can command it later, and nothing ever commands a
+snapshot: ``useStreamLifecycle`` sends ``CMD_QUIT`` for streaming
+connections only. Passing one to a ``frames=1`` jpeg request would also
+make ``zms`` create a command socket and lock file per poll.
 
 In snapshot mode, ``useMonitorStream`` exposes ``imageSrc`` for the
 ``<img>`` to bind to on every platform; this equals ``streamUrl``, so
-the WebView or browser loads each ``mode=single`` URL directly as the
-cache buster changes.
+the WebView or browser loads each snapshot URL directly as the cache
+buster changes.
 
 Per-platform transport
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -116,6 +116,8 @@ A new profile picks its Streaming Mode from the server it just connected to:
 - **Multi-port streaming configured** (`ZM_MIN_STREAMING_PORT`): **Streaming**, whatever the monitor count. Each camera streams on its own port, so the per-server connection limit no longer applies.
 - **6 or more monitors and no multi-port streaming**: **Snapshot**. Streaming that many feeds would stall after the first few; snapshot mode fetches a still on an interval instead of holding a connection, so every tile keeps updating.
 
+Snapshot mode needs a decoded image waiting on the server. For a monitor whose *Decoding* is not *Always*, ZoneMinder stops decoding about ten seconds after the last viewer, so the app asks such monitors for their stills in a way that counts as watching and keeps them decoding. That request only exists in ZoneMinder 1.37.61 and later. On older servers a monitor set to *On demand* decoding freezes its snapshot tile on one frame: set it to *Decoding: Always*, or use Streaming mode for it.
+
 The count is the monitors the app shows for that server: deleted and per-profile excluded monitors are left out, disabled ones still count because they still get a tile. If the app cannot list the monitors on first connect, the mode stays at Snapshot until a later connect can decide. A profile with *Force disable multi-port streaming* on (Advanced) is treated as if the server had none.
 
 The row shows which mode is recommended for the server and a line explaining why. The recommendation is only the starting value: changing the toggle overrides it for that profile, and no later connection changes it back.


### PR DESCRIPTION
Refs #383.

## The problem, from the issue

> When cameras (monitors) are not set up to Decoding: Always (only pass-trough recording for the sake of power efficiency with a Decoding setting: On demand or On demand + Keyframes) montage view is not working. It will take a frame or two and then freezes.

> Expected behavior: Montage view supposed to take a "live" stream as it is in single view.

## Cause

`zms` serves `mode=single` straight out of shared memory and never calls `setLastViewed()`, so `zmc` sees no viewer. `Monitor::hasViewers()` is "viewed within the last 10 seconds", and `zmc` only decodes an on-demand monitor while that is true. Snapshot polling therefore stops the decoder, and every later poll returns the same frozen frame. Single-monitor view works because it streams (`mode=jpeg`), and the streaming loop calls `setLastViewed()` on every pass.

## Fix

Snapshot polling picks its request shape per monitor:

- `Decoding` present and not `Always`, on ZM >= 1.37.61: `mode=jpeg&frames=1`. That runs one pass of the streaming loop, which marks the monitor viewed, then stops after a single frame.
- Anything else: `mode=single`, exactly as before.

The fallback covers two cases. A monitor on `Decoding=Always` never stops decoding and does not need the more expensive request. A server that reports no `Decoding` is older than that field, which is also older than `frames=`; `zms` only logs unknown parameters, so a `frames=1` request there would leave an unbounded MJPEG connection open on every poll. `frames=` reached `zms` during 1.37.61 development (January 2024), after `Decoding` did, hence the version floor as well as the field check.

Snapshot requests also stop carrying a `connkey`. Nothing ever commands a snapshot connection (`CMD_QUIT` is sent for streaming connections only), and a connkey on a `frames=1` jpeg request would make `zms` open a command socket and lock file on every poll.

## Verification

- `app/src/hooks/__tests__/useMonitorStream.test.ts`: on-demand monitor gets `mode=jpeg&frames=1` and no connkey; `Decoding=Always` keeps `mode=single`; a server with no `Decoding` keeps `mode=single`; a 1.37 build below the floor keeps `mode=single`.
- `npm run gates`: 4217 passed, 2 skipped; build; `lint:a11y`, `lint:correctness`, `lint:ratchet` (201, at baseline).

Docs move with the behavior: developer guide 07 (streaming vs snapshot), `agents/project/domain-context.md`, and the user guide note about older servers still needing `Decoding: Always` or Streaming mode.

Not addressed here: `Decoding: None` currently takes the `frames=1` path, where `zms` cannot serve a live image either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW