### PR TITLE
fix(profiles): log in once when adding a server, and go straight to the app

### DIFF
--- a/app/src/pages/ProfileForm.tsx
+++ b/app/src/pages/ProfileForm.tsx
@@ -14,6 +14,7 @@ import { Label } from '../components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
 import { useProfileStore } from '../stores/profile';
 import type { ApiClient } from '../api/client';
+import type { LoginResponse } from '../api/types';
 import { createStoreApiClient } from '../api/store-gates';
 import { asProfileId } from '../api/types';
 import { discoverUrls, DiscoveryError } from '../services/discovery';
@@ -174,6 +175,9 @@ export default function ProfileForm() {
       // so there's no session to pull a client from; both branches below build
       // one directly for this candidate profileId. Refs #337.
       let profileClient: ApiClient | undefined;
+      // Discovery logs in to read ZM_PATH_ZMS; reuse that instead of paying
+      // ZoneMinder's ~0.6s password hash a second time.
+      let discoveredLogin: LoginResponse | undefined;
 
       if (showManualUrls) {
         // Manual URL entry mode
@@ -227,6 +231,7 @@ export default function ProfileForm() {
         confirmedPortalUrl = discovered.portalUrl;
         apiUrl = discovered.apiUrl;
         cgiUrl = discovered.cgiUrl;
+        discoveredLogin = discovered.loginResponse;
         log.profileForm('URLs discovered', LogLevel.INFO, { portalUrl: confirmedPortalUrl, apiUrl, cgiUrl });
       }
 
@@ -267,8 +272,13 @@ export default function ProfileForm() {
           useAuthStore.getState().logout(profileId);
           log.profileForm('Cleared existing auth state for fresh login', LogLevel.DEBUG);
 
-          await useAuthStore.getState().login(profileId, normalizedUsername, password, profileClient);
-          log.profileForm('Login successful', LogLevel.INFO);
+          if (discoveredLogin) {
+            useAuthStore.getState().setTokens(profileId, discoveredLogin);
+            log.profileForm('Reused the login discovery performed', LogLevel.INFO);
+          } else {
+            await useAuthStore.getState().login(profileId, normalizedUsername, password, profileClient);
+            log.profileForm('Login successful', LogLevel.INFO);
+          }
 
           // Note: ZMS path is already fetched during discovery when credentials are provided,
           // so cgiUrl is already set correctly. We just need to fetch Go2RTC path here.
@@ -328,10 +338,9 @@ export default function ProfileForm() {
         await switchProfile(profileId);
       }
 
-      // Navigate after a short delay
-      setTimeout(() => {
-        navigate(returnTo);
-      }, 1000);
+      // The destination page is the confirmation; a fixed pause before it
+      // was one more second on every first connect.
+      navigate(returnTo);
     } catch (err: unknown) {
       // The failed/cancelled attempt may have landed real tokens under this
       // profile's minted id (a successful login before a later step, e.g.

--- a/app/src/pages/__tests__/ProfileForm.test.tsx
+++ b/app/src/pages/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Add-server, end to end against the real stores and a scripted server.
+ *
+ * Two things the old flow did that a user paid for on every first connect:
+ * it logged in twice (discovery logged in to read ZM_PATH_ZMS and threw the
+ * token away, then the form logged in again; ZoneMinder's login.json hashes
+ * the password server-side at ~0.6s a call), and it slept a fixed second
+ * before navigating. Both are asserted here as what the server saw and when
+ * the user moved on, not as which function was called.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../api/store-gates', () => import('../../tests/fake-store-gates'));
+vi.mock('../../lib/security/secureStorage', () => import('../../tests/fake-secure-storage'));
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateSpy,
+  useSearchParams: () => [new URLSearchParams('returnTo=/monitors')],
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import ProfileForm from '../ProfileForm';
+import { seedProfiles, resetProfileFixture, fakeApiClient } from '../../tests/profile-fixture';
+import { installDefaultApiClient, resetFakeStoreGates } from '../../tests/fake-store-gates';
+import { useProfileStore } from '../../stores/profile';
+import { useAuthStore } from '../../stores/auth';
+
+const server = () =>
+  fakeApiClient({
+    '/host/getVersion.json': { version: '1.36.0', apiversion: '2.0' },
+    '/host/login.json': {
+      access_token: 'tok', access_token_expires: 3600,
+      refresh_token: 'ref', refresh_token_expires: 86400,
+      version: '1.36.0', apiversion: '2.0',
+    },
+    'ZM_PATH_ZMS': { config: { Value: '/zm/cgi-bin/nph-zms' } },
+    'ZM_GO2RTC_PATH': { config: { Value: '' } },
+    '/servers.json': { servers: [] },
+  });
+
+describe('ProfileForm add-server', () => {
+  let client: ReturnType<typeof server>;
+
+  beforeEach(() => {
+    seedProfiles([], { current: null });
+    client = server();
+    installDefaultApiClient(client);
+    navigateSpy.mockClear();
+  });
+  afterEach(() => {
+    resetProfileFixture();
+    resetFakeStoreGates();
+  });
+
+  it('logs in once, saves the profile, and moves on without a pause', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm />);
+
+    await user.clear(screen.getByTestId('setup-portal-url'));
+    await user.type(screen.getByTestId('setup-portal-url'), 'http://zm.example.com');
+    await user.type(screen.getByTestId('setup-username'), 'admin');
+    await user.type(screen.getByTestId('setup-password'), 'pw');
+    await user.click(screen.getByTestId('connect-button'));
+
+    // The destination page is the confirmation; no fixed sleep in between.
+    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('/monitors'), { timeout: 900 });
+
+    const logins = client.calls.filter((c) => c.method === 'POST' && c.url.includes('/host/login.json'));
+    expect(logins).toHaveLength(1);
+
+    const profile = useProfileStore.getState().profiles[0];
+    expect(profile?.cgiUrl).toBe('http://zm.example.com/zm/cgi-bin/nph-zms');
+    expect(useAuthStore.getState().slices[profile.id]?.accessToken).toBe('tok');
+  });
+});

--- a/app/src/services/__tests__/discovery.test.ts
+++ b/app/src/services/__tests__/discovery.test.ts
@@ -325,3 +325,41 @@ describe('discoverZoneminder', () => {
     });
   });
 });
+
+/**
+ * Discovery logs in to read ZM_PATH_ZMS, then threw the token away, and the
+ * add-server form logged in again for the same credentials 600ms later:
+ * ZoneMinder's login.json hashes the password server-side and is 20x slower
+ * than any other endpoint. The login discovery already did is now part of
+ * its result, so a caller that holds it can skip its own.
+ */
+describe('discovery returns the login it performed', () => {
+  it('carries the validated login response alongside the URLs', async () => {
+    const mockGet = vi.fn()
+      .mockResolvedValueOnce({ status: 200, data: { version: '1.36.0' } })          // getVersion probe
+      .mockResolvedValueOnce({ status: 200, data: { config: { Value: '/zm/cgi-bin/nph-zms' } } }); // ZM_PATH_ZMS
+    const mockPost = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      data: { access_token: 'tok', access_token_expires: 3600, refresh_token: 'ref', refresh_token_expires: 86400, version: '1.36.0', apiversion: '2.0' },
+    });
+    (createStoreApiClient as any).mockReturnValue({ get: mockGet, post: mockPost });
+
+    const result = await discoverZoneminder('http://zm.example.com', { username: 'admin', password: 'pw' });
+
+    expect(result.cgiUrl).toBe('http://zm.example.com/zm/cgi-bin/nph-zms');
+    expect(result.loginResponse?.access_token).toBe('tok');
+    expect(result.loginResponse?.refresh_token).toBe('ref');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the login when the server answered without tokens', async () => {
+    const mockGet = vi.fn().mockResolvedValueOnce({ status: 200, data: { version: '1.36.0' } });
+    const mockPost = vi.fn().mockResolvedValueOnce({ status: 200, data: {} });
+    (createStoreApiClient as any).mockReturnValue({ get: mockGet, post: mockPost });
+
+    const result = await discoverZoneminder('http://zm.example.com', { username: 'admin', password: 'pw' });
+
+    expect(result.loginResponse).toBeUndefined();
+    expect(result.cgiUrl).toBe('http://zm.example.com/zm/cgi-bin/nph-zms');
+  });
+});

--- a/app/src/services/__tests__/discovery.test.ts
+++ b/app/src/services/__tests__/discovery.test.ts
@@ -342,7 +342,7 @@ describe('discovery returns the login it performed', () => {
       status: 200,
       data: { access_token: 'tok', access_token_expires: 3600, refresh_token: 'ref', refresh_token_expires: 86400, version: '1.36.0', apiversion: '2.0' },
     });
-    (createStoreApiClient as any).mockReturnValue({ get: mockGet, post: mockPost });
+    vi.mocked(createStoreApiClient).mockReturnValue({ get: mockGet, post: mockPost } as unknown as ApiClient);
 
     const result = await discoverZoneminder('http://zm.example.com', { username: 'admin', password: 'pw' });
 
@@ -355,7 +355,7 @@ describe('discovery returns the login it performed', () => {
   it('omits the login when the server answered without tokens', async () => {
     const mockGet = vi.fn().mockResolvedValueOnce({ status: 200, data: { version: '1.36.0' } });
     const mockPost = vi.fn().mockResolvedValueOnce({ status: 200, data: {} });
-    (createStoreApiClient as any).mockReturnValue({ get: mockGet, post: mockPost });
+    vi.mocked(createStoreApiClient).mockReturnValue({ get: mockGet, post: mockPost } as unknown as ApiClient);
 
     const result = await discoverZoneminder('http://zm.example.com', { username: 'admin', password: 'pw' });
 

--- a/app/src/services/discovery.ts
+++ b/app/src/services/discovery.ts
@@ -1,7 +1,7 @@
 
 import type { ApiClient } from '../api/client';
 import { createStoreApiClient } from '../api/store-gates';
-import { PROBE_PROFILE_ID, type ProfileId } from '../api/types';
+import { LoginResponseSchema, PROBE_PROFILE_ID, type LoginResponse, type ProfileId } from '../api/types';
 import type { HttpError } from '../lib/http';
 import { log, LogLevel } from '../lib/logger';
 import { isAbortError } from '../lib/is-abort-error';
@@ -35,6 +35,13 @@ export interface DiscoveryResult {
     portalUrl: string;
     apiUrl: string;
     cgiUrl: string;
+    /**
+     * The login discovery performed to read ZM_PATH_ZMS, when credentials
+     * were given and the server issued tokens. ZoneMinder's login.json
+     * hashes the password server-side and costs ~0.6s, 20x any other call;
+     * a caller that holds this can install it instead of logging in again.
+     */
+    loginResponse?: LoginResponse;
 }
 
 /**
@@ -181,12 +188,17 @@ async function probeApi(apiUrl: string, profileId: ProfileId, signal?: AbortSign
  * Returns the full cgiUrl or null if fetch fails.
  * Throws if signal is aborted.
  */
-async function fetchCgiUrl(apiUrl: string, portalUrl: string, options: DiscoveryOptions, profileId: ProfileId): Promise<string | null> {
+interface CgiFetch {
+    cgiUrl: string | null;
+    loginResponse?: LoginResponse;
+}
+
+async function fetchCgiUrl(apiUrl: string, portalUrl: string, options: DiscoveryOptions, profileId: ProfileId): Promise<CgiFetch> {
     const { username, password, signal } = options;
 
     if (!username || !password) {
         log.discovery('No credentials provided, skipping ZMS path fetch', LogLevel.DEBUG);
-        return null;
+        return { cgiUrl: null };
     }
 
     // Check if already aborted
@@ -208,8 +220,12 @@ async function fetchCgiUrl(apiUrl: string, portalUrl: string, options: Discovery
 
         if (!loginResponse.data?.access_token) {
             log.discovery('Login did not return access token', LogLevel.DEBUG);
-            return null;
+            return { cgiUrl: null };
         }
+        // Validated so the caller can hand it to the auth store as-is; a body
+        // the schema rejects is treated as no login rather than a bad one.
+        const parsedLogin = LoginResponseSchema.safeParse(loginResponse.data);
+        const validLogin = parsedLogin.success ? parsedLogin.data : undefined;
 
         // Check if aborted before fetching config
         if (signal?.aborted) {
@@ -230,8 +246,9 @@ async function fetchCgiUrl(apiUrl: string, portalUrl: string, options: Discovery
             const url = new URL(portalUrl);
             const cgiUrl = `${url.origin}${zmsPath}`;
             log.discovery('ZMS path fetched from server', LogLevel.INFO, { zmsPath, cgiUrl });
-            return cgiUrl;
+            return { cgiUrl, loginResponse: validLogin };
         }
+        return { cgiUrl: null, loginResponse: validLogin };
     } catch (error) {
         // Re-throw abort/cancel errors
         if (error instanceof DiscoveryError && error.code === 'CANCELLED') {
@@ -245,7 +262,7 @@ async function fetchCgiUrl(apiUrl: string, portalUrl: string, options: Discovery
         });
     }
 
-    return null;
+    return { cgiUrl: null };
 }
 
 /**
@@ -297,7 +314,8 @@ export async function discoverZoneminder(inputUrl: string, options: DiscoveryOpt
 
                     // Try to fetch actual ZMS path from server (requires auth)
                     // Fall back to inference if auth fails or no credentials
-                    let cgiUrl = await fetchCgiUrl(fullApiUrl, portalUrl, options, profileId);
+                    const fetched = await fetchCgiUrl(fullApiUrl, portalUrl, options, profileId);
+                    let cgiUrl = fetched.cgiUrl;
 
                     if (!cgiUrl) {
                         // Default: derive from portalUrl
@@ -311,6 +329,7 @@ export async function discoverZoneminder(inputUrl: string, options: DiscoveryOpt
                         portalUrl,
                         apiUrl: fullApiUrl,
                         cgiUrl,
+                        ...(fetched.loginResponse ? { loginResponse: fetched.loginResponse } : {}),
                     };
                 }
             } catch (error) {

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -549,9 +549,14 @@ time, logs in to confirm the details, then saves the profile and switches to it.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/CertTrustDialog.tsx>`__
    · → :doc:`05-component-architecture`
 
-#. **Confirm with a login.** After a fresh ``logout()``, the auth store's
-   ``login()`` authenticates against the confirmed server; failure is surfaced as
-   a localized error.
+#. **Install the login discovery already did.** Discovery logged in to read
+   ``ZM_PATH_ZMS`` and returns that response as ``loginResponse``; after a fresh
+   ``logout()`` the form hands it to ``setTokens()`` rather than calling
+   ``login()`` a second time. ZoneMinder's ``login.json`` hashes the password
+   server-side and costs about 0.6s, twenty times any other call, so the second
+   login was most of the wait on a first connect. Only when discovery returned no
+   tokens (no credentials, or a server with auth off) does ``login()`` run.
+   Failure is surfaced as a localized error either way.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/stores/auth.ts>`__
    · → :doc:`11-application-lifecycle`
 


### PR DESCRIPTION
Refs #392

## Acceptance

Adding a server logged in twice and then slept a fixed second. Both gone:

- Discovery returns the login it already performed (`loginResponse`, validated);
  the form installs it with `setTokens` instead of calling `login()` again.
  `login()` still runs when discovery returned no tokens.
- The `setTimeout(..., 1000)` before `navigate` is removed.

Why it matters: your ZoneMinder's `login.json` measures 0.61s (server-side
password hash), 20× any other endpoint. Users get ~1.6s off every first connect;
the e2e Background pays this path 165 times.

Not changed, deliberately: the edit-profile path relies on discovery's own
login for its `cgiUrl` and is untouched; `bootstrapAuth`'s launch-time login is a
separate design decision (it clears state on purpose) and is not in scope.

## Checks run

- Two new tests, both proven red against `main`'s code by swapping the files in:
  discovery carries the login response; the add-server form, against the real
  stores and a scripted server, POSTs `login.json` exactly once, saves the real
  `cgiUrl`, and navigates with no timer.
- `npm run gates` bare: 4298 passed; `tsc -b` clean; the quality ratchet held at
  72 (it caught my first draft stubbing two components, which I removed).
- `node scripts/proven-red.mjs main HEAD`: changed tests fail on the pre-change code.
- Call flow 4 updated to describe the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW