### PR TITLE
fix(notifications): report direct-mode poller status live

### DIFF
--- a/app/src/pages/NotificationSettings.tsx
+++ b/app/src/pages/NotificationSettings.tsx
@@ -5,7 +5,7 @@
  * monitor filters, and push notification settings.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../lib/query/query-keys';
 import { useNotificationStore, startEventPoller } from '../stores/notifications';
@@ -41,7 +41,7 @@ import { useTranslation } from 'react-i18next';
 import { log, LogLevel } from '../lib/logger';
 import { checkNotificationsApiSupport } from '../api/notifications';
 import { getSession } from '../services/sessions';
-import { getEventPoller, stopEventPoller } from '../services/eventPoller';
+import { isEventPollerRunning, stopEventPoller, subscribeEventPollers } from '../services/eventPoller';
 import type { NotificationMode } from '../types/notifications';
 import { NotificationBadge } from '../components/NotificationBadge';
 import { NotificationModeSection } from '../components/notifications/NotificationModeSection';
@@ -99,6 +99,14 @@ export default function NotificationSettings() {
     useShallow((s) => (profileId ? s.getProfileSettings(profileId) : null))
   );
   const unreadCount = useNotificationStore((s) => (profileId ? s.getUnreadCount(profileId) : 0));
+
+  // The poller lives outside React and starts asynchronously after the mode
+  // switch, so its run state has to be subscribed to. Reading isRunning()
+  // during render showed "not running" until an unrelated re-render.
+  const pollerRunning = useSyncExternalStore(
+    subscribeEventPollers,
+    useCallback(() => (profileId ? isEventPollerRunning(profileId) : false), [profileId])
+  );
 
   // Fetch monitors
   const { data: monitorsData } = useQuery({
@@ -277,8 +285,7 @@ export default function NotificationSettings() {
 
   const handlePollingIntervalRestart = () => {
     if (!currentProfile) return;
-    const poller = getEventPoller(currentProfile.id);
-    if (poller.isRunning()) {
+    if (isEventPollerRunning(currentProfile.id)) {
       startEventPoller(currentProfile.id);
     }
   };
@@ -297,8 +304,7 @@ export default function NotificationSettings() {
       // here and the registered/not-registered split would damn an
       // impossibility. Report the thing that actually runs: the poller.
       if (!Platform.isNative) {
-        const polling = currentProfile ? getEventPoller(currentProfile.id).isRunning() : false;
-        return polling ? (
+        return pollerRunning ? (
           <Badge variant="default" className="gap-1.5 bg-blue-500">
             <CheckCircle className="h-3 w-3" />
             {t('notifications.status.direct_polling')}

--- a/app/src/pages/__tests__/NotificationSettings.allmode.test.tsx
+++ b/app/src/pages/__tests__/NotificationSettings.allmode.test.tsx
@@ -32,6 +32,8 @@ vi.mock('../../api/notifications', () => ({
 }));
 vi.mock('../../services/eventPoller', () => ({
   getEventPoller: () => ({ isRunning: () => false, stop: vi.fn() }),
+  isEventPollerRunning: () => false,
+  subscribeEventPollers: () => () => {},
   stopEventPoller: vi.fn(),
 }));
 // startEventPoller reaches into eventPoller/session wiring only exercised by

--- a/app/src/pages/__tests__/NotificationSettings.realstore.test.tsx
+++ b/app/src/pages/__tests__/NotificationSettings.realstore.test.tsx
@@ -9,7 +9,7 @@
  * mirrors.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import NotificationSettings from '../NotificationSettings';
@@ -17,7 +17,6 @@ import { useCurrentProfile, useProfileById } from '../../hooks/useCurrentProfile
 import { useProfileScope } from '../../hooks/useProfileScope';
 import { useNotificationStore } from '../../stores/notifications';
 import { Platform } from '../../lib/platform';
-import { getEventPoller } from '../../services/eventPoller';
 
 // Platform.isNative is a getter; spy on it rather than assigning.
 let nativeSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -53,8 +52,21 @@ vi.mock('../../api/monitors', () => ({
 vi.mock('../../api/notifications', () => ({
   checkNotificationsApiSupport: vi.fn().mockResolvedValue(true),
 }));
+const pollerState = vi.hoisted(() => ({
+  running: false,
+  listeners: new Set<() => void>(),
+  setRunning(running: boolean) {
+    pollerState.running = running;
+    for (const listener of pollerState.listeners) listener();
+  },
+}));
 vi.mock('../../services/eventPoller', () => ({
-  getEventPoller: vi.fn(() => ({ isRunning: () => false, stop: vi.fn() })),
+  getEventPoller: vi.fn(() => ({ isRunning: () => pollerState.running, stop: vi.fn() })),
+  isEventPollerRunning: vi.fn(() => pollerState.running),
+  subscribeEventPollers: (listener: () => void) => {
+    pollerState.listeners.add(listener);
+    return () => pollerState.listeners.delete(listener);
+  },
   stopEventPoller: vi.fn(),
 }));
 vi.mock('../../components/NotificationBadge', () => ({
@@ -143,6 +155,8 @@ describe('NotificationSettings direct-mode badge reflects registration, not inte
 
   afterEach(() => {
     useNotificationStore.setState({ profileSettings: {} });
+    pollerState.running = false;
+    pollerState.listeners.clear();
     nativeSpy?.mockRestore();
     nativeSpy = undefined;
   });
@@ -162,13 +176,31 @@ describe('NotificationSettings direct-mode badge reflects registration, not inte
   });
 
   it('off-native shows polling when the poller runs', () => {
-    vi.mocked(getEventPoller).mockReturnValue({ isRunning: () => true, stop: vi.fn() } as never);
+    pollerState.running = true;
     useNotificationStore.getState().updateProfileSettings(profileA.id, {
       enabled: true, notificationMode: 'direct', host: 'a.zm.local', notificationId: null,
     });
     renderPage();
     expect(screen.getByText('notifications.status.direct_polling').textContent)
       .toBe('notifications.status.direct_polling');
+  });
+
+  // The poller starts asynchronously after the mode switch, so the badge that
+  // read isRunning() during render was stale until an unrelated re-render (the
+  // user navigating away and back) happened to re-read it.
+  it('flips to polling when the poller starts after render, without a remount', () => {
+    useNotificationStore.getState().updateProfileSettings(profileA.id, {
+      enabled: true, notificationMode: 'direct', host: 'a.zm.local', notificationId: null,
+    });
+    renderPage();
+    expect(screen.getByText('notifications.status.direct_poller_stopped').textContent)
+      .toBe('notifications.status.direct_poller_stopped');
+
+    act(() => pollerState.setRunning(true));
+
+    expect(screen.getByText('notifications.status.direct_polling').textContent)
+      .toBe('notifications.status.direct_polling');
+    expect(screen.queryByText('notifications.status.direct_poller_stopped')).toBeNull();
   });
 
   it('says not registered when direct push is on but registration never succeeded', () => {

--- a/app/src/services/__tests__/eventPoller.test.ts
+++ b/app/src/services/__tests__/eventPoller.test.ts
@@ -38,7 +38,13 @@ vi.mock('../../lib/logger', () => ({
   },
 }));
 
-import { getEventPoller, stopAllEventPollers, stopEventPoller } from '../eventPoller';
+import {
+  getEventPoller,
+  isEventPollerRunning,
+  stopAllEventPollers,
+  stopEventPoller,
+  subscribeEventPollers,
+} from '../eventPoller';
 
 // --- Helpers ---
 
@@ -354,5 +360,50 @@ describe('EventPollerService', () => {
     expect(deps.onEvent).toHaveBeenCalledWith(
       expect.objectContaining({ MonitorName: 'Monitor 99' }),
     );
+  });
+});
+
+/**
+ * The direct-mode badge read `isRunning()` imperatively, so it showed
+ * "Poller not running" until something else re-rendered the page: running
+ * state was neither observable nor true until the first poll resolved.
+ */
+describe('observable running state', () => {
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    deps = makeDeps();
+    mockGetMonitors.mockResolvedValue({ monitors: [] });
+    mockGetEvents.mockResolvedValue({ events: [] });
+  });
+
+  afterEach(() => {
+    stopEventPoller('profile-1');
+    vi.useRealTimers();
+  });
+
+  it('is running from the moment start() is called, before the first poll resolves', () => {
+    getEventPoller('profile-1').start('profile-1', deps);
+    expect(isEventPollerRunning('profile-1')).toBe(true);
+  });
+
+  it('notifies subscribers on start and on stop', async () => {
+    const seen: boolean[] = [];
+    const unsubscribe = subscribeEventPollers(() => seen.push(isEventPollerRunning('profile-1')));
+
+    await getEventPoller('profile-1').start('profile-1', deps);
+    await vi.advanceTimersByTimeAsync(0);
+    stopEventPoller('profile-1');
+    unsubscribe();
+
+    expect(seen[0]).toBe(true);
+    expect(seen[seen.length - 1]).toBe(false);
+  });
+
+  it('reports nothing running for a profile that never started - no phantom entry', () => {
+    expect(isEventPollerRunning('never-polled')).toBe(false);
+    stopEventPoller('never-polled');
   });
 });

--- a/app/src/services/eventPoller.ts
+++ b/app/src/services/eventPoller.ts
@@ -42,7 +42,36 @@ function parseEventId(id: string | number): number {
   return parseInt(String(id), 10);
 }
 
+/**
+ * Poller run-state is observable so UI can react to it: the notification
+ * settings badge subscribes here instead of reading isRunning() during
+ * render, which never re-ran when a poller started or stopped.
+ */
+const pollerChangeListeners = new Set<() => void>();
+
+function notifyPollerChange(): void {
+  for (const listener of pollerChangeListeners) listener();
+}
+
+/** Subscribe to any poller starting or stopping. Returns an unsubscribe. */
+export function subscribeEventPollers(listener: () => void): () => void {
+  pollerChangeListeners.add(listener);
+  return () => {
+    pollerChangeListeners.delete(listener);
+  };
+}
+
+/**
+ * Whether this profile's poller is running. Unlike
+ * `getEventPoller(id).isRunning()`, this never creates a registry entry for
+ * a profile that has never polled.
+ */
+export function isEventPollerRunning(profileId: string): boolean {
+  return eventPollers.get(profileId)?.isRunning() ?? false;
+}
+
 class EventPollerService {
+  private running = false;
   private timerId: ReturnType<typeof setTimeout> | null = null;
   private profileId: string | null = null;
   private deps: EventPollerDeps | null = null;
@@ -75,6 +104,11 @@ class EventPollerService {
     this.deps = deps;
     this.seenEventIds.clear();
     this.isFirstPoll = true;
+    // Running from here, not from the first timer: start() awaits the monitor
+    // load and the first poll, and a UI reading timerId in that window showed
+    // "not running" for a poller that was already working.
+    this.running = true;
+    notifyPollerChange();
 
     log.notifications('Starting event poller for direct mode', LogLevel.INFO, { profileId });
 
@@ -99,6 +133,8 @@ class EventPollerService {
     this.monitorData = [];
     this.namesReloadPromise = null;
     this.namesReloadAfter = 0;
+    this.running = false;
+    notifyPollerChange();
 
     log.notifications('Stopped event poller', LogLevel.INFO);
   }
@@ -107,7 +143,7 @@ class EventPollerService {
    * Check if the poller is running.
    */
   isRunning(): boolean {
-    return this.timerId !== null;
+    return this.running;
   }
 
   private async _loadMonitorNames(): Promise<void> {


### PR DESCRIPTION
Fixes the badge in #425.

## What changed

- `EventPollerService` tracks a `running` flag set at `start()` and cleared in `stop()`, instead of deriving run state from `timerId` (only assigned after the monitor load and first poll resolve).
- New `subscribeEventPollers(listener)` and `isEventPollerRunning(profileId)`: start/stop is observable, and asking about a profile creates no registry entry.
- `NotificationSettings` subscribes via `useSyncExternalStore` instead of reading the service during render.

## Acceptance

- The badge reads "Polling" as soon as the poller starts, without navigating away and back.
- `isRunning()` is true from the moment `start()` is called, not from the first scheduled timer.
- Poller start/stop is observable, so any UI can subscribe instead of polling the service during render.
- Asking whether a profile's poller runs does not create a registry entry for a profile that never polled.

## Tests

Red-first: three in `services/__tests__/eventPoller.test.ts` (running before the first poll resolves, subscriber notification on start/stop, no phantom entry) and one in `pages/__tests__/NotificationSettings.realstore.test.tsx` (badge flips to polling without a remount).

`npm run gates`: 4310 tests, build, three lints — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuMbBuEJr4KfvDBtcNBjPV