### PR TITLE
fix(notifications): direct mode registers on enable, once, and says so

### DIFF
--- a/app/src/api/notifications.ts
+++ b/app/src/api/notifications.ts
@@ -31,8 +31,11 @@ interface NotificationResponse {
 }
 
 /**
- * Register or upsert an FCM token with the ZM server.
- * If the token already exists, updates the existing row.
+ * Register an FCM token with the ZM server.
+ * Notifications.Token is uniquely indexed server-side: re-posting a token the
+ * server already holds fails with an HTTP 500 duplicate-entry error rather
+ * than updating the row. Callers keep the returned Id and update through
+ * updateNotification instead.
  */
 export async function registerToken(
   client: ApiClient,

--- a/app/src/components/NotificationHandler.tsx
+++ b/app/src/components/NotificationHandler.tsx
@@ -139,7 +139,13 @@ export function NotificationHandler() {
     return unsubscribe;
   }, []);
 
-  // Get settings for current profile
+  // Subscribe to the settings slice so enabling/disabling notifications
+  // re-renders this component. Direct mode opens no websocket, so nothing in
+  // `connections` changes: without this, the delegated hooks below keep the
+  // settings object from the render before the toggle and FCM registration
+  // never runs. Selecting the raw slice (not a mapped object) keeps the
+  // subscription stable; getProfileSettings spreads a fresh object per call.
+  useNotificationStore((state) => state.profileSettings);
   const settings = currentProfile ? getProfileSettings(currentProfile.id) : null;
 
   // --- Delegated hooks ---

--- a/app/src/components/__tests__/NotificationHandler.test.tsx
+++ b/app/src/components/__tests__/NotificationHandler.test.tsx
@@ -55,8 +55,12 @@ vi.mock('../../components/notifications/ProfileNotificationConnector', () => ({
   ),
 }));
 
+const pushSetupCalls = vi.hoisted(() => [] as Array<{ enabled?: boolean; notificationMode?: string } | null>);
+
 vi.mock('../../hooks/useNotificationPushSetup', () => ({
-  useNotificationPushSetup: () => {},
+  useNotificationPushSetup: ({ settings }: { settings: { enabled?: boolean; notificationMode?: string } | null }) => {
+    pushSetupCalls.push(settings);
+  },
 }));
 
 vi.mock('../../hooks/useNotificationDelivered', () => ({
@@ -197,5 +201,43 @@ describe('NotificationHandler All-mode fan-out (refs #337)', () => {
     const { getByTestId } = renderHandler();
 
     expect(getByTestId('connector-profile-a')).toBeInTheDocument();
+  });
+});
+
+// Direct mode never opens a websocket, so nothing in `connections` changes when
+// the user enables it. Unless this component subscribes to profileSettings, it
+// never re-renders and useNotificationPushSetup keeps its stale `enabled:false`
+// settings -- FCM registration never runs and the badge stays "not registered"
+// until an unrelated ES connect happens to re-render it.
+describe('NotificationHandler settings subscription', () => {
+  beforeEach(() => {
+    pushSetupCalls.length = 0;
+    useNotificationStore.setState({
+      profileEvents: {},
+      profileSettings: {},
+      currentProfileId: null,
+    });
+    seedProfiles([makeProfile(PROFILE_ID, { name: 'Test Profile', portalUrl: 'http://zm.local' })]);
+  });
+
+  afterEach(() => {
+    resetProfileFixture();
+    resetFakeStoreGates();
+  });
+
+  it('passes updated settings to push setup when direct mode is enabled', () => {
+    useNotificationStore.getState().updateProfileSettings(PROFILE_ID, {
+      enabled: false,
+      notificationMode: 'direct',
+    });
+    renderHandler();
+    expect(pushSetupCalls.at(-1)?.enabled).toBe(false);
+
+    act(() => {
+      useNotificationStore.getState().updateProfileSettings(PROFILE_ID, { enabled: true });
+    });
+
+    expect(pushSetupCalls.at(-1)?.enabled).toBe(true);
+    expect(pushSetupCalls.at(-1)?.notificationMode).toBe('direct');
   });
 });

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -1000,7 +1000,8 @@
       "connecting": "Verbinde...",
       "direct_active": "Direktmodus aktiv",
       "direct_not_registered": "Direktmodus nicht registriert",
-      "direct_native_only": "Direktmodus braucht die Mobile-App"
+      "direct_polling": "Fragt Ereignisse ab",
+      "direct_poller_stopped": "Abfrage läuft nicht"
     },
     "switch_profile_title": "Profil wechseln?",
     "switch_profile_desc": "Diese Benachrichtigung stammt von \"{{profile}}\". Zu diesem Profil wechseln, um das Ereignis anzuzeigen?",

--- a/app/src/locales/de/translation.json
+++ b/app/src/locales/de/translation.json
@@ -999,7 +999,7 @@
       "disconnected": "Getrennt",
       "connecting": "Verbinde...",
       "direct_active": "Direktmodus aktiv",
-      "direct_not_registered": "Direktmodus nicht registriert",
+      "direct_registering": "Warte auf Registrierung",
       "direct_polling": "Fragt Ereignisse ab",
       "direct_poller_stopped": "Abfrage läuft nicht"
     },

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -1000,7 +1000,8 @@
       "connecting": "Connecting...",
       "direct_active": "Direct mode active",
       "direct_not_registered": "Direct mode not registered",
-      "direct_native_only": "Direct mode needs the mobile app"
+      "direct_polling": "Polling for events",
+      "direct_poller_stopped": "Poller not running"
     },
     "switch_profile_title": "Switch Profile?",
     "switch_profile_desc": "This notification is from \"{{profile}}\". Switch to this profile to view the event?",

--- a/app/src/locales/en/translation.json
+++ b/app/src/locales/en/translation.json
@@ -999,7 +999,7 @@
       "disconnected": "Disconnected",
       "connecting": "Connecting...",
       "direct_active": "Direct mode active",
-      "direct_not_registered": "Direct mode not registered",
+      "direct_registering": "Waiting for registration",
       "direct_polling": "Polling for events",
       "direct_poller_stopped": "Poller not running"
     },

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -1000,7 +1000,8 @@
       "connecting": "Conectando...",
       "direct_active": "Modo directo activo",
       "direct_not_registered": "Modo directo no registrado",
-      "direct_native_only": "El modo directo requiere la app móvil"
+      "direct_polling": "Consultando eventos",
+      "direct_poller_stopped": "Sondeo detenido"
     },
     "switch_profile_title": "Cambiar perfil?",
     "switch_profile_desc": "Esta notificacion es de \"{{profile}}\". Cambiar a este perfil para ver el evento?",

--- a/app/src/locales/es/translation.json
+++ b/app/src/locales/es/translation.json
@@ -999,7 +999,7 @@
       "disconnected": "Desconectado",
       "connecting": "Conectando...",
       "direct_active": "Modo directo activo",
-      "direct_not_registered": "Modo directo no registrado",
+      "direct_registering": "Esperando el registro",
       "direct_polling": "Consultando eventos",
       "direct_poller_stopped": "Sondeo detenido"
     },

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -999,7 +999,7 @@
       "disconnected": "Déconnecté",
       "connecting": "Connexion...",
       "direct_active": "Mode direct actif",
-      "direct_not_registered": "Mode direct non enregistré",
+      "direct_registering": "En attente d'enregistrement",
       "direct_polling": "Interrogation des événements",
       "direct_poller_stopped": "Interrogation arrêtée"
     },

--- a/app/src/locales/fr/translation.json
+++ b/app/src/locales/fr/translation.json
@@ -1000,7 +1000,8 @@
       "connecting": "Connexion...",
       "direct_active": "Mode direct actif",
       "direct_not_registered": "Mode direct non enregistré",
-      "direct_native_only": "Le mode direct nécessite l’app mobile"
+      "direct_polling": "Interrogation des événements",
+      "direct_poller_stopped": "Interrogation arrêtée"
     },
     "switch_profile_title": "Changer de profil ?",
     "switch_profile_desc": "Cette notification provient de \"{{profile}}\". Passer a ce profil pour voir l'evenement ?",

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -999,7 +999,7 @@
       "disconnected": "已断开",
       "connecting": "连接中...",
       "direct_active": "直连模式已激活",
-      "direct_not_registered": "直连模式未注册",
+      "direct_registering": "等待注册",
       "direct_polling": "正在轮询事件",
       "direct_poller_stopped": "轮询未运行"
     },

--- a/app/src/locales/zh/translation.json
+++ b/app/src/locales/zh/translation.json
@@ -1000,7 +1000,8 @@
       "connecting": "连接中...",
       "direct_active": "直连模式已激活",
       "direct_not_registered": "直连模式未注册",
-      "direct_native_only": "直连模式需要移动应用"
+      "direct_polling": "正在轮询事件",
+      "direct_poller_stopped": "轮询未运行"
     },
     "switch_profile_title": "切换配置文件？",
     "switch_profile_desc": "此通知来自\"{{profile}}\"。切换到此配置文件以查看事件？",

--- a/app/src/pages/NotificationSettings.tsx
+++ b/app/src/pages/NotificationSettings.tsx
@@ -291,14 +291,22 @@ export default function NotificationSettings() {
     // outcome; settings.enabled is only the user's intent. Reporting the
     // toggle told users push was active when registration had failed.
     if (mode === 'direct' && settings?.enabled) {
-      // FCM registration is native-only (pushNotifications.initialize returns
-      // on web), so notificationId can never be set here. A red "not
-      // registered" would damn an impossibility; say what is actually true.
+      // Off-native, direct mode delivers by polling the events API
+      // (useNotificationAutoConnect starts the poller on desktop and web);
+      // FCM registration is native-only, so notificationId can never be set
+      // here and the registered/not-registered split would damn an
+      // impossibility. Report the thing that actually runs: the poller.
       if (!Platform.isNative) {
-        return (
+        const polling = currentProfile ? getEventPoller(currentProfile.id).isRunning() : false;
+        return polling ? (
+          <Badge variant="default" className="gap-1.5 bg-blue-500">
+            <CheckCircle className="h-3 w-3" />
+            {t('notifications.status.direct_polling')}
+          </Badge>
+        ) : (
           <Badge variant="secondary" className="gap-1.5">
             <AlertCircle className="h-3 w-3" />
-            {t('notifications.status.direct_native_only')}
+            {t('notifications.status.direct_poller_stopped')}
           </Badge>
         );
       }

--- a/app/src/pages/NotificationSettings.tsx
+++ b/app/src/pages/NotificationSettings.tsx
@@ -310,11 +310,14 @@ export default function NotificationSettings() {
           </Badge>
         );
       }
+      // Amber, not destructive: registration runs asynchronously after the
+      // toggle, so this is the normal in-between state as often as it is a
+      // failure.
       if (!settings?.notificationId) {
         return (
-          <Badge variant="destructive" className="gap-1.5">
-            <AlertCircle className="h-3 w-3" />
-            {t('notifications.status.direct_not_registered')}
+          <Badge variant="default" className="gap-1.5 bg-amber-500">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t('notifications.status.direct_registering')}
           </Badge>
         );
       }

--- a/app/src/pages/__tests__/NotificationSettings.realstore.test.tsx
+++ b/app/src/pages/__tests__/NotificationSettings.realstore.test.tsx
@@ -158,7 +158,7 @@ describe('NotificationSettings direct-mode badge reflects registration, not inte
     renderPage();
     expect(screen.getByText('notifications.status.direct_poller_stopped').textContent)
       .toBe('notifications.status.direct_poller_stopped');
-    expect(screen.queryByText('notifications.status.direct_not_registered')).toBeNull();
+    expect(screen.queryByText('notifications.status.direct_registering')).toBeNull();
   });
 
   it('off-native shows polling when the poller runs', () => {
@@ -177,8 +177,8 @@ describe('NotificationSettings direct-mode badge reflects registration, not inte
       enabled: true, notificationMode: 'direct', host: 'a.zm.local', notificationId: null,
     });
     renderPage();
-    expect(screen.getByText('notifications.status.direct_not_registered').textContent)
-      .toBe('notifications.status.direct_not_registered');
+    expect(screen.getByText('notifications.status.direct_registering').textContent)
+      .toBe('notifications.status.direct_registering');
     expect(screen.queryByText('notifications.status.direct_active')).toBeNull();
   });
 

--- a/app/src/pages/__tests__/NotificationSettings.realstore.test.tsx
+++ b/app/src/pages/__tests__/NotificationSettings.realstore.test.tsx
@@ -17,6 +17,7 @@ import { useCurrentProfile, useProfileById } from '../../hooks/useCurrentProfile
 import { useProfileScope } from '../../hooks/useProfileScope';
 import { useNotificationStore } from '../../stores/notifications';
 import { Platform } from '../../lib/platform';
+import { getEventPoller } from '../../services/eventPoller';
 
 // Platform.isNative is a getter; spy on it rather than assigning.
 let nativeSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -53,7 +54,7 @@ vi.mock('../../api/notifications', () => ({
   checkNotificationsApiSupport: vi.fn().mockResolvedValue(true),
 }));
 vi.mock('../../services/eventPoller', () => ({
-  getEventPoller: () => ({ isRunning: () => false, stop: vi.fn() }),
+  getEventPoller: vi.fn(() => ({ isRunning: () => false, stop: vi.fn() })),
   stopEventPoller: vi.fn(),
 }));
 vi.mock('../../components/NotificationBadge', () => ({
@@ -146,15 +147,28 @@ describe('NotificationSettings direct-mode badge reflects registration, not inte
     nativeSpy = undefined;
   });
 
-  it('on web says direct mode needs the mobile app: registration cannot happen here', () => {
-    // jsdom is the web platform; no Platform override.
+  it('off-native reports the poller, which is how direct mode delivers there', () => {
+    // jsdom is the web platform; no Platform override. The suite's eventPoller
+    // mock reports isRunning() false, so the badge must say the poller is
+    // stopped -- and never the FCM registered/not-registered split, which
+    // cannot happen off-native.
     useNotificationStore.getState().updateProfileSettings(profileA.id, {
       enabled: true, notificationMode: 'direct', host: 'a.zm.local', notificationId: null,
     });
     renderPage();
-    expect(screen.getByText('notifications.status.direct_native_only').textContent)
-      .toBe('notifications.status.direct_native_only');
+    expect(screen.getByText('notifications.status.direct_poller_stopped').textContent)
+      .toBe('notifications.status.direct_poller_stopped');
     expect(screen.queryByText('notifications.status.direct_not_registered')).toBeNull();
+  });
+
+  it('off-native shows polling when the poller runs', () => {
+    vi.mocked(getEventPoller).mockReturnValue({ isRunning: () => true, stop: vi.fn() } as never);
+    useNotificationStore.getState().updateProfileSettings(profileA.id, {
+      enabled: true, notificationMode: 'direct', host: 'a.zm.local', notificationId: null,
+    });
+    renderPage();
+    expect(screen.getByText('notifications.status.direct_polling').textContent)
+      .toBe('notifications.status.direct_polling');
   });
 
   it('says not registered when direct push is on but registration never succeeded', () => {

--- a/app/src/services/__tests__/pushNotifications.test.ts
+++ b/app/src/services/__tests__/pushNotifications.test.ts
@@ -102,6 +102,7 @@ function makeSettings(overrides: Partial<NotificationSettings> = {}): Notificati
     enabled: true,
     notificationMode: 'es',
     notificationId: null,
+    notificationToken: null,
     host: 'es.example.com',
     port: 9000,
     ssl: false,
@@ -303,7 +304,57 @@ describe('registerTokenWithServer()', () => {
         profile: 'Home',
       })
     );
-    expect(gates.notifications.updateProfileSettings).toHaveBeenCalledWith('profile-1', { notificationId: 42 });
+    expect(gates.notifications.updateProfileSettings).toHaveBeenCalledWith('profile-1', {
+      notificationId: 42,
+      notificationToken: 'fcm-token-123',
+    });
+  });
+
+  // The FCM token arrives twice on a cold enable: once from getToken() and
+  // once from the tokenReceived listener. Both used to POST it, and ZM's
+  // Notifications.Token unique index answered the loser with an HTTP 500
+  // "Duplicate entry" that surfaced as a registration failure.
+  it('registers once when the same token arrives twice concurrently', async () => {
+    gates.notifications.getProfileSettings = vi.fn().mockReturnValue(makeSettings({ notificationMode: 'direct' }));
+    let resolveRegister: (value: { Id: number }) => void = () => {};
+    mockRegisterToken.mockImplementation(() => new Promise((resolve) => { resolveRegister = resolve; }));
+
+    const service = new MobilePushService();
+    await service.initialize();
+    const second = service.registerTokenWithServer();
+    resolveRegister({ Id: 42 });
+    await second;
+
+    expect(mockRegisterToken).toHaveBeenCalledTimes(1);
+  });
+
+  // A cold start re-runs initialize() with the same token. Without the
+  // stored token the POST repeats every launch and fails the same way.
+  it('skips the POST when this token is already registered for the profile', async () => {
+    gates.notifications.getProfileSettings = vi.fn().mockReturnValue(
+      makeSettings({ notificationMode: 'direct', notificationId: 42, notificationToken: 'fcm-token-123' })
+    );
+
+    const service = new MobilePushService();
+    await service.initialize();
+
+    expect(mockRegisterToken).not.toHaveBeenCalled();
+  });
+
+  it('re-registers when the stored token no longer matches', async () => {
+    gates.notifications.getProfileSettings = vi.fn().mockReturnValue(
+      makeSettings({ notificationMode: 'direct', notificationId: 42, notificationToken: 'stale-token' })
+    );
+    mockRegisterToken.mockResolvedValue({ Id: 43 });
+
+    const service = new MobilePushService();
+    await service.initialize();
+
+    expect(mockRegisterToken).toHaveBeenCalledTimes(1);
+    expect(gates.notifications.updateProfileSettings).toHaveBeenCalledWith('profile-1', {
+      notificationId: 43,
+      notificationToken: 'fcm-token-123',
+    });
   });
 
   it('swallows a direct-mode registration failure instead of throwing', async () => {
@@ -375,7 +426,10 @@ describe('deregister()', () => {
     await service.deregister();
 
     expect(mockDeleteNotification).toHaveBeenCalledWith(expect.anything(), 99);
-    expect(gates.notifications.updateProfileSettings).toHaveBeenCalledWith('profile-1', { notificationId: null });
+    expect(gates.notifications.updateProfileSettings).toHaveBeenCalledWith('profile-1', {
+      notificationId: null,
+      notificationToken: null,
+    });
     expect(mockRemoveAllListeners).toHaveBeenCalled();
     expect(mockDeleteToken).toHaveBeenCalled();
     expect(service.getToken()).toBeNull();

--- a/app/src/services/pushNotifications.ts
+++ b/app/src/services/pushNotifications.ts
@@ -92,6 +92,8 @@ export interface PushNotificationData {
 export class MobilePushService {
   private isInitialized = false;
   private currentToken: string | null = null;
+  // `${profileId}:${token}` of the direct-mode registration in flight or done.
+  private registrationKey: string | null = null;
 
   /**
    * Initialize push notifications (mobile only)
@@ -236,7 +238,8 @@ export class MobilePushService {
           if (notifId) {
             log.push('Deleting notification via ZM API (direct mode)', LogLevel.INFO, { notificationId: notifId });
             await deleteNotification(getSession(asProfileId(profileId)).client, notifId);
-            gates.updateProfileSettings(profileId, { notificationId: null });
+            gates.updateProfileSettings(profileId, { notificationId: null, notificationToken: null });
+            this.registrationKey = null;
           }
         } else {
           // ES mode: deregister via websocket
@@ -429,6 +432,28 @@ export class MobilePushService {
     const settings = gates.notifications.getProfileSettings(profileId);
 
     if (settings.notificationMode === 'direct') {
+      // Same token, same server row: a restart re-runs initialize() with the
+      // token it registered last launch, and re-POSTing it hits ZM's
+      // Notifications.Token unique index. Monitor filters and badge counts
+      // sync through updateNotification, so skipping the create loses nothing.
+      if (settings.notificationId && settings.notificationToken === token) {
+        log.push('FCM token already registered with ZM API', LogLevel.INFO, {
+          notificationId: settings.notificationId,
+        });
+        return;
+      }
+
+      // A cold enable delivers the same token twice - getToken() resolves it
+      // and the tokenReceived listener fires with it - and both used to POST
+      // it, so the loser got an HTTP 500 duplicate-entry error. Claim the
+      // token before the first await, so the twin call has something to see.
+      const key = `${profileId}:${token}`;
+      if (this.registrationKey === key) {
+        log.push('FCM token registration already in progress', LogLevel.INFO);
+        return;
+      }
+      this.registrationKey = key;
+
       // Direct mode: register via ZM REST API (no websocket needed)
       try {
         const platform = Capacitor.getPlatform() as 'android' | 'ios';
@@ -451,9 +476,12 @@ export class MobilePushService {
           profile: currentProfile?.name,
         });
 
-        gates.notifications.updateProfileSettings(profileId, { notificationId: result.Id });
+        gates.notifications.updateProfileSettings(profileId, { notificationId: result.Id, notificationToken: token });
         log.push('Successfully registered FCM token via ZM API', LogLevel.INFO, { notificationId: result.Id });
       } catch (error) {
+        // Let the next attempt retry: a failed registration must not look
+        // like a completed one.
+        this.registrationKey = null;
         log.push('Failed to register FCM token via ZM API', LogLevel.ERROR, error);
       }
     } else {

--- a/app/src/stores/notifications.ts
+++ b/app/src/stores/notifications.ts
@@ -158,6 +158,7 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   enabled: false,
   notificationMode: 'es',
   notificationId: null,
+  notificationToken: null,
   host: '',
   port: NOTIFICATIONS_SERVICE.defaultPort,
   ssl: true,

--- a/app/src/types/notifications.ts
+++ b/app/src/types/notifications.ts
@@ -67,6 +67,7 @@ export interface NotificationSettings {
     enabled: boolean;
     notificationMode: NotificationMode; // 'es' = Event Server websocket, 'direct' = ZM REST API
     notificationId: number | null; // Server-side Notifications.Id (direct mode)
+    notificationToken: string | null; // FCM token that notificationId was created for
     host: string; // Event server host (e.g., "zm.example.com")
     port: number; // Event server port (default 9000)
     ssl: boolean; // Use wss:// instead of ws://


### PR DESCRIPTION
Refs #392

Follow-up to #422, from device testing on iOS.

## Acceptance

Maintainer report: enabling direct mode showed "Direct mode not registered" and
stayed there; switching to ES and back made it work.

1. **Registration never ran on enable.** `NotificationHandler` read
   `profileSettings` through `getProfileSettings` but subscribed only to
   `connections`, `currentProfileId` and `profileEvents`. Direct mode opens no
   websocket, so enabling it changed nothing the component subscribed to: no
   re-render, and the delegated hooks kept the pre-toggle settings object.
   `useNotificationPushSetup` never saw `enabled` flip, so FCM init never ran.
   ES-and-back "fixed" it only because the ES connect changed `connections`.
   The same staleness silently disabled the auto-connect and poller-teardown
   effects for direct-mode toggles.

2. **The token registered twice.** `getToken()` and the `tokenReceived`
   listener both POSTed it; ZM's uniquely indexed `Notifications.Token`
   answered the loser with `HTTP 500 ... Duplicate entry`. A restart repeated
   the POST for the previous launch's token. Now a direct-mode registration
   claims its profile/token pair before the first await, and the token is
   persisted beside `notificationId` so a later launch skips the create.
   Filters and badge counts already sync through `updateNotification`.

3. **The badge overstated it.** Registration is asynchronous, so an unset
   `notificationId` is usually a half-second wait, not a failure. Red
   "Direct mode not registered" is now an amber spinner, "Waiting for
   registration", in all five locales.

## Checks run

- Each fix has a test proven red first: the handler passes updated settings to
  push setup; concurrent same-token registers once; an already-registered token
  skips the POST; a changed token re-registers.
- `npm run gates`: 4305 tests pass, build clean, lint backlog at baseline (193).
- Device: iOS, the reported repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3J1jukBd4zRSMHWr2bG9t