### PR TITLE
chore: dependabot for security advisories only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,45 +1,38 @@
-# The audit backlog grew from 22 to 37 in app/ (19 more at the root) between
-# two reviews with nothing watching it. Dependabot opens the PRs; CI decides
-# whether they land.
+# Security updates only.
 #
-# Tuned for a small number of PRs that are worth reading, not coverage: patch
-# and minor bumps arrive grouped, majors arrive one at a time, and the limits
-# cap how many can be open at once so they queue instead of flooding. A major
-# bump to an action used only by the release workflows is NOT exercised by
-# CI - those workflows run on a tag, never on a PR - so read those before
-# merging.
+# The audit backlog (37 in app/, 29 of them high or critical) is almost
+# entirely @wdio/* and @capacitor/assets: device-test and icon-generation
+# tooling that never ships to a device. Routine version bumps for that are
+# churn, and the first run proved it, opening five PRs that fixed none of the
+# 37.
+#
+# What is worth interrupting for is an advisory against something that does
+# ship. That comes from Dependabot security updates, a repo setting rather
+# than this file, and it is now on along with vulnerability alerts. Setting
+# every version-update limit to 0 leaves those running and stops the rest.
+#
+# To go back to routine bumps, raise a limit and add a `groups:` block so a
+# week of patches is one PR. Do not drop grouping; ungrouped, github-actions
+# alone opened four PRs in one morning.
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /app
     schedule:
       interval: weekly
-    open-pull-requests-limit: 2
-    groups:
-      patch-and-minor:
-        update-types: [minor, patch]
+    open-pull-requests-limit: 0
     labels: [dependencies]
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 1
-    groups:
-      patch-and-minor:
-        update-types: [minor, patch]
+    open-pull-requests-limit: 0
     labels: [dependencies]
 
-  # Third-party actions are pinned to mutable major tags in several workflows;
-  # this at least surfaces when one moves. Grouped: ungrouped, the first run
-  # opened four separate PRs for four action bumps, which is noise nobody
-  # reads. One PR a month, or none.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 2
-    groups:
-      actions:
-        patterns: ['*']
+    open-pull-requests-limit: 0
     labels: [dependencies]


### PR DESCRIPTION
Refs #392

## Acceptance

Corrects how P9-2 was implemented in #394.

The finding said the audit backlog grew from 22 to 37 with no dependabot. True,
but I added routine version updates without first checking what the 37 were.
They are almost entirely `@wdio/*` and `@capacitor/assets`: device-test and
icon-generation tooling that never ships to a device. The first run opened five
PRs and fixed none of them.

Meanwhile the half that would have mattered was not running at all.
`dependabot_security_updates` and vulnerability alerts are repo settings, not
`dependabot.yml`, and both were disabled. So after #394 the repo had the churn
and none of the protection.

- Vulnerability alerts: enabled.
- Dependabot security updates: enabled.
- Every version-update limit set to 0, which leaves security updates running
  and stops routine bumps.

Net effect: no scheduled PRs, and a PR when an advisory lands against something
that actually ships.

## Checks run

- `.github/dependabot.yml` parses; all three ecosystems at limit 0.
- Repo settings verified after the change: `dependabot_security_updates` is
  `enabled`, `vulnerability-alerts` returns 204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW