### PR TITLE
fix(monitors, events): reset zoom when the route moves to another monitor or event

### DIFF
--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -21,7 +21,7 @@ import { useSettingsStore } from '../stores/settings';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { ArrowLeft, Settings, Maximize2, Minimize2, AlertTriangle, Download, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsUpDown, Layers, Video, Eye, Disc } from 'lucide-react';
-import { useState, useRef, useMemo, useCallback } from 'react';
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { cn } from '../lib/utils';
 import { toast } from 'sonner';
 import { downloadSnapshotFromElement } from '../services/download';
@@ -153,6 +153,16 @@ export default function MonitorDetail() {
     onSwipeLeft,
     onSwipeRight,
   });
+
+  // Zoom belongs to the picture the user zoomed into, not to the page. Stepping
+  // to another monitor keeps this component mounted (the route element is not
+  // keyed on the id), so without this the next monitor arrived still magnified
+  // and panned to the previous one's framing (refs #382). Covers every path
+  // that changes the id in place: keyboard jump, prev/next, swipe, auto-cycle.
+  const resetZoom = zoomPan.reset;
+  useEffect(() => {
+    resetZoom();
+  }, [id, resetZoom]);
 
   // Remembered per profile: the video owns every drag that lands on it, so a
   // tablet wants the pad for good rather than once per visit.

--- a/app/src/pages/__tests__/MonitorDetail.test.tsx
+++ b/app/src/pages/__tests__/MonitorDetail.test.tsx
@@ -21,6 +21,7 @@ const h = vi.hoisted(() => ({
     insomnia: false,
     forceDisableMultiPort: false,
   } as Record<string, unknown>,
+  zoomReset: vi.fn(),
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -80,7 +81,7 @@ vi.mock('../../services/download', () => ({ downloadSnapshotFromElement: vi.fn()
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../hooks/useInsomnia', () => ({ useInsomnia: () => {} }));
 vi.mock('../../hooks/useZoomPan', () => ({
-  useZoomPan: () => ({ ref: { current: null }, innerRef: { current: null }, reset: vi.fn() }),
+  useZoomPan: () => ({ ref: { current: null }, innerRef: { current: null }, reset: h.zoomReset }),
 }));
 vi.mock('../../hooks/useServerUrls', () => ({
   useServerUrls: () => ({ portalPath: 'https://portal.test/index.php', apiBaseUrl: 'https://api.test' }),
@@ -154,6 +155,7 @@ describe('MonitorDetail All-mode deep route (refs #337)', () => {
     tryGetCurrentSessionMock.mockClear();
     useQueryMock.mockReset();
     liveMonitorPlayerMock.mockClear();
+    h.zoomReset.mockClear();
   });
 
   afterEach(() => {
@@ -212,6 +214,35 @@ describe('MonitorDetail All-mode deep route (refs #337)', () => {
 
     expect(tryGetCurrentSessionMock).toHaveBeenCalled();
     expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('drops the zoom back to fit when the route moves to another monitor (refs #382)', () => {
+    // The route element is not keyed on the monitor id, so stepping from one
+    // monitor to the next (keyboard jump, prev/next, swipe, auto-cycle) keeps
+    // this page mounted, and without this the zoom transform stayed applied to
+    // whatever loaded next.
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: readonly unknown[] }) => {
+      if (queryKey[0] === 'monitor') {
+        return { data: monitor, isLoading: false, error: null, refetch: vi.fn() };
+      }
+      return { data: undefined, isLoading: false, error: null, refetch: vi.fn() };
+    });
+
+    const { rerender } = render(<MonitorDetail />);
+    h.zoomReset.mockClear();
+
+    // A re-render on the same monitor must not disturb a zoom the user set.
+    rerender(<MonitorDetail />);
+    expect(h.zoomReset).not.toHaveBeenCalled();
+
+    h.routeParams = { id: '2' };
+    rerender(<MonitorDetail />);
+    expect(h.zoomReset).toHaveBeenCalledTimes(1);
+
+    // Same for the All-mode deep route, where the id is a different param.
+    h.routeParams = { profileId: 'profile-b', monitorId: '3' };
+    rerender(<MonitorDetail />);
+    expect(h.zoomReset).toHaveBeenCalledTimes(2);
   });
 
   it('renders the existing error state instead of crashing for an unknown route profileId', () => {

--- a/app/tests/features/monitor-detail.feature
+++ b/app/tests/features/monitor-detail.feature
@@ -92,6 +92,15 @@ Feature: Monitor Detail Page
     Then the pan controls should be visible
 
   @web
+  Scenario: Zoom resets when stepping to another monitor
+    Then I should see the monitor player
+    When I zoom into the monitor view
+    Then the pan controls should be visible
+    When I click the next monitor button if visible
+    Then the monitor should change to next in list
+    And the monitor view should be back at fit
+
+  @web
   Scenario: Keyboard and mouse pan the zoomed view
     Then I should see the monitor player
     When I zoom into the monitor view

--- a/app/tests/steps/monitor-zoom-pan.steps.ts
+++ b/app/tests/steps/monitor-zoom-pan.steps.ts
@@ -1,11 +1,15 @@
 import { createBdd } from 'playwright-bdd';
 import { expect } from '@playwright/test';
 import { testConfig } from '../helpers/config';
+import { log } from '../../src/lib/logger';
 
 const { When, Then } = createBdd();
 
 // Zoom / pan (keyboard + mouse) - issue #191
 let panTransformBefore = '';
+// Monitor the view was zoomed on, so the reset check below can tell a real
+// monitor switch from a server with only one monitor to switch to.
+let zoomedMonitorId: string | null = null;
 
 async function readZoomTransform(page: import('@playwright/test').Page): Promise<string> {
   return page
@@ -27,6 +31,7 @@ When('I scroll the wheel up over the monitor view', async ({ page }) => {
 });
 
 When('I zoom into the monitor view', async ({ page }) => {
+  zoomedMonitorId = page.url().match(/monitors\/(\d+)/)?.[1] ?? null;
   const zoomIn = page.getByTestId('zoom-in-button');
   await expect(zoomIn).toBeVisible({ timeout: testConfig.timeouts.pageLoad });
   // Two steps so the view is well past the zoom threshold with room to pan.
@@ -63,6 +68,23 @@ When('I drag the monitor view with the mouse', async ({ page }) => {
   await page.mouse.up();
   await expect.poll(() => readZoomTransform(page), { timeout: testConfig.timeouts.transition })
     .not.toBe(panTransformBefore);
+});
+
+// Zoom belongs to the picture, not the page (refs #382). Stepping to another
+// monitor keeps the page mounted, so the transform has to be cleared explicitly.
+Then('the monitor view should be back at fit', async ({ page }) => {
+  const nowId = page.url().match(/monitors\/(\d+)/)?.[1] ?? null;
+  if (!nowId || nowId === zoomedMonitorId) {
+    log.info('E2E: Skipping zoom-reset assertion - no second monitor to switch to', { component: 'e2e' });
+    return;
+  }
+  // The zoom controls collapse back to the two buttons only while the hook
+  // itself reports 1x, so this fails if the scale state survives the switch
+  // even when the new monitor's element paints unzoomed.
+  await expect(page.getByTestId('pan-left-button')).toBeHidden({ timeout: testConfig.timeouts.transition });
+  // '' on a freshly mounted element, 'scale(1)' on one the reset wrote to.
+  const transform = await readZoomTransform(page);
+  expect(transform === '' || transform.includes('scale(1)')).toBe(true);
 });
 
 Then('the view should pan', async ({ page }) => {


### PR DESCRIPTION
Refs #382.

## From the issue

> When you zoom into a monitor, then switch to another one via keyboard, it seems to keep the same zoom level. [...] If you go through Montage or Monitors or Dashboard, etc, and change monitors that way, it does seem to reset.

> Expected behavior: Zoom resets and shows 100% of the view when changing monitors, zoom really only makes sense when viewing the one monitor.

## Cause

`/monitors/:id` and `/all/monitors/:profileId/:monitorId` render `MonitorDetail` with no `key`, so changing only the param keeps the same component instance alive. `useZoomPan` holds scale and offset in a ref and its zoomed flag in state, and nothing watched the monitor id: `zoomPan.reset()` had exactly one caller, the fullscreen toggle. Going through Montage or Monitors unmounts the page, which is why that path resets.

This affects every in-place monitor change, not only the keyboard jump: prev/next buttons, swipe, and the auto-cycle all `navigate()` to a sibling id.

`EventDetail` has the same shape with `useEventNavigation` and never called reset at all, so stepping between events kept the zoom too. Both are fixed here, one commit each.

## Fix

Reset the zoom from an effect keyed on the id, on both pages. One place covers every path, since they all end in the same param change.

The alternative, keying the route element on the id, also works but remounts the player on every step, tearing down the stream and minting a fresh connkey for what is meant to be a quick flip between cameras.

## Verification

- `app/src/pages/__tests__/MonitorDetail.test.tsx` and `EventDetail.test.tsx`: reset fires when the id changes on either route shape, and does not fire on a re-render of the same monitor or event (a zoom the user set must survive an unrelated render).
- `app/tests/features/monitor-detail.feature` and `events.feature`: zoom in, step to the neighbouring monitor or event, expect the pan controls gone. Both verified red on the pre-fix code and green after, against a live server.
- `npm run gates`: 4221 passed, 2 skipped; build; `lint:a11y`, `lint:correctness`, `lint:ratchet` (201, at baseline).

Note on the e2e assertion: on a monitor switch the zoom element itself unmounts and remounts with no inline transform, so a transform check alone passes even without the fix. What survives is the hook's own scale and zoomed state, which is why the pan controls stayed up and the next gesture jumped back to 2x. The scenarios assert that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW