### PR TITLE
ci: exempt bots from the acceptance check, and quiet dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,20 @@
 # The audit backlog grew from 22 to 37 in app/ (19 more at the root) between
 # two reviews with nothing watching it. Dependabot opens the PRs; CI decides
-# whether they land. Grouped so a week of patch bumps is one PR to review
-# rather than thirty.
+# whether they land.
+#
+# Tuned for a small number of PRs that are worth reading, not coverage: patch
+# and minor bumps arrive grouped, majors arrive one at a time, and the limits
+# cap how many can be open at once so they queue instead of flooding. A major
+# bump to an action used only by the release workflows is NOT exercised by
+# CI - those workflows run on a tag, never on a PR - so read those before
+# merging.
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /app
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     groups:
       patch-and-minor:
         update-types: [minor, patch]
@@ -18,16 +24,22 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       patch-and-minor:
         update-types: [minor, patch]
     labels: [dependencies]
 
   # Third-party actions are pinned to mutable major tags in several workflows;
-  # this at least surfaces when one moves.
+  # this at least surfaces when one moves. Grouped: ungrouped, the first run
+  # opened four separate PRs for four action bumps, which is noise nobody
+  # reads. One PR a month, or none.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    open-pull-requests-limit: 2
+    groups:
+      actions:
+        patterns: ['*']
     labels: [dependencies]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,16 @@ jobs:
   # Fork PRs are exempt. The rule governs how this project's own work lands;
   # failing a first-time outside contributor on a heading nobody told them
   # about would cost more than it buys.
+  #
+  # Bots are exempt too. P1 is about a human landing work against an issue's
+  # acceptance lines; a dependabot bump has no issue and no acceptance lines to
+  # quote, and this job failed all five of the first batch it ever saw.
   pr-acceptance:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot'
 
     steps:
       - name: PR body quotes the issue's acceptance lines


### PR DESCRIPTION
Refs #392

## Acceptance

Two follow-ups to what #394 landed, both found by its first contact with reality.

- **P13-2 follow-up.** The `pr-acceptance` job failed all five PRs in the
  first dependabot batch it saw (#396-#400). P1 governs a human landing work
  against an issue's acceptance lines; a dependency bump has no issue and no
  acceptance lines to quote. Bots are now exempt, like forks.
- **P9-2 follow-up.** The dependabot config opened five PRs at once, four of
  them one-per-action. A queue of unread PRs is worse than no dependabot.
  Action updates are now grouped into one monthly PR, and the open-PR limits
  drop to 2 (app), 1 (root), 2 (actions) so bumps queue instead of flooding.

## The trap this batch exposed

A major bump to an action used only by the release workflows is **not**
exercised by CI. Every `build-*` workflow triggers on `push: tags:
zmNinjaNg-*` or manual dispatch, never on a PR, so a green tick on #396,
#397 and #398 says the rest of CI still passes, not that the bump works. That
is now written into the config comment so the next reader does not have to
rediscover it.

## Checks run

- Verified against the real payload for #396: `user.type` is `Bot`.
- `.github/dependabot.yml` and `ci.yml` both parse; the job condition is
  unchanged for human same-repo PRs, which this PR itself exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW