### PR TITLE
fix(assistant): token-match monitor mentions, break triage contradictions safely, stop caching interpreter failures

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -88,7 +88,11 @@ after any prompt or provider change and put both scores in the PR.
   enum, with NO_MATCH derived in code from place+covered (21/24; the model
   still copies time words into `place`, stripped in code via
   `scanTimeExpressions`, and still calls a backyard covered by a garage
-  monitor - a nearby-outdoor-area substitution no wording fixed). llama3.2
+  monitor - a nearby-outdoor-area substitution no wording fixed). The model
+  also emits the CONTRADICTION `covered: false` with a real name in
+  `monitor` (observed live on a paraphrase, refs #430); the parser resolves
+  that to NONE, since asserting no-coverage about a monitor the model
+  itself named is the worst outcome. llama3.2
   scores 10/16 on the same stage: it answers `covered: true` for near
   places, so a wrong monitor can be pinned rather than abstained; qwen3:8b
   remains the recommended Ollama model.

--- a/app/src/lib/assistant/__tests__/monitor-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/monitor-stage.test.ts
@@ -31,6 +31,31 @@ describe('scanMonitorMentions', () => {
     expect(scanMonitorMentions('how many people came by yesterday', roster)).toEqual([]);
   });
 
+  // Refs #430, observed live: "front of my door" is not a contiguous
+  // substring of any name, so the substring pass missed FrontDoor and the
+  // turn fell to the model, which contradicted itself. Every token of a
+  // name appearing in the question is just as deterministic a signal.
+  it('matches a name whose tokens all appear in the question, words intervening', () => {
+    expect(scanMonitorMentions('how many people came to the front of my door yesterday?', roster)).toEqual([
+      { id: '3', name: 'Front Door' },
+    ]);
+  });
+
+  it('splits camelCase names into tokens', () => {
+    const camel = [{ id: '7', name: 'FrontDoor' }];
+    expect(scanMonitorMentions('anything at the front of the door?', camel)).toEqual([{ id: '7', name: 'FrontDoor' }]);
+  });
+
+  // "Front Yard" shares the "front" token; only a full token set matches.
+  it('does not match a name when only some of its tokens appear', () => {
+    const yards = [{ id: '8', name: 'Front Yard' }];
+    expect(scanMonitorMentions('who came to the front of my door', yards)).toEqual([]);
+  });
+
+  it('does not token-match on partial words', () => {
+    expect(scanMonitorMentions('the doorbell rang out front', roster)).toEqual([]);
+  });
+
   // A monitor whose name normalizes to '' (all punctuation) must never match
   // every question by matching the empty string.
   it('ignores a monitor whose normalized name is empty', () => {

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -247,6 +247,25 @@ describe('classifyRequest with a monitor roster', () => {
     expect(verdict).toEqual({ kind: 'zoneminder', monitor: 'NONE' });
   });
 
+  // Refs #430, observed live: {"place":"front of my door","covered":false,
+  // "monitor":"FrontDoor"}: the model denied coverage while naming the
+  // right monitor. A contradictory verdict is uncertainty, and asserting
+  // "no camera covers that place" about a camera the model itself named is
+  // the worst outcome; NONE (no injected line) is the safe read.
+  it('resolves a covered:false verdict that still names a real monitor to NONE', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","place":"front of my door","covered":false,"monitor":"FrontDoor"}');
+    const verdict = await classifyRequest(
+      provider,
+      'how many people came to the front of my door yesterday?',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor', 'Garage Outdoor'],
+    );
+    expect(verdict).toEqual({ kind: 'zoneminder', monitor: 'NONE' });
+  });
+
   // An unconstrained backend can reply anything; a monitor value outside the
   // enum must arrive as undefined, never as a trusted name.
   it('drops a monitor value that is not in the roster', async () => {

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -59,6 +59,36 @@ describe('interpretWhen', () => {
     expect(result).toMatchObject({ error: expect.stringContaining('right now') });
   });
 
+  // Refs #430, observed live: one transient provider failure during the
+  // pre-warm (overlapped since #429) was written into the per-day cache, so
+  // the tool round's "yesterday" served the cached error and its own "Retry"
+  // advice could never work. A transient failure is not a property of the
+  // phrase; only real interpretations are worth a day of reuse.
+  it('does not cache a provider failure: the next call asks the model again', async () => {
+    const complete = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('server busy'))
+      .mockResolvedValue({ text: '{"daysAgo": 1}' });
+    const p = { complete } as unknown as AssistantProvider;
+
+    const first = await interpretWhen('yesterday', p, NOW, 'UTC', new AbortController().signal);
+    expect(first).toHaveProperty('error');
+    const second = await interpretWhen('yesterday', p, NOW, 'UTC', new AbortController().signal);
+    expect(second).toEqual({ daysAgo: 1 });
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache an unparseable reply either', async () => {
+    const complete = vi
+      .fn()
+      .mockResolvedValueOnce({ text: 'no json here' })
+      .mockResolvedValue({ text: '{"daysAgo": 1}' });
+    const p = { complete } as unknown as AssistantProvider;
+
+    expect(await interpretWhen('yesterday', p, NOW, 'UTC', new AbortController().signal)).toHaveProperty('error');
+    expect(await interpretWhen('yesterday', p, NOW, 'UTC', new AbortController().signal)).toEqual({ daysAgo: 1 });
+  });
+
   it('caches per phrase and calendar day, so repeats cost nothing', async () => {
     const p = providerSaying('{"daysAgo": 0}');
     await interpretWhen('today', p, NOW, 'UTC', new AbortController().signal);

--- a/app/src/lib/assistant/monitor-stage.ts
+++ b/app/src/lib/assistant/monitor-stage.ts
@@ -78,19 +78,37 @@ export async function getMonitorRoster(profileId: string): Promise<MonitorRoster
   }
 }
 
+/** A name or question as lowercase word tokens: camelCase seams split
+ *  ("FrontDoor" -> front, door) and anything non-alphanumeric separates.
+ *  Token EQUALITY is the match unit, so "doorbell" never matches "door". */
+function wordTokens(value: string): string[] {
+  return value
+    .replace(/(\p{Ll})(\p{Lu})/gu, '$1 $2')
+    .split(/[^\p{L}\p{N}]+/u)
+    .map((token) => token.toLowerCase())
+    .filter((token) => token.length > 0);
+}
+
 /**
  * Every monitor whose name appears in the question, in roster order.
  *
- * Matches on the same normalized key `resolveMonitorRef` uses for
- * model-supplied names, so "FRONTDOOR" and "front-door" both find "Front
- * Door". A name that normalizes to '' never matches: the empty string is a
- * substring of everything.
+ * Two deterministic passes, either one a hit (refs #430):
+ * - The whole name as a contiguous substring, on the same normalized key
+ *   `resolveMonitorRef` uses for model-supplied names, so "FRONTDOOR" and
+ *   "front-door" both find "Front Door". A name that normalizes to '' never
+ *   matches: the empty string is a substring of everything.
+ * - Every token of the name present among the question's tokens, so "front
+ *   of my door" still finds "FrontDoor" with words intervening. All tokens,
+ *   not some: "front of my door" must not match "Front Yard".
  */
 export function scanMonitorMentions(question: string, roster: MonitorRosterEntry[]): MonitorRosterEntry[] {
   const haystack = normalizeMonitorName(question);
+  const questionTokens = new Set(wordTokens(question));
   return roster.filter((entry) => {
     const needle = normalizeMonitorName(entry.name);
-    return needle.length > 0 && haystack.includes(needle);
+    if (needle.length > 0 && haystack.includes(needle)) return true;
+    const tokens = wordTokens(entry.name);
+    return tokens.length > 0 && tokens.every((token) => questionTokens.has(token));
   });
 }
 

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -221,6 +221,12 @@ export function parseTriageMonitor(reply: string, monitors: readonly string[]): 
       return raw.monitor;
     }
     if (raw.covered === false) {
+      // A contradiction (coverage denied while a real roster name is filled
+      // in) is uncertainty, observed live: {"place":"front of my door",
+      // "covered":false,"monitor":"FrontDoor"} (refs #430). Asserting "no
+      // camera covers that place" about a monitor the model itself named is
+      // the worst outcome, so the verdict degrades to NONE: no line at all.
+      if (typeof raw.monitor === 'string' && monitors.includes(raw.monitor)) return MONITOR_NONE;
       const place = typeof raw.place === 'string' ? raw.place : '';
       // "summarize today" copied "today" into place (2/2 at temp 0), and the
       // prompt's "time words are not places" line did not stop it. Decidable

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -265,7 +265,11 @@ export async function interpretWhen(
     });
     result = { error: `Could not interpret "${phrase}" as a time window right now. Retry, or rephrase the when argument.` };
   }
-  CACHE.set(cacheKey, result);
+  // Only a real interpretation earns a day of reuse (refs #430): a cached
+  // error made its own "Retry" advice a lie, since every retry of the phrase
+  // served the failure back until the calendar day rolled over. Observed
+  // live with "yesterday" after one transient failure during the pre-warm.
+  if (!('error' in result)) CACHE.set(cacheKey, result);
   return result;
 }
 

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2166,9 +2166,11 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    monitor list is not copied into every prompt because ``list_monitors``
    resolves names when needed; what does run up front is
    ``scanMonitorMentions`` (``monitor-stage.ts``), a deterministic pass that
-   matches monitor names the question states verbatim against the cached
-   per-profile roster (``getMonitorRoster``), on the same normalized key
-   ``resolveMonitorRef`` uses for model-supplied names.
+   matches monitor names against the cached per-profile roster
+   (``getMonitorRoster``) two ways: the whole name as a substring on the same
+   normalized key ``resolveMonitorRef`` uses for model-supplied names, or
+   every token of the name present among the question's words, so "front of
+   my door" still finds "FrontDoor" with words intervening (refs #430).
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/components/assistant/AskPanel.tsx>`__
    · → :doc:`16-platform-surfaces`
 
@@ -2191,7 +2193,10 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    names, so a monitor that does not exist is undecodable).
    ``parseTriageMonitor`` derives the outcome in code - a named place that
    ``covered`` denies is ``NO_MATCH``, a place that is only time words is
-   ``NONE`` - and ``buildMonitorSystemLine`` turns it into one system line:
+   ``NONE``, and a contradiction (``covered`` false while ``monitor`` names a
+   real roster entry, observed live, refs #430) is ``NONE`` rather than a
+   false no-coverage claim - and ``buildMonitorSystemLine``
+   turns it into one system line:
    a resolved monitor pins ``monitorId``, a ``NO_MATCH`` place gets a guard
    telling the model to say no monitor covers it and never attribute other
    monitors' events to it. Asked "how many people came to my front door


### PR DESCRIPTION
Fixes #430.

Three faults observed in one live turn, each fixed at root:

1. **Scan misses paraphrase.** `scanMonitorMentions` gains a second deterministic pass: a monitor matches when every token of its name (camelCase and punctuation split) appears among the question's words, so "front of my door" resolves "FrontDoor" before any model round. Token equality, not substring: "doorbell" never matches "door"; "Front Yard" needs "yard".
2. **Contradictory triage verdict asserted a falsehood.** `{"covered":false,"monitor":"FrontDoor"}` used to derive NO_MATCH and inject "No monitor in this system matches the place" about a monitor the model itself named. A contradiction now resolves to NONE: no injected line at all.
3. **Cached transient failure.** `interpretWhen` wrote its catch-path error into the per-day cache; one hiccup during the overlapped pre-warm (#429) poisoned "yesterday" for the whole day while telling the model to "Retry". Errors are no longer cached.

## Acceptance
- "`scanMonitorMentions` also matches a monitor whose name tokens (camelCase and punctuation split) all appear among the question's tokens, so 'front of my door' resolves FrontDoor deterministically, before any model round." — done, unit-tested (positive, camelCase, partial-token negative, partial-word negative).
- "A triage contradiction — `covered:false` with a real roster name in `monitor` — resolves to NONE (no injected line), never to NO_MATCH; consistent abstention still derives NO_MATCH." — done, unit-tested.
- "`interpretWhen` never caches an error result; a retry after a transient failure actually re-asks the model." — done, unit-tested for both the thrown and the unparseable path.
- "Triage evals unchanged (38/38 roster-less; triage-monitor no worse than 21/24 on qwen3:8b)." — triage-monitor 21/24 (same single known ceiling case); roster-less prompt untouched.

Gates: `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5