### PR TITLE
fix(events): reset zoom on event change, and fix the e2e skip guard it exposed

### DIFF
--- a/agents/project/testing.md
+++ b/agents/project/testing.md
@@ -15,13 +15,25 @@ Read before tests, UI work, navigation work, or platform checks.
   show it fail (`node scripts/proven-red.mjs <base> <head>` does this in a
   worktree; CI runs it on every PR). A bug fix starts with that red command,
   shown, before any code is read for a theory.
+- That script skips e2e, which needs a server, so an e2e scenario is proven
+  red by hand: `git stash push <source file>`, `npx bddgen`, `npx playwright
+  test --grep "<scenario name>"`, then `git stash pop`. Skipping it hides a
+  scenario that skips itself or asserts the wrong thing (refs #382).
 - Route new tests by tier: pure logic in `lib/`, stores, and hooks gets unit tests; user-visible behavior or navigation gets a feature e2e scenario plus units for the logic beneath; native-only flows rely on manual device checks. E2e asserts the journey, units the edge cases; do not cover the same assertion in both tiers.
 - Unit tests live beside source in `__tests__/`.
 - Browser e2e uses `app/tests/features/*.feature` and screen-specific step files in `app/tests/steps/`. Do not add direct Playwright specs.
+- Rename or add a step and the generated specs go stale: run `npx bddgen`
+  (`npm run test:e2e` does it first). A stale `.features-gen` reports
+  `Missing step`, which reads like a failing test and is not one.
 - Test UI and navigation changes with relevant feature e2e.
 - New interactive UI needs a kebab-case `data-testid`. Repeated elements suffix the entity id (`monitor-card-${monitor.Id}`); variants suffix kind or role (`assistant-message-${msg.role}`).
 - Do not use fixed `waitForTimeout`. Use auto-retrying `expect`.
 - Capability-based e2e skips must derive from API or fixture data, never visibility of UI under test. When capability exists, assert the UI.
+- Pages that stay mounted across a route param change (`/monitors/:id`,
+  `/events/:id`) repaint their content either way, so a DOM property such as a
+  transform is green with or without the fix. Assert the state that survives
+  the repaint, such as a control that only renders while the hook holds the
+  old value (refs #382).
 - Every `Then` step asserts, through `expect` or an `assert*` helper, and every step definition is referenced by a feature. `app/src/tests/e2e-steps.test.ts` fails the unit suite otherwise, so a step that cannot fail and a step nothing runs both surface without an e2e run.
 
 ## Platforms

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -318,6 +318,15 @@ export default function EventDetail() {
   // Pinch-to-zoom and pan for event video/image
   const zoomPan = useZoomPan({ maxScale: 4 });
 
+  // Zoom belongs to the frame the user zoomed into, not to the page. Stepping
+  // to another event keeps this component mounted (the route element is not
+  // keyed on the id), so without this the next event arrived magnified and
+  // panned to the previous one's framing (refs #382).
+  const resetZoom = zoomPan.reset;
+  useEffect(() => {
+    resetZoom();
+  }, [id, resetZoom]);
+
   // Frame carousel viewer (#272): the full-size image covers the player, so
   // playback pauses while it is open and resumes on close if it was running.
   // The player is held structurally so this page does not import video.js.

--- a/app/src/pages/__tests__/EventDetail.test.tsx
+++ b/app/src/pages/__tests__/EventDetail.test.tsx
@@ -35,6 +35,7 @@ const h = vi.hoisted(() => ({
   logEventDetail: vi.fn(),
   logOther: vi.fn(),
   toastError: vi.fn(),
+  zoomReset: vi.fn(),
 }));
 
 vi.mock('@tanstack/react-query', () => ({
@@ -145,7 +146,7 @@ vi.mock('../../hooks/useZoomPan', () => ({
     innerRef: { current: null },
     scale: 1,
     isZoomed: false,
-    reset: vi.fn(),
+    reset: h.zoomReset,
     zoomIn: vi.fn(),
     zoomOut: vi.fn(),
     panLeft: vi.fn(),
@@ -446,6 +447,33 @@ describe('EventDetail All-mode deep route (refs #337)', () => {
 
   afterEach(() => {
     h.routeParams = { id: '101' };
+  });
+
+  it('drops the zoom back to fit when the route moves to another event (refs #382)', () => {
+    // Same shape as MonitorDetail: the route element is not keyed on the event
+    // id, so stepping to the next event keeps this page mounted and without
+    // this the zoom stayed on whatever loaded next.
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: readonly unknown[] }) => {
+      if (queryKey[0] === 'event') return { data: event, isLoading: false, error: null };
+      if (queryKey[0] === 'monitor') return { data: monitorData, isLoading: false, error: null };
+      return { data: null, isLoading: false, error: null };
+    });
+
+    const { rerender } = render(<EventDetail />);
+    h.zoomReset.mockClear();
+
+    // A re-render on the same event must not disturb a zoom the user set.
+    rerender(<EventDetail />);
+    expect(h.zoomReset).not.toHaveBeenCalled();
+
+    h.routeParams = { id: '102' };
+    rerender(<EventDetail />);
+    expect(h.zoomReset).toHaveBeenCalledTimes(1);
+
+    // Same for the All-mode deep route, where the id is a different param.
+    h.routeParams = { profileId: 'profile-b', eventId: '103' };
+    rerender(<EventDetail />);
+    expect(h.zoomReset).toHaveBeenCalledTimes(2);
   });
 
   it('fetches the event via the route profileId\'s client and query key', () => {

--- a/app/tests/steps/monitor-zoom-pan.steps.ts
+++ b/app/tests/steps/monitor-zoom-pan.steps.ts
@@ -1,15 +1,26 @@
 import { createBdd } from 'playwright-bdd';
 import { expect } from '@playwright/test';
 import { testConfig } from '../helpers/config';
+import { getMonitorCount } from '../helpers/zm-api';
 import { log } from '../../src/lib/logger';
 
 const { When, Then } = createBdd();
 
 // Zoom / pan (keyboard + mouse) - issue #191
 let panTransformBefore = '';
-// Monitor the view was zoomed on, so the reset check below can tell a real
-// monitor switch from a server with only one monitor to switch to.
-let zoomedMonitorId: string | null = null;
+
+// Stepping to a neighbour needs a neighbour to step to. Ask the ZM API, never
+// the buttons under test: a guard that reads their visibility skips exactly
+// when the bug it guards has hidden them, and reports green (refs #382).
+// Cached per worker, one call per run.
+let monitorCount: number | null = null;
+async function serverHasTwoMonitors(): Promise<boolean> {
+  if (monitorCount === null) {
+    monitorCount = await getMonitorCount();
+    log.info('E2E server monitor count', { component: 'e2e', count: monitorCount });
+  }
+  return monitorCount > 1;
+}
 
 async function readZoomTransform(page: import('@playwright/test').Page): Promise<string> {
   return page
@@ -31,7 +42,6 @@ When('I scroll the wheel up over the monitor view', async ({ page }) => {
 });
 
 When('I zoom into the monitor view', async ({ page }) => {
-  zoomedMonitorId = page.url().match(/monitors\/(\d+)/)?.[1] ?? null;
   const zoomIn = page.getByTestId('zoom-in-button');
   await expect(zoomIn).toBeVisible({ timeout: testConfig.timeouts.pageLoad });
   // Two steps so the view is well past the zoom threshold with room to pan.
@@ -71,20 +81,22 @@ When('I drag the monitor view with the mouse', async ({ page }) => {
 });
 
 // Zoom belongs to the picture, not the page (refs #382). Stepping to another
-// monitor keeps the page mounted, so the transform has to be cleared explicitly.
+// monitor keeps the page mounted, so the zoom has to be cleared explicitly.
 Then('the monitor view should be back at fit', async ({ page }) => {
-  const nowId = page.url().match(/monitors\/(\d+)/)?.[1] ?? null;
-  if (!nowId || nowId === zoomedMonitorId) {
-    log.info('E2E: Skipping zoom-reset assertion - no second monitor to switch to', { component: 'e2e' });
+  if (!(await serverHasTwoMonitors())) {
+    log.info('E2E: Skipping zoom-reset assertion - server has one monitor', { component: 'e2e' });
     return;
   }
-  // The zoom controls collapse back to the two buttons only while the hook
-  // itself reports 1x, so this fails if the scale state survives the switch
-  // even when the new monitor's element paints unzoomed.
+  // The pan controls only render while the hook itself reports more than 1x,
+  // so their absence is the zoom state being cleared, not just a repainted
+  // element: the <img> remounts on the switch and paints unzoomed either way.
   await expect(page.getByTestId('pan-left-button')).toBeHidden({ timeout: testConfig.timeouts.transition });
   // '' on a freshly mounted element, 'scale(1)' on one the reset wrote to.
-  const transform = await readZoomTransform(page);
-  expect(transform === '' || transform.includes('scale(1)')).toBe(true);
+  // Polled: the reset animates over 0.2s, so the inline style can still carry
+  // the old scale for a frame after the controls have gone.
+  await expect
+    .poll(() => readZoomTransform(page), { timeout: testConfig.timeouts.transition })
+    .toMatch(/^$|scale\(1\)/);
 });
 
 Then('the view should pan', async ({ page }) => {


### PR DESCRIPTION
Refs #382. Follow-on to #388, which merged the monitor half only: auto-merge squashed the branch before the events commit landed, so that fix never reached main. It is recovered here.

## What is in this PR

**1. `EventDetail` resets the zoom on the event id.** Same shape as `MonitorDetail`: the route element is not keyed on the id, so stepping between events keeps the page mounted and `useZoomPan` keeps scale, offset and zoomed state. That page never called `reset()` at all.

Unit test only, and deliberately so. I wrote an e2e scenario for it and it passed with the fix disabled: on the MP4 playback path the zoom state clears on its own when stepping events (the page does not remount — I checked with a mount counter — so something in the player path is clearing it). A scenario that cannot fail is worse than none, so it was removed rather than shipped green. The effect still earns its place: it makes the two pages behave the same by construction instead of by a side effect of how a player remounts.

**2. The monitor scenario's skip guard now derives from the API.** It read the visibility of the buttons under test, which the testing playbook already forbids: such a guard skips exactly when the bug has hidden them. That is not hypothetical here — the events version of the same guard skipped itself and reported green on a run that asserted nothing. It now asks `getMonitorCount()`.

**3. Three lines added to `agents/project/testing.md`**, per the self-improvement protocol, for what this fix cost time to rediscover:
- `scripts/proven-red.mjs` skips e2e by design (needs a server), so an e2e scenario is proven red by hand: stash the source file, `npx bddgen`, `--grep` the scenario.
- Rename a step and `.features-gen` goes stale, reporting `Missing step` — which reads like a failing test and is not one.
- A page that stays mounted across a route param change repaints its content either way, so a DOM property such as a transform is green with or without the fix. Assert the state that survives, such as a control that only renders while the hook holds the old value.

## Verification

- `npm run gates`: 4221 passed, 2 skipped; build; `lint:a11y`, `lint:correctness`, `lint:ratchet` (201, at baseline).
- `Zoom resets when stepping to another monitor` re-run against the live server with the API-derived guard: passes, and the log line shows it saw 8 monitors, so the assertion actually ran. Verified red again with the fix disabled in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW