### PR TITLE
fix(assistant): resolve the monitor a question refers to before the tool round

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -80,6 +80,18 @@ after any prompt or provider change and put both scores in the PR.
 - Prompt classification teaches dimensions (intent by subject), never
   instance lists; instance-based triage misclassified every combination
   outside its examples, four times.
+- A name enum cannot express abstention: asked which monitor a place means,
+  qwen3:8b substituted the nearest listed name for a place the list lacks
+  (12/16) under three prompt wordings and both enum orders. What worked
+  (refs #427, `prompt-eval.mts triage-monitor`, temp 0, 2026-09): copy the
+  place words first, then answer `covered` as its own boolean, then the name
+  enum, with NO_MATCH derived in code from place+covered (21/24; the model
+  still copies time words into `place`, stripped in code via
+  `scanTimeExpressions`, and still calls a backyard covered by a garage
+  monitor - a nearby-outdoor-area substitution no wording fixed). llama3.2
+  scores 10/16 on the same stage: it answers `covered: true` for near
+  places, so a wrong monitor can be pinned rather than abstained; qwen3:8b
+  remains the recommended Ollama model.
 - Apple Foundation Models invents tool arguments (validate before use) and
   calls real tools on greeting turns; the first tool call on a tool-less
   turn gets a no-tools pushback (578787dc).

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -560,9 +560,65 @@ async function scoreTriage(runs: number) {
   return { pass, total, failures };
 }
 
+/** Camera-verdict cases (refs #427): the triage round, handed a monitor
+ *  roster, must map a place word onto the camera that covers it (in any
+ *  language), say NO_MATCH for a place no camera covers, and say NONE for a
+ *  question that names no place, without disturbing the kind verdict. The
+ *  live failure this scores: "front door" answered from "Garage Outdoor". */
+const TRIAGE_MONITOR_CASES: Array<{ q: string; roster: string[]; kind: string; monitor: string }> = [
+  { q: 'how many people came to my front door yesterday', roster: ['Garage Outdoor', 'Driveway'], kind: 'ZONEMINDER', monitor: 'NO_MATCH' },
+  { q: 'how many people came to my front door yesterday', roster: ['Garage Outdoor', 'Doorbell'], kind: 'ZONEMINDER', monitor: 'Doorbell' },
+  { q: 'any cars in the driveway today', roster: ['Garage Outdoor', 'Driveway'], kind: 'ZONEMINDER', monitor: 'Driveway' },
+  { q: 'was war gestern an der Haustür los', roster: ['Garage Outdoor', 'Doorbell'], kind: 'ZONEMINDER', monitor: 'Doorbell' },
+  { q: 'summarize today', roster: ['Garage Outdoor', 'Driveway'], kind: 'ZONEMINDER', monitor: 'NONE' },
+  { q: 'is the server ok', roster: ['Garage Outdoor', 'Driveway'], kind: 'ZONEMINDER', monitor: 'NONE' },
+  { q: 'hello', roster: ['Garage Outdoor', 'Driveway'], kind: 'CHAT', monitor: 'NONE' },
+  { q: 'arm the backyard camera', roster: ['Garage Outdoor', 'Driveway'], kind: 'ACTION', monitor: 'NO_MATCH' },
+];
+
+async function scoreTriageMonitor(runs: number) {
+  const { buildTriagePromptForEval, buildTriageSchema, parseTriageMonitor } = await import('../src/lib/assistant/triage');
+  let pass = 0;
+  let total = 0;
+  const failures: string[] = [];
+  for (const c of TRIAGE_MONITOR_CASES) {
+    for (let i = 0; i < runs; i++) {
+      total++;
+      try {
+        const r = await chat({
+          model: MODEL,
+          messages: [{ role: 'system', content: buildTriagePromptForEval(c.roster) }, { role: 'user', content: c.q }],
+          stream: false,
+          max_tokens: 60,
+          ...(TEMP === undefined ? {} : { temperature: TEMP }),
+          ...REASONING,
+          response_format: { type: 'json_schema', json_schema: { name: 'result', schema: buildTriageSchema(c.roster), strict: true } },
+        });
+        const text = r.choices?.[0]?.message?.content ?? '';
+        const parsed = JSON.parse(text);
+        // Scored on what production derives (parseTriageMonitor), not the raw
+        // monitor field: NO_MATCH is computed in code from place + covered.
+        const monitor = parseTriageMonitor(text, c.roster) ?? 'NONE';
+        if (parsed?.kind === c.kind && monitor === c.monitor) pass++;
+        else failures.push(`[triage-monitor] "${c.q}" [${c.roster.join(', ')}] -> ${parsed?.kind}/${monitor} (raw ${text}), expected ${c.kind}/${c.monitor}`);
+      } catch (e) {
+        failures.push(`[triage-monitor] "${c.q}" error: ${(e as Error).message}`);
+      }
+    }
+  }
+  return { pass, total, failures };
+}
+
 const variant = process.argv[2] ?? 'baseline';
 const runs = Number(process.argv[3] ?? 2);
 const started = Date.now();
+if (variant === 'triage-monitor') {
+  const w = await scoreTriageMonitor(runs);
+  console.log(`\n=== triage-monitor via ${MODEL}, temp ${TEMP ?? 'default'} ===`);
+  console.log(`triage-monitor: ${w.pass}/${w.total}`);
+  for (const f of w.failures) console.log(`  ${f}`);
+  process.exit(0);
+}
 if (variant === 'triage') {
   const w = await scoreTriage(runs);
   console.log(`\n=== triage via ${MODEL}, temp ${TEMP ?? 'default'} ===`);

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -45,6 +45,7 @@ import { TOOLS, specializeToolSchemas, withServerArg } from '../../lib/assistant
 import { buildScopedServers } from '../../lib/assistant/scoped-servers';
 import { interpretWhen } from '../../lib/assistant/window-interpreter';
 import { extractTimeframes, buildTimeframeSystemLine } from '../../lib/assistant/timeframe-stage';
+import { getMonitorRoster, scanMonitorMentions, resolveMonitorMention, buildMonitorSystemLine } from '../../lib/assistant/monitor-stage';
 import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
 import { classifyRequest, buildNoToolPrompt, type RequestKind } from '../../lib/assistant/triage';
 import type { AssistantBackend, AssistantMessage, AssistantTurn, ProviderConfig, ToolActivity, ToolContext, TraceEntry } from '../../lib/assistant/types';
@@ -539,6 +540,16 @@ export function AskPanel() {
       // guessing at a taxonomy. Cached per profile; never throws.
       const objectLabels = await getObjectLabels(profileId);
 
+      // The camera the question refers to, resolved BEFORE any model round
+      // (refs #427): a deterministic scan for monitor names the question
+      // states verbatim; anything it cannot decide (a place word like "front
+      // door") goes to the triage round below, constrained to this roster.
+      // Skipped inside a group: monitor names collide across servers, and the
+      // aggregate id has no session (getMonitorRoster returns [] then anyway).
+      // Cached per profile; never throws.
+      const monitorRoster = isAllMode || isAssistantTestMode() ? [] : await getMonitorRoster(profileId);
+      const monitorScanHits = scanMonitorMentions(text, monitorRoster);
+
       // Every server this view combines, or an empty list outside a group
       // (refs #337). It drives three things that must agree: the roster in the
       // prompt, the `server` argument's enum, and which sessions the tool
@@ -618,13 +629,26 @@ export function AskPanel() {
       // runs it. That made the old English keyword overrule (requiresLiveData)
       // deletable: it was a hardcoded vocabulary in front of exactly the
       // language interpretation the model does better.
-      const kind: RequestKind = isAssistantTestMode()
-        ? 'zoneminder'
+      const verdict = isAssistantTestMode()
+        ? { kind: 'zoneminder' as const }
         : // serverNames too: a question that names a server ("compare warehouse and
           // cabin") is about this system, and without the roster the classifier
           // read those as unrelated words and routed the turn to chat (refs #337).
-          await classifyRequest(provider, text, controller.signal, collectTrace, (s) => host.onStatus?.(s), serverNames);
-      log.assistant('Request classified', LogLevel.DEBUG, { kind });
+          // The monitor roster rides the same round (refs #427), but only when
+          // the deterministic scan above found nothing: a name the scan already
+          // matched needs no model, and the roster-less prompt stays exactly
+          // what the eval harness scores.
+          await classifyRequest(
+            provider,
+            text,
+            controller.signal,
+            collectTrace,
+            (s) => host.onStatus?.(s),
+            serverNames,
+            monitorScanHits.length === 0 ? monitorRoster.map((m) => m.name) : [],
+          );
+      const kind: RequestKind = verdict.kind;
+      log.assistant('Request classified', LogLevel.DEBUG, { kind, monitor: verdict.monitor });
 
       // Every timeframe the question names is extracted and resolved BEFORE the
       // tool round (refs #270, pipeline-v2): the native tool loops cannot nest
@@ -651,6 +675,16 @@ export function AskPanel() {
         ctx.allowedWhenPhrases = phrases;
         ctx.resolvedTimeframes = resolved;
         turnSystem = `${system}\n${buildTimeframeSystemLine(phrases)}`;
+
+        // The camera verdict becomes one system line, exactly like the
+        // timeframe line (refs #427): a resolved monitor pins monitorId, a
+        // NO_MATCH place gets the do-not-attribute guard, no place adds
+        // nothing. The scan outvotes the model; a roster-less turn (group
+        // mode, fetch failure) resolves to none and the line stays empty.
+        const monitorLine = buildMonitorSystemLine(
+          resolveMonitorMention(monitorScanHits, verdict.monitor, monitorRoster),
+        );
+        if (monitorLine) turnSystem = `${turnSystem}\n${monitorLine}`;
       }
 
       // Already only this turn's new messages (see runAssistantTurn): the

--- a/app/src/lib/assistant/__tests__/monitor-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/monitor-stage.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { scanMonitorMentions, resolveMonitorMention, buildMonitorSystemLine } from '../monitor-stage';
+import type { MonitorRosterEntry } from '../monitor-stage';
+
+const roster: MonitorRosterEntry[] = [
+  { id: '1', name: 'Garage Outdoor' },
+  { id: '2', name: 'Driveway' },
+  { id: '3', name: 'Front Door' },
+];
+
+describe('scanMonitorMentions', () => {
+  it('finds a monitor named verbatim in the question', () => {
+    expect(scanMonitorMentions('show me the driveway today', roster)).toEqual([{ id: '2', name: 'Driveway' }]);
+  });
+
+  // Models and users both mangle spacing and case; the scan matches on the
+  // same normalized key resolveMonitorRef uses for model-supplied names.
+  it('matches ignoring case, spacing, and punctuation', () => {
+    expect(scanMonitorMentions('anything on FRONTDOOR?', roster)).toEqual([{ id: '3', name: 'Front Door' }]);
+    expect(scanMonitorMentions('check front-door please', roster)).toEqual([{ id: '3', name: 'Front Door' }]);
+  });
+
+  it('finds every mentioned monitor, in roster order', () => {
+    expect(scanMonitorMentions('compare front door and driveway', roster)).toEqual([
+      { id: '2', name: 'Driveway' },
+      { id: '3', name: 'Front Door' },
+    ]);
+  });
+
+  it('finds nothing when the question names no monitor', () => {
+    expect(scanMonitorMentions('how many people came by yesterday', roster)).toEqual([]);
+  });
+
+  // A monitor whose name normalizes to '' (all punctuation) must never match
+  // every question by matching the empty string.
+  it('ignores a monitor whose normalized name is empty', () => {
+    expect(scanMonitorMentions('summarize today', [{ id: '9', name: '***' }])).toEqual([]);
+  });
+});
+
+describe('resolveMonitorMention', () => {
+  it('resolves a single scan hit deterministically, ignoring the model verdict', () => {
+    expect(resolveMonitorMention([roster[1]], 'NO_MATCH', roster)).toEqual({
+      kind: 'resolved',
+      id: '2',
+      name: 'Driveway',
+    });
+  });
+
+  // Two named monitors: the model handles them itself (one call each); pinning
+  // one would hide the other.
+  it('resolves multiple scan hits to none', () => {
+    expect(resolveMonitorMention([roster[0], roster[1]], undefined, roster)).toEqual({ kind: 'none' });
+  });
+
+  it('maps a triage monitor name to its roster entry', () => {
+    expect(resolveMonitorMention([], 'Garage Outdoor', roster)).toEqual({
+      kind: 'resolved',
+      id: '1',
+      name: 'Garage Outdoor',
+    });
+  });
+
+  it('maps NO_MATCH to no_match and NONE to none', () => {
+    expect(resolveMonitorMention([], 'NO_MATCH', roster)).toEqual({ kind: 'no_match' });
+    expect(resolveMonitorMention([], 'NONE', roster)).toEqual({ kind: 'none' });
+  });
+
+  // The enum constrains capable backends, but an unconstrained one can reply
+  // anything; a name outside the roster must not be trusted.
+  it('treats an unknown or missing verdict as none', () => {
+    expect(resolveMonitorMention([], 'Backyard', roster)).toEqual({ kind: 'none' });
+    expect(resolveMonitorMention([], undefined, roster)).toEqual({ kind: 'none' });
+  });
+});
+
+describe('buildMonitorSystemLine', () => {
+  it('names the resolved monitor and its id', () => {
+    const line = buildMonitorSystemLine({ kind: 'resolved', id: '2', name: 'Driveway' });
+    expect(line).toContain('"2"');
+    expect(line).toContain('Driveway');
+    expect(line).toContain('monitorId');
+  });
+
+  it('tells the model no camera covers the named place on no_match', () => {
+    const line = buildMonitorSystemLine({ kind: 'no_match' });
+    expect(line).toContain('No monitor');
+    expect(line).toContain('never');
+  });
+
+  it('is empty when no place was named', () => {
+    expect(buildMonitorSystemLine({ kind: 'none' })).toBe('');
+  });
+});

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -91,9 +91,9 @@ describe('classifyRequest', () => {
   // the tool loop), never to an assistant that cannot answer questions.
   it('falls back to zoneminder when the provider throws', async () => {
     const provider = { complete: vi.fn().mockRejectedValue(new Error('offline')) } as unknown as AssistantProvider;
-    await expect(classifyRequest(provider, 'is the server ok', new AbortController().signal)).resolves.toBe(
-      'zoneminder',
-    );
+    await expect(classifyRequest(provider, 'is the server ok', new AbortController().signal)).resolves.toMatchObject({
+      kind: 'zoneminder',
+    });
   });
 
   it('propagates an abort instead of swallowing it as a classification', async () => {
@@ -106,7 +106,7 @@ describe('classifyRequest', () => {
   it('reads the keyword out of a wrapped reply', async () => {
     await expect(
       classifyRequest(providerSaying('{"answer":"CHAT"}'), 'hi', new AbortController().signal),
-    ).resolves.toBe('chat');
+    ).resolves.toMatchObject({ kind: 'chat' });
   });
 });
 
@@ -171,5 +171,95 @@ describe('classifyRequest inside a server group', () => {
     const [withNone] = vi.mocked(bare.complete).mock.calls[0];
 
     expect(withOne).toBe(withNone);
+  });
+});
+
+/**
+ * Refs #427, observed live: "how many people came to my front door yesterday"
+ * was answered as "3 people came to your front door" from events on a monitor
+ * called "Garage Outdoor". The triage round is the one model call that can
+ * decide, in any language, which camera a question refers to, so when the
+ * caller hands it the monitor roster it classifies that too, constrained to
+ * the real names plus NONE and NO_MATCH so nothing can be hallucinated.
+ */
+describe('classifyRequest with a monitor roster', () => {
+  it('names the cameras in the prompt and constrains the monitor field to them', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","place":"driveway","covered":true,"monitor":"Driveway"}');
+    const verdict = await classifyRequest(
+      provider,
+      'anything on the driveway today',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['Driveway', 'Front Door'],
+    );
+
+    const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
+    expect(system).toContain('Driveway, Front Door');
+    expect(schema).toMatchObject({
+      properties: { monitor: { enum: ['NONE', 'Driveway', 'Front Door'] }, covered: { type: 'boolean' } },
+      required: ['kind', 'place', 'covered', 'monitor'],
+    });
+    expect(verdict).toEqual({ kind: 'zoneminder', monitor: 'Driveway' });
+  });
+
+  it('sends the unchanged prompt and schema when no roster is given', async () => {
+    const provider = providerSaying('{"kind":"CHAT"}');
+    const verdict = await classifyRequest(provider, 'hello', new AbortController().signal);
+
+    const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
+    expect(system).not.toContain("This system's cameras are");
+    expect(schema).toMatchObject({ required: ['kind'] });
+    expect((schema as { properties: object }).properties).not.toHaveProperty('monitor');
+    expect(verdict).toEqual({ kind: 'chat', monitor: undefined });
+  });
+
+  // NO_MATCH is derived in code from place + covered, never decoded from a
+  // name enum: asked to choose from the names directly, the model substituted
+  // the nearest camera for a place the list lacks (measured 12/16, see
+  // buildTriageSchema).
+  it('reports NO_MATCH when a named place is covered by no camera', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","place":"front door","covered":false,"monitor":"NONE"}');
+    const verdict = await classifyRequest(
+      provider,
+      'how many people came to my front door',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['Garage Outdoor'],
+    );
+    expect(verdict).toEqual({ kind: 'zoneminder', monitor: 'NO_MATCH' });
+  });
+
+  it('reports NONE when the question names no place at all', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","place":"","covered":false,"monitor":"NONE"}');
+    const verdict = await classifyRequest(
+      provider,
+      'summarize today',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['Garage Outdoor'],
+    );
+    expect(verdict).toEqual({ kind: 'zoneminder', monitor: 'NONE' });
+  });
+
+  // An unconstrained backend can reply anything; a monitor value outside the
+  // enum must arrive as undefined, never as a trusted name.
+  it('drops a monitor value that is not in the roster', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","place":"backyard","covered":true,"monitor":"Backyard"}');
+    const verdict = await classifyRequest(
+      provider,
+      'anything in the backyard',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['Garage Outdoor'],
+    );
+    expect(verdict).toEqual({ kind: 'zoneminder', monitor: undefined });
   });
 });

--- a/app/src/lib/assistant/monitor-ref.ts
+++ b/app/src/lib/assistant/monitor-ref.ts
@@ -21,8 +21,9 @@ export type MonitorRefResolution = { id: string } | { error: string };
 /** Letters and digits only (any script), lowercased: makes "Front Door",
  *  "front door" and "FrontDoor" the same key, which covers how models mangle
  *  names. Unicode-aware, or two monitors with non-Latin names both normalize
- *  to '' and collide as false "duplicates". */
-function normalizeName(value: string): string {
+ *  to '' and collide as false "duplicates". Shared with the pre-turn mention
+ *  scan (monitor-stage.ts) so a name matches the same way on both paths. */
+export function normalizeMonitorName(value: string): string {
   return value.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
 }
 
@@ -42,8 +43,8 @@ export function resolveMonitorRef(ref: string, monitors: MonitorData[]): Monitor
   const byId = monitors.find((m) => m.Monitor.Id === trimmed);
   if (byId) return { id: byId.Monitor.Id };
 
-  const target = normalizeName(trimmed);
-  const byName = monitors.filter((m) => normalizeName(m.Monitor.Name) === target);
+  const target = normalizeMonitorName(trimmed);
+  const byName = monitors.filter((m) => normalizeMonitorName(m.Monitor.Name) === target);
   if (byName.length === 1) return { id: byName[0].Monitor.Id };
   if (byName.length > 1) {
     // Two monitors sharing a name: picking one would be a coin flip, and this

--- a/app/src/lib/assistant/monitor-stage.ts
+++ b/app/src/lib/assistant/monitor-stage.ts
@@ -1,0 +1,135 @@
+/**
+ * Resolves the camera a question refers to BEFORE the tool round runs
+ * (refs #427).
+ *
+ * Observed live: "how many people came to my front door yesterday" queried
+ * every monitor, got 3 person events on "Garage Outdoor", and answered "3
+ * people came to your front door". No front-door monitor exists; the location
+ * claim was copied from the user's words, and a prompt rule alone cannot stop
+ * a small model doing that (see llm-models.md: prompt-only guardrails).
+ *
+ * Division of labor mirrors the timeframe stage: a deterministic scan owns
+ * every mention code can decide (a monitor named verbatim, however the case
+ * and spacing are mangled); the triage round decides only what code cannot,
+ * which camera a PLACE word means ("front door" -> "Doorbell", in any
+ * language), constrained to the real names plus NONE / NO_MATCH so nothing
+ * can be hallucinated (see buildTriageSchema). The outcome becomes one system
+ * line, exactly like the resolved-timeframes line.
+ */
+import { getMonitors } from '../../api/monitors';
+import { getSession } from '../../services/sessions';
+import { asProfileId } from '../../api/types';
+import { normalizeMonitorName } from './monitor-ref';
+import { ASSISTANT } from '../zmninja-ng-constants';
+import { log, LogLevel } from '../logger';
+
+export interface MonitorRosterEntry {
+  id: string;
+  name: string;
+}
+
+/** What the question's place reference resolved to: one real monitor, a place
+ *  no monitor covers, or no place named at all. */
+export type MonitorMentionResolution =
+  | { kind: 'resolved'; id: string; name: string }
+  | { kind: 'no_match' }
+  | { kind: 'none' };
+
+/** The triage schema's two sentinel monitor values (see buildTriageSchema):
+ *  the question names no particular camera or place, and the question names a
+ *  place no monitor in the roster covers. */
+export const MONITOR_NONE = 'NONE';
+export const MONITOR_NO_MATCH = 'NO_MATCH';
+
+interface CachedRoster {
+  roster: MonitorRosterEntry[];
+  at: number;
+}
+
+/** Per profile, like the object-label cache: two installs reached from one app
+ *  must not share a camera list. */
+const cache = new Map<string, CachedRoster>();
+
+export function __clearMonitorRosterCacheForTests(): void {
+  cache.clear();
+}
+
+/**
+ * The profile's monitor names and ids, cached per profile.
+ *
+ * Never throws: a failed request (or an aggregate profile id, which has no
+ * session) yields an empty roster and the stage simply does not run, which is
+ * exactly the pre-#427 behavior.
+ */
+export async function getMonitorRoster(profileId: string): Promise<MonitorRosterEntry[]> {
+  const hit = cache.get(profileId);
+  if (hit && Date.now() - hit.at < ASSISTANT.monitorRosterCacheMs) return hit.roster;
+
+  try {
+    const { monitors } = await getMonitors(getSession(asProfileId(profileId)).client, asProfileId(profileId));
+    const roster = monitors.map((m) => ({ id: m.Monitor.Id, name: m.Monitor.Name }));
+    cache.set(profileId, { roster, at: Date.now() });
+    return roster;
+  } catch (error) {
+    log.assistant('Could not read the monitor roster', LogLevel.WARN, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+/**
+ * Every monitor whose name appears in the question, in roster order.
+ *
+ * Matches on the same normalized key `resolveMonitorRef` uses for
+ * model-supplied names, so "FRONTDOOR" and "front-door" both find "Front
+ * Door". A name that normalizes to '' never matches: the empty string is a
+ * substring of everything.
+ */
+export function scanMonitorMentions(question: string, roster: MonitorRosterEntry[]): MonitorRosterEntry[] {
+  const haystack = normalizeMonitorName(question);
+  return roster.filter((entry) => {
+    const needle = normalizeMonitorName(entry.name);
+    return needle.length > 0 && haystack.includes(needle);
+  });
+}
+
+/**
+ * The stage's verdict: the deterministic scan wins whenever it found exactly
+ * one monitor; several named monitors resolve to none (the model handles them
+ * itself, one call each, and pinning one would hide the others); otherwise the
+ * triage round's monitor field decides, distrusted unless it names a roster
+ * entry or a sentinel (an unconstrained backend can reply anything).
+ */
+export function resolveMonitorMention(
+  scanHits: MonitorRosterEntry[],
+  triageMonitor: string | undefined,
+  roster: MonitorRosterEntry[],
+): MonitorMentionResolution {
+  if (scanHits.length === 1) return { kind: 'resolved', ...scanHits[0] };
+  if (scanHits.length > 1) return { kind: 'none' };
+  if (triageMonitor === MONITOR_NO_MATCH) return { kind: 'no_match' };
+  const named = roster.find((entry) => entry.name === triageMonitor);
+  if (named) return { kind: 'resolved', ...named };
+  return { kind: 'none' };
+}
+
+/** The one system line handed to the answering model, mirroring
+ *  buildTimeframeSystemLine, or '' when the question named no place.
+ *  Model-facing (rule 5 exempt). */
+export function buildMonitorSystemLine(resolution: MonitorMentionResolution): string {
+  if (resolution.kind === 'resolved') {
+    return (
+      `Monitor for this question, already resolved: pass monitorId "${resolution.id}" to event tools; ` +
+      `the place the question asks about is the monitor named "${resolution.name}".`
+    );
+  }
+  if (resolution.kind === 'no_match') {
+    return (
+      'No monitor in this system matches the place this question names. Say plainly that no camera covers ' +
+      'that place. If you still report events, attribute them to the monitor names in the tool result, ' +
+      'never to the place the user named.'
+    );
+  }
+  return '';
+}

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -19,8 +19,21 @@
 import type { AssistantMessage, AssistantProvider, AssistantStatus, TraceEntry } from './types';
 import { sanitizeModelText } from './sanitize';
 import { isAbortError } from '../is-abort-error';
+import { MONITOR_NONE, MONITOR_NO_MATCH } from './monitor-stage';
+import { scanTimeExpressions } from './timeframe-stage';
 
 export type RequestKind = 'zoneminder' | 'chat' | 'action';
+
+/** What one triage round decided: the request kind, and (only when the caller
+ *  handed it a monitor roster, refs #427) which camera the message is about, a
+ *  roster name or one of the sentinels. `undefined` whenever no roster was
+ *  sent, the backend omitted the field, or the value is outside the enum: an
+ *  unconstrained backend can reply anything, and a name the roster does not
+ *  hold must never be trusted. */
+export interface TriageVerdict {
+  kind: RequestKind;
+  monitor?: string;
+}
 
 /** Model-facing (rule 5 exempt): never rendered, only matched below.
  *
@@ -61,7 +74,7 @@ export type RequestKind = 'zoneminder' | 'chat' | 'action';
  *  constrained JSON. Editing the existing list instead costs no length and
  *  measured 34/36. Add nothing here without re-running `prompt-eval.mts
  *  triage`. */
-const triagePromptLines = (servers: readonly string[]): string[] => [
+const triagePromptLines = (servers: readonly string[], monitors: readonly string[]): string[] => [
   'You classify one user message for a ZoneMinder security-camera app. Reply with EXACTLY one word.',
   '',
   'Decide by WHAT THE USER WANTS DONE and WHAT IT CONCERNS, whatever language the message is in:',
@@ -88,13 +101,40 @@ const triagePromptLines = (servers: readonly string[]): string[] => [
   'CHAT - anything NOT about this system: greetings, thanks, small talk, questions about you, general',
   '  knowledge, or summarizing something that is not this system\'s activity.',
   '',
-  'Reply with one word: ZONEMINDER, ACTION, or CHAT.',
+  // Refs #427, observed live: "how many people came to my front door" was
+  // answered from a monitor called "Garage Outdoor" and attributed to the
+  // front door. This round is the one model call that can map a place word
+  // onto the user's own camera names, in any language; the schema constrains
+  // the reply to the real names plus the two sentinels, so nothing can be
+  // hallucinated (buildTriageSchema). The block is appended only when the
+  // caller has a roster, so the roster-less prompt stays byte-identical to
+  // what the eval harness scores.
+  ...(monitors.length > 0
+    ? [
+        `This system's cameras are: ${monitors.join(', ')}.`,
+        // Copy-then-judge (refs #265's copy-interpret pattern, applied here
+        // after direct classification force-picked the nearest camera):
+        // "place" makes the model write down what the message actually named,
+        // and "covered" asks the yes/no question on its own before any name
+        // can be decoded. Asked to pick from the list directly, the model
+        // substituted the nearest camera for a place the list lacks.
+        'Also copy into "place" the exact place or camera words the message names ("" when it names none;',
+        'time words such as today or yesterday are not places).',
+        'Then "covered": true only when a listed camera\'s name means that same place, in any language; false',
+        'when "place" is "" or when no listed camera means it. A camera covers only what its own name says:',
+        'a nearby or similar place is still false, never the closest name.',
+        `Then "monitor": the listed camera that means the place, or ${MONITOR_NONE} when "covered" is false.`,
+        '',
+        'Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "place", "covered", and "monitor".',
+      ]
+    : ['Reply with one word: ZONEMINDER, ACTION, or CHAT.']),
 ];
 
-/** The classifier's prompt for a turn covering `servers`. Fewer than two names
- *  it identically to the string this file has always sent. */
-function buildTriagePrompt(servers: readonly string[]): string {
-  return triagePromptLines(servers).join('\n');
+/** The classifier's prompt for a turn covering `servers`, extended with the
+ *  camera question when `monitors` has a roster (refs #427). With neither, it
+ *  is identical to the string this file has always sent. */
+function buildTriagePrompt(servers: readonly string[], monitors: readonly string[] = []): string {
+  return triagePromptLines(servers, monitors).join('\n');
 }
 
 const TRIAGE_PROMPT = buildTriagePrompt([]);
@@ -109,6 +149,32 @@ export const TRIAGE_SCHEMA = {
   additionalProperties: false,
 } as const;
 
+/** TRIAGE_SCHEMA, plus the camera verdict when a roster exists (refs #427):
+ *  an enum of the REAL monitor names and the two sentinels, so a constrained
+ *  backend physically cannot reply with a camera that does not exist. With no
+ *  roster it is exactly TRIAGE_SCHEMA. */
+export function buildTriageSchema(monitors: readonly string[]): Record<string, unknown> {
+  if (monitors.length === 0) return TRIAGE_SCHEMA as unknown as Record<string, unknown>;
+  return {
+    type: 'object',
+    properties: {
+      kind: { type: 'string', enum: ['ZONEMINDER', 'ACTION', 'CHAT'] },
+      // Decoded BEFORE `covered` and `monitor` on purpose (property order is
+      // generation order under constrained decoding): copying the message's
+      // own place words first puts the mismatch in front of the model.
+      place: { type: 'string' },
+      // The abstention as its own yes/no question. Asked to choose from the
+      // name enum directly, the model substituted the nearest camera for a
+      // place the list lacks, under three prompt wordings and both enum
+      // orders (12/16); the boolean is what made it abstain.
+      covered: { type: 'boolean' },
+      monitor: { type: 'string', enum: [MONITOR_NONE, ...monitors] },
+    },
+    required: ['kind', 'place', 'covered', 'monitor'],
+    additionalProperties: false,
+  };
+}
+
 /** A schema-constrained backend replies `{"kind":"CHAT"}`; that is read
  *  first. Everything else is matched loosely on purpose: a small model asked
  *  for one word still says "CHAT." or `{"answer":"CHAT"}` (the on-device
@@ -121,6 +187,13 @@ export const TRIAGE_SCHEMA = {
  *  sends. Not used elsewhere. */
 export const TRIAGE_PROMPT_FOR_EVAL = TRIAGE_PROMPT;
 
+/** The roster-extended prompt for the eval harness (prompt-eval.mts
+ *  triage-monitor stage), so the camera verdict is scored on exactly what
+ *  production sends (refs #427). Not used elsewhere. */
+export function buildTriagePromptForEval(monitors: readonly string[]): string {
+  return buildTriagePrompt([], monitors);
+}
+
 export function parseRequestKind(reply: string): RequestKind {
   try {
     const kind = (JSON.parse(reply) as { kind?: unknown }).kind;
@@ -129,6 +202,37 @@ export function parseRequestKind(reply: string): RequestKind {
     // Not the constrained shape; fall through to the loose match.
   }
   return parseKindWord(reply);
+}
+
+/** The camera verdict out of the same reply (refs #427): a roster name, NONE,
+ *  NO_MATCH, or undefined when the reply does not carry the constrained shape.
+ *  Derived from all three fields, in code: a named place that `covered` says
+ *  no camera means is NO_MATCH whatever `monitor` holds, and a monitor name
+ *  outside the roster is never trusted (an unconstrained backend can reply
+ *  anything). No loose fallback on purpose: a wrong kind degrades to a
+ *  recoverable misroute, but a wrong monitor becomes a system line asserting
+ *  the wrong camera. Exported for the eval harness (prompt-eval.mts
+ *  triage-monitor), which must score exactly what production derives. */
+export function parseTriageMonitor(reply: string, monitors: readonly string[]): string | undefined {
+  if (monitors.length === 0) return undefined;
+  try {
+    const raw = JSON.parse(reply) as { place?: unknown; covered?: unknown; monitor?: unknown };
+    if (raw.covered === true && typeof raw.monitor === 'string' && monitors.includes(raw.monitor)) {
+      return raw.monitor;
+    }
+    if (raw.covered === false) {
+      const place = typeof raw.place === 'string' ? raw.place : '';
+      // "summarize today" copied "today" into place (2/2 at temp 0), and the
+      // prompt's "time words are not places" line did not stop it. Decidable
+      // in code: strip every time expression the timeframe scan owns, and a
+      // place with nothing else left named no place at all.
+      const rest = scanTimeExpressions(place).reduce((text, phrase) => text.replace(phrase, ' '), place);
+      return /[\p{L}\p{N}]/u.test(rest) ? MONITOR_NO_MATCH : MONITOR_NONE;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function parseKindWord(text: string): RequestKind {
@@ -159,21 +263,27 @@ export async function classifyRequest(
    *  because a message that names one is about this system and nothing else
    *  here can tell the classifier that. */
   servers: readonly string[] = [],
-): Promise<RequestKind> {
+  /** Monitor names to resolve a place reference against (refs #427). Empty
+   *  skips the camera question entirely: prompt and schema stay exactly what
+   *  this file always sent. The caller passes names only when its own
+   *  deterministic scan found nothing (monitor-stage.ts). */
+  monitors: readonly string[] = [],
+): Promise<TriageVerdict> {
   try {
     // `complete`, not `chat`: a classifier handed the tool catalog, the
     // few-shot block and the JSON output contract answers like an assistant
     // instead of returning a verdict. The schema constrains a backend that
     // can enforce it to `{"kind":"..."}`; the parser still accepts the loose
     // one-word reply from a backend that cannot.
-    const result = await provider.complete(buildTriagePrompt(servers), question, signal, TRIAGE_SCHEMA as unknown as Record<string, unknown>, onStatus);
+    const result = await provider.complete(buildTriagePrompt(servers, monitors), question, signal, buildTriageSchema(monitors), onStatus);
     if (result.exchange) {
       onTrace?.({ kind: 'exchange', exchange: { ...result.exchange, backend: `${result.exchange.backend} (triage)` } });
     }
-    return parseRequestKind(sanitizeModelText(result.text, 'triage'));
+    const text = sanitizeModelText(result.text, 'triage');
+    return { kind: parseRequestKind(text), monitor: parseTriageMonitor(text, monitors) };
   } catch (error) {
     if (isAbortError(error)) throw error;
-    return 'zoneminder';
+    return { kind: 'zoneminder' };
   }
 }
 

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -710,6 +710,9 @@ export const ASSISTANT = {
   // Vocabulary changes when someone reconfigures a detector, which is rare, so
   // this is cached for a whole session rather than per turn.
   objectLabelCacheMs: 30 * 60 * 1000,
+  // Monitor names change when someone renames a camera, which is rarer still;
+  // same session-length cache as the object vocabulary (monitor-stage.ts).
+  monitorRosterCacheMs: 30 * 60 * 1000,
   maxTokens: 1024,
   // The remote path needs its own budget for the same reason the native one
   // above does, and neither of `maxTokens`'s constraints applies here: an

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2164,7 +2164,11 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    ``buildSystemPrompt`` (``system-prompt.ts``) folds in the profile timezone,
    locale, ZM version, and the install's own detected-object labels. The
    monitor list is not copied into every prompt because ``list_monitors``
-   resolves names when needed.
+   resolves names when needed; what does run up front is
+   ``scanMonitorMentions`` (``monitor-stage.ts``), a deterministic pass that
+   matches monitor names the question states verbatim against the cached
+   per-profile roster (``getMonitorRoster``), on the same normalized key
+   ``resolveMonitorRef`` uses for model-supplied names.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/assistant/AskPanel.tsx>`__
    · → :doc:`16-platform-surfaces`
 
@@ -2178,6 +2182,21 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    refuse a data question any more: the loop fails open (next steps), so the
    old English keyword overrule (``requiresLiveData``) is deleted rather
    than maintained as a vocabulary.
+
+   The same round resolves the monitor a question refers to (refs #427), but
+   only when the deterministic scan above found no monitor name: the roster
+   goes into the prompt and ``buildTriageSchema`` extends the verdict with
+   ``place`` (the question's own place words, copied), ``covered`` (whether
+   any listed monitor means that place), and ``monitor`` (an enum of the real
+   names, so a monitor that does not exist is undecodable).
+   ``parseTriageMonitor`` derives the outcome in code - a named place that
+   ``covered`` denies is ``NO_MATCH``, a place that is only time words is
+   ``NONE`` - and ``buildMonitorSystemLine`` turns it into one system line:
+   a resolved monitor pins ``monitorId``, a ``NO_MATCH`` place gets a guard
+   telling the model to say no monitor covers it and never attribute other
+   monitors' events to it. Asked "how many people came to my front door
+   yesterday" with no door monitor, the assistant used to answer "3 people
+   came to your front door" from a garage monitor's events.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/triage.ts>`__
    · → :doc:`15-assistant`
 


### PR DESCRIPTION
Fixes #427.

Live failure: "how many people came to my front door yesterday" answered "3 people came to your front door" from events on "Garage Outdoor". No door monitor exists; the location claim was copied from the user's words.

## What changed
- New `monitor-stage.ts`: cached per-profile monitor roster, a deterministic scan for monitor names stated verbatim (same normalized key as `resolveMonitorRef`), resolution logic, and the injected system line mirroring the timeframe line.
- Triage round now doubles as the place resolver when the scan finds nothing: the roster rides its prompt, and the constrained schema gains `place` (copied words), `covered` (boolean abstention), and `monitor` (enum of real names, so nothing can be hallucinated). `NO_MATCH` is derived in code from place+covered, with time words stripped via `scanTimeExpressions`.
- A resolved monitor pins `monitorId`; `NO_MATCH` injects a guard: say no monitor covers that place, never attribute results to the user's place word. No roster (group mode, fetch failure, triage outage) degrades to today's behavior.
- `prompt-eval.mts` gains a `triage-monitor` stage scored through the production parser.

## Acceptance
- "A deterministic scan matches monitor names mentioned in the question (normalized, any script) before any model round." — `scanMonitorMentions`, unit-tested.
- "When the scan finds nothing, the existing triage round also resolves the place reference: schema-constrained to the profile's real monitor names plus NONE / NO_MATCH, so no name can be hallucinated." — `buildTriageSchema` + `parseTriageMonitor` (NO_MATCH derived in code; a name enum cannot express abstention, measured 12/16).
- "A resolved monitor is injected into the turn's system prompt as an already-resolved monitorId line, mirroring the timeframe line." — `buildMonitorSystemLine`, wired in `AskPanel`.
- "A NO_MATCH verdict injects a guard line: say no camera covers that place, attribute any results to their own monitor names, never to the user's place word." — done.
- "No roster, aggregate (ALL) mode, and triage failure all degrade to today's behavior." — roster skipped in group/test mode; `getMonitorRoster` never throws; triage catch returns kind-only verdict.
- "Triage eval scores unchanged on the roster-less prompt; new roster cases added and scored." — triage 38/38 before and after (roster-less prompt byte-identical); triage-monitor 21/24 on qwen3:8b, 10/16 on llama3.2, recorded in `llm-models.md`.

## Eval scores (temp 0, reasoning none, local Ollama)
| stage | qwen3:8b | llama3.2 |
|---|---|---|
| triage (pre-change) | 38/38 | — |
| triage (post-change) | 38/38 | — |
| triage-monitor (new) | 21/24 | 10/16 |

Remaining measured ceiling: "backyard" judged covered by a garage monitor (nearby-outdoor substitution no wording fixed; on that eval case the kind is ACTION, where the monitor verdict is unused). Documented in `agents/project/llm-models.md`.

Gates: `npm run gates` green (vitest, build, three lints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5