### PR TITLE
chore(release): record each e2e run and recommend one when stale

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -44,3 +44,4 @@ android/app/src/main/assets/public/
 android/keystore.properties
 *.jks
 *.keystore
+.e2e-last-run.json

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -28,7 +28,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1,
   workers: process.env.E2E_WORKERS ? Number(process.env.E2E_WORKERS) : 1,
-  reporter: 'html',
+  // The JSON file is the "when did e2e last run, and did it pass" stamp that
+  // make_release.sh reads before tagging. Overwritten on every run.
+  reporter: [['html'], ['json', { outputFile: '.e2e-last-run.json' }]],
 
   timeout: 30000,
 

--- a/docs/building/index.rst
+++ b/docs/building/index.rst
@@ -146,6 +146,12 @@ scenario. A gate that always costs 18 minutes gets routed around, so it asks
 instead: Enter runs it, ``n`` skips with a warning. ``--skip-e2e`` skips
 without the question, for scripted runs.
 
+Every e2e run writes ``app/.e2e-last-run.json`` (Playwright's JSON reporter,
+gitignored). The prompt reads it and says when the suite last ran on this
+machine and whether it passed, and recommends a run when that record is
+missing, failed, or older than two weeks. It only recommends; the answer is
+still yours.
+
 With no terminal to ask on, it runs rather than skipping: silence should not
 lose the only cover these journeys have. Missing ``app/.env`` is an error
 rather than a silent skip, for the same reason.

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -240,6 +240,31 @@ elif [ ! -t 0 ]; then
 else
     echo "The browser e2e suite takes about 18 minutes and is the only"
     echo "automated cover these user journeys get."
+    # Every run writes app/.e2e-last-run.json (Playwright's json reporter).
+    # Recommend a run when that is missing, red, or older than two weeks.
+    E2E_MAX_AGE_DAYS=14
+    if [ -f app/.e2e-last-run.json ]; then
+        E2E_LAST=$(node -e '
+            const s = require("./app/.e2e-last-run.json").stats || {};
+            const days = Math.floor((Date.now() - new Date(s.startTime)) / 864e5);
+            const red = (s.unexpected || 0) > 0;
+            console.log(`${days} ${red ? "red" : "green"} ${s.expected || 0} ${s.unexpected || 0}`);
+        ' 2>/dev/null)
+        read -r E2E_AGE E2E_RESULT E2E_PASSED E2E_FAILED <<< "$E2E_LAST"
+        if [ -z "$E2E_AGE" ]; then
+            echo "⚠️  app/.e2e-last-run.json is unreadable; treating e2e as never run."
+        elif [ "$E2E_RESULT" = "red" ]; then
+            echo "⚠️  Last e2e run was $E2E_AGE day(s) ago and FAILED ($E2E_FAILED failed, $E2E_PASSED passed)."
+            echo "   Recommended: run it now."
+        elif [ "$E2E_AGE" -gt "$E2E_MAX_AGE_DAYS" ]; then
+            echo "⚠️  Last e2e run was $E2E_AGE days ago (passed, $E2E_PASSED scenarios)."
+            echo "   That is older than $E2E_MAX_AGE_DAYS days. Recommended: run it now."
+        else
+            echo "ℹ️  Last e2e run was $E2E_AGE day(s) ago and passed ($E2E_PASSED scenarios)."
+        fi
+    else
+        echo "⚠️  No record of an e2e run on this machine. Recommended: run it now."
+    fi
     read -p "Run it before tagging $TAG? [Y/n] " -n 1 -r
     echo ""
     if [[ $REPLY =~ ^[Nn]$ ]]; then


### PR DESCRIPTION
Refs #392

## Acceptance

1. When e2e runs, it writes its result to a file: `app/.e2e-last-run.json`
   (Playwright's built-in json reporter; start time, passed, failed; gitignored).
2. `make_release.sh` reads that file before asking about e2e, reports when it
   last ran and whether it passed, and recommends running when the record is
   missing, failed, or older than 14 days. The question is still asked either way.

## Checks run

- All five prompt branches exercised against synthetic stamps: fresh green,
  stale green, recent red, missing, unreadable.
- A real `playwright test` run writes the stamp. Note a CLI `--reporter` flag
  replaces config reporters, so only flag-less runs stamp; `npm run test:e2e`
  passes none.
- `bash -n` on the script; `agents-contracts` and `quality-ratchet` gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW