### PR TITLE
ci: a ratchet baseline is bookkeeping, not source, for proven-red

### DIFF
--- a/scripts/__tests__/proven-red.test.mjs
+++ b/scripts/__tests__/proven-red.test.mjs
@@ -89,3 +89,9 @@ test('proveRed fails a behavior change that brings no unit test', () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('a ratchet baseline is bookkeeping, not source', () => {
+  const split = classify(['app/.quality-baseline.json', 'app/.lint-baseline.json', 'app/src/hooks/__tests__/x.test.ts']);
+  assert.deepEqual(split.source, []);
+  assert.equal(skipReason('test: migrate', split), 'no source file changed');
+});

--- a/scripts/proven-red.mjs
+++ b/scripts/proven-red.mjs
@@ -34,7 +34,11 @@ export const SKIP_TYPES = ['docs', 'chore', 'ci', 'refactor', 'build', 'style', 
 
 const UNIT_TEST = /^app\/src\/.*\.test\.(ts|tsx)$/;
 const TEST_SUPPORT = /^app\/src\/tests\/|\/__tests__\/|^app\/tests\/steps\//;
-const NON_CODE = /^(docs\/|agents\/|\.github\/|.*\.md$|.*\.rst$|app\/src\/locales\/|app\/tests\/features\/)/;
+// Ratchet baselines record a count; changing one is bookkeeping, not
+// behaviour. Counting them as source made a pure test migration (tests
+// changed, a baseline lowered, no app code touched) demand a red proof it
+// cannot give, since its tests rightly pass on the old code too.
+const NON_CODE = /^(docs\/|agents\/|\.github\/|.*\.md$|.*\.rst$|app\/src\/locales\/|app\/tests\/features\/|app\/\.[\w-]+-baseline\.json$)/;
 
 /** Split a changed-file list into what to run, what to carry along, and what counts as behavior. */
 export function classify(files) {


### PR DESCRIPTION
Refs #392

## Acceptance

`proven-red` classified `app/.quality-baseline.json` as a source file, so #417 — a
pure test migration that lowers the baseline, no app code touched — was asked to
prove its tests go red on the old code. They rightly do not. Baseline files now
classify as non-code; a script test pins it.

## Checks run

- `npm run test:scripts`: all pass including the new case.
- No unit tests changed, so this PR itself is skipped by proven-red as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug2KMTruP49Y8cmdZc97AW