### PR TITLE
docs(agents): history-mined lessons from the 2026-08 fix chains

### DIFF
--- a/AGENTS.project.md
+++ b/AGENTS.project.md
@@ -62,7 +62,7 @@ Gate: `app/src/tests/agents-contracts.test.ts`; review; subscription changes nee
 ### Aggregation (virtual profile groups)
 Owns: surfaces fanning out over multiple profiles.
 Path: scope from `useProfileScope` only (filters disabled profiles; single mode is a one-element array); an aggregate id is a virtual profile id, tested with `isAggregateProfileId`; fan out via `useQueries` with `combine` (`useScopedMonitors` is the template); aggregate-keyed state uses `monitorCacheKey` composites, raw ZM ids collide across servers; stagger via `staggeredRefetchInterval`.
-Never: bare monitor/event ids as aggregate keys; new `ALL_PROFILES_ID` references beyond the rehydrate migration and existing legacy arms; `getCurrentSession` where an aggregate can be current; server-scoped prefs read from an aggregate bucket.
+Never: bare monitor/event ids as aggregate keys; new `ALL_PROFILES_ID` references beyond the rehydrate migration and existing legacy arms; any unparented current-profile read (`getCurrentSession`, `useFreshAccessToken()`, `useProfileScope().settings`) where an aggregate can be current; server-scoped prefs read from an aggregate bucket.
 Gate: review; mechanizing these is a tracked follow-up.
 
 ### Notifications

--- a/agents/project/domain-context.md
+++ b/agents/project/domain-context.md
@@ -47,6 +47,18 @@ matching reality, fixing it is a protocol change like any rule edit.
   ZoneMinder's zone editor. 1.39.18 writes percent, so a full-frame zone reads
   `0,0 100,0 100,100 0,100`; percent values carry two decimals, so parse them
   as floats, and scale before rotation, which works in pixel space.
+- `ajax/control.php` has no denial branch. A PTZ command the account may
+  not send is answered with 200 and an empty body, so there is no refusal
+  for the client to catch; PTZ is gated proactively on permissions or not
+  at all (6161352f).
+- Control definitions arrive with their axis flags coerced to strings, and
+  a server may send a JSON boolean or an empty column, which lands as
+  `'false'` or `''`. Gate capability on `=== '1'` rather than `!== '0'`,
+  and treat only an absent field as capable (343bd334, 26054e6f).
+- A server that prunes deletes events underneath an open list, so a card
+  can outlive the row it describes and a PUT to that id answers 404. Treat
+  that as the event being gone and refresh the list, not as a failed write
+  (8002b74c). `isNotFound` lives beside `createHttpError`.
 
 ## Streaming and media
 
@@ -160,6 +172,31 @@ matching reality, fixing it is a protocol change like any rule edit.
   gated off on iOS; remote Ollama is the supported path there.
 - Google Play's native debug-symbols warning for Android builds is inherent
   to stripped Google dependencies and cannot be cleared.
+- Capacitor 8's core `SystemBars` plugin owns the Android window chrome and
+  re-asserts it on every configuration change: it re-applies the bar style
+  it is tracking, and its `setStyle` finishes by repainting the decor view
+  with the theme's `windowBackground`, which follows OS night mode rather
+  than the app theme. Anything written directly to the insets controller
+  or the window background is overwritten on the next rotation. Drive icon
+  style through `SystemBars.setStyle` from the web layer so the tracked
+  style is the one it re-applies; restore the window colour after a
+  configuration change, posted so it queues behind the plugin's handler;
+  order any direct window write after `setStyle`. Five fixes on one plugin
+  before this was understood (68eab240, 2672c108, 7d3d8fb4, e1f55af0,
+  aaf4dbfd).
+- On the Android WebView `env(safe-area-inset-*)` is unreliable: 0 below
+  WebView 140, 0 under enforced edge-to-edge on Android 16. Capacitor
+  injects `--safe-area-inset-*` inline on `documentElement`, so `--sai-*`
+  resolves through that first and `env()` second (aaf4dbfd). The md layout
+  shields the top inset with a sticky opaque strip, not padding: padding
+  scrolls with the content and pages rendered behind the status bar
+  (34cb62d7, 4c6f2ecd).
+- Android's `HttpURLConnection` error text reaches the user verbatim
+  through Capacitor, leading slash from `InetSocketAddress.toString()`
+  included. Detect "unreachable" structurally, an `HttpError` with no
+  `status` never received a response, and take the host from the request
+  URL, never from the message; matching wording would encode four
+  platforms' prose (65f7a963).
 
 ## Libraries and state
 
@@ -174,6 +211,25 @@ matching reality, fixing it is a protocol change like any rule edit.
 - The React Compiler lint reports at most one violation per function and
   only file-scoped `eslint-disable` comments silence it; fixing one
   violation can reveal the next on the same function.
+- `MonitorDetail` and `EventDetail` stay mounted across a route param
+  change: the route elements carry no `key`, so stepping between ids keeps
+  every piece of per-visit state (the zoom, the MP4-to-ZMS fallback flag,
+  anything in `useState`). Per-visit state resets from an effect on the id
+  or it leaks onto the next entity (4e447581, 200d805d, ec43a4dd). Keying
+  the route instead would remount the player and mint a fresh connkey on
+  every step.
+- The scroll pad's automatic trigger was wrong twice, a free-pixel threshold
+  the player's `100svh-7rem` cap could never satisfy and then a coverage
+  ratio, and became a remembered per-profile setting (524d45a5, 500cae59,
+  1a0b5139, 7a6e72c5). Do not re-attempt auto-measurement. The underlying
+  problem was `touch-action: none` at every zoom level; it now follows the
+  zoom (`pan-y` unzoomed, `none` zoomed), which is what let a finger scroll
+  from over the feed (e3e11b4f, 4956078f).
+- Compact mode rewrites Tailwind utility classes, not arbitrary values, so
+  a `pt-[2rem]` beside a compacted `h-8` opens a gap. Toolbar clearance
+  reads `--fullscreen-toolbar-h`, overridden in the compact block beside
+  the rule it tracks (6882898c). Fullscreen montage tile math excludes the
+  overlay header, which takes no flow space (267d8453).
 
 ## Hardware and CI limits
 
@@ -200,6 +256,12 @@ contract. Remaining code-path facts:
   `resolveWindow` does arithmetic. Never regress to direct fills or
   app-side phrase regexes (deleted twice); the measured why lives in
   `llm-models.md`.
+- Counts computed from a truncated page are not facts, and the model drops
+  qualifiers such as "(listed rows)". A truncated result either fetches the
+  real totals (`pagination.totalCount`, one count query per monitor,
+  capped) or omits the field so there is nothing to misquote. A `when`
+  phrase that resolves to no window is a corrective error, never a silent
+  unfiltered query (e657f33e, 17b83354, 7c36ff0f).
 
 ## CI runners
 
@@ -234,3 +296,10 @@ contract. Remaining code-path facts:
   parallel e2e runs (filter-popover timeouts, drifting counts). Five
   events-filter scenarios are bisect-proven pre-existing failures
   tracked in #342; treat new failures against that baseline, not zero.
+- An unparented read of the current profile inside a group resolves to the
+  aggregate id, which is no profile: `useFreshAccessToken()` answers with
+  the empty auth slice and a stream never starts; `useProfileScope().settings`
+  reads a bucket nothing writes server-scoped keys into. Every multi-server
+  read takes the owning `profileId` as a required prop with no default
+  (c4a68a72, 93b56b7b, 9be0f2ef); two of those were the same component in
+  two branches.

--- a/agents/project/testing.md
+++ b/agents/project/testing.md
@@ -75,6 +75,11 @@ Never run two web e2e suites in one checkout. They share generated files and res
   settings shape, not just files importing the changed module. Two
   fixtures broke this way in one wave while the directly-scoped suites
   stayed green.
+- `mockReturnValue` set inside one test outlives `vi.clearAllMocks()`,
+  which clears recorded calls but not implementations. A store override
+  that leaked this way made a timezone test pass in UTC-5 and fail in
+  CI's UTC for weeks (75c89db3). Use `mockReturnValueOnce`, or reset the
+  mock in `beforeEach`.
 
 ## Regression tests for store-subscription bugs
 


### PR DESCRIPTION
Periodic sweep of the commit history since the last mining commit (`bb0f0c0e`), 519 commits, for lessons the instruction files had not captured. Every entry cites the commits behind it; the contracts test verifies each hash exists.

## Changes

**`agents/project/domain-context.md`** — ten new entries under existing headers:
- ZoneMinder API: `control.php` never denies a PTZ command; control axis flags arrive as strings; a 404 on a pruned event means the event is gone.
- Platform quirks: Capacitor 8 `SystemBars` re-asserts window chrome on every configuration change (five fixes on one plugin); Android safe-area resolution; structural detection of an unreachable host.
- Libraries and state: detail pages stay mounted across a route param change (three fixes); scroll-pad auto-measurement is a do-not-retry; compact mode cannot rewrite arbitrary values.
- All-profiles: unparented current-profile reads resolve to the aggregate (three fixes).
- Assistant: counts from a truncated page are not facts.

**`agents/project/testing.md`** — one trap: `mockReturnValue` outlives `vi.clearAllMocks()` (a leaked override hid a real failure from CI for weeks).

**`AGENTS.project.md`** — the Aggregation contract's `Never` line widens from `getCurrentSession` alone to any unparented current-profile read, naming the two hooks that each caused a fix.

No generic rule candidates this run; every class is specific to Capacitor, ZoneMinder or React Router. Already-covered fixes verified and listed in the session report rather than re-added.

## Verification

`app/src/tests/agents-contracts.test.ts`: 18 passed, including the word budget and the check that every cited hash exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW