### PR TITLE
feat(assistant): time-track fixes and one-call parse (month guard, weekday ranges, extraction merge)

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -91,6 +91,13 @@ after any prompt or provider change and put both scores in the PR.
   (observed live on a paraphrase, refs #430); the parser leaves both slots
   unset then, since asserting no-coverage about a monitor the model itself
   named is the worst outcome.
+- Adding the `when` slot to the parse flipped "front door" (no door
+  monitor) from a clean noMatch to covered:true with the WHOLE roster selected,
+  under two rule wordings (refs #434): unrelated schema fields perturb a
+  borderline judgment, so re-run the parse eval after ANY parse-prompt or
+  schema change. The fix is structural, not wording: a whole-roster
+  selection leaves the slot unset, since it pins nothing an unpinned query
+  lacks and is the false-cover signature.
 - The full parse (refs #432, `prompt-eval.mts parse`, temp 0, 2026-09):
   slots as array enums (monitors as a SET, subject, objects) with an
   umbrella-coverage rule (a house contains what its monitors watch) scores 30/30
@@ -98,7 +105,11 @@ after any prompt or provider change and put both scores in the PR.
   "folks" -> person, and German -> the door monitor - the cases the single
   slot and the English category list failed. llama3.2 scores 8/20, mostly
   kind misroutes (ACTION for count questions); qwen3:8b remains the
-  recommended Ollama model.
+  recommended Ollama model. With the `when` slot merged in (refs #434) the
+  parse scores 36/36 and the separate extraction call is gone on the roster
+  lane; the eval's extract stage still measures the roster-less fallback's
+  model-only recall, where multi-phrase misses are pre-existing and the
+  scan union covers them.
 - Apple Foundation Models invents tool arguments (validate before use) and
   calls real tools on greeting turns; the first tool call on a tool-less
   turn gets a no-tools pushback (578787dc).

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -578,18 +578,26 @@ interface ParseCase {
   monitors?: string[];
   /** Accept any non-empty subset of these instead of an exact set. */
   monitorsWithin?: string[];
+  /** Pass when nothing is pinned: monitors unset/empty or noMatch - any
+   *  outcome except a positive pin of wrong cameras. */
+  unpinned?: boolean;
   noMatch?: boolean;
   subject?: string;
   objects?: string[];
+  /** Each must appear (normalized) inside the UNION of the deterministic
+   *  scan and the parse's when slot - the same union production queries. */
+  when?: string[];
 }
 const PARSE_CASES: ParseCase[] = [
   // The live failures this architecture exists for:
-  { q: 'How may folks came to the front of my house between mon and tue?', roster: R_HOUSE, kind: 'ZONEMINDER', monitorsWithin: ['FrontDoor', 'Front Yard'], subject: 'events', objects: ['person'] },
-  { q: 'how many people came to my front door yesterday', roster: R_PLAIN, kind: 'ZONEMINDER', noMatch: true, subject: 'events', objects: ['person'] },
+  { q: 'How may folks came to the front of my house between mon and tue?', roster: R_HOUSE, kind: 'ZONEMINDER', monitorsWithin: ['FrontDoor', 'Front Yard'], subject: 'events', objects: ['person'], when: ['between mon and tue'] },
+  { q: 'how many people came to my front door yesterday', roster: R_PLAIN, kind: 'ZONEMINDER', unpinned: true, subject: 'events', objects: ['person'], when: ['yesterday'] },
   { q: 'how many people came to my front door yesterday', roster: R_DOOR, kind: 'ZONEMINDER', monitors: ['Doorbell'], subject: 'events', objects: ['person'] },
   { q: 'any cars in the driveway today', roster: R_PLAIN, kind: 'ZONEMINDER', monitors: ['Driveway'], subject: 'events', objects: ['car'] },
   { q: 'was war gestern an der Haust\u00fcr los', roster: R_DOOR, kind: 'ZONEMINDER', monitors: ['Doorbell'], subject: 'events' },
-  { q: 'summarize today', roster: R_PLAIN, kind: 'ZONEMINDER', monitors: [], subject: 'events', objects: [] },
+  { q: 'summarize today', roster: R_PLAIN, kind: 'ZONEMINDER', monitors: [], subject: 'events', objects: [], when: ['today'] },
+  { q: 'who came at lunch 5 days ago', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['lunch', '5 days ago'] },
+  { q: 'was war letzte Woche los', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'events', when: ['letzte woche'] },
   { q: 'is the server ok', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'server' },
   { q: 'what cameras do I have', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'monitors' },
   { q: 'hello', roster: R_PLAIN, kind: 'CHAT' },
@@ -602,6 +610,8 @@ function setEq(a: readonly string[] | undefined, b: readonly string[]): boolean 
 
 async function scoreParse(runs: number) {
   const { buildTriagePromptForEval, buildTriageSchema, parseTriageSlots } = await import('../src/lib/assistant/triage');
+  const { scanTimeExpressions } = await import('../src/lib/assistant/timeframe-stage');
+  const { normalizeWhenPhrase } = await import('../src/lib/assistant/tool-helpers');
   let pass = 0;
   let total = 0;
   const failures: string[] = [];
@@ -629,8 +639,14 @@ async function scoreParse(runs: number) {
           if (!within) bad.push(`monitors ${JSON.stringify(slots.monitors)} not within ${JSON.stringify(c.monitorsWithin)}`);
         }
         if (c.noMatch !== undefined && slots.noMatch !== c.noMatch) bad.push(`noMatch ${String(slots.noMatch)}`);
+        if (c.unpinned && (slots.monitors?.length ?? 0) > 0) bad.push(`pinned ${JSON.stringify(slots.monitors)}`);
         if (c.subject !== undefined && slots.subject !== c.subject) bad.push(`subject ${String(slots.subject)}`);
         if (c.objects !== undefined && !setEq(slots.objects, c.objects)) bad.push(`objects ${JSON.stringify(slots.objects)}`);
+        if (c.when !== undefined) {
+          const union = [...scanTimeExpressions(c.q), ...(slots.when ?? [])].map(normalizeWhenPhrase);
+          const missing = c.when.filter((w) => !union.some((u) => u.includes(normalizeWhenPhrase(w))));
+          if (missing.length > 0) bad.push(`when missing ${JSON.stringify(missing)} (union ${JSON.stringify(union)})`);
+        }
         if (bad.length === 0) pass++;
         else failures.push(`[parse] "${c.q}" [${c.roster.join(', ')}] -> ${bad.join('; ')} (raw ${text})`);
       } catch (e) {

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -521,21 +521,7 @@ export function AskPanel() {
         sharedMockProvider.contextWindow = window.__assistantMockContextWindow;
       }
 
-      // The timeframe extraction can start before anything else: it needs
-      // only the question and the provider, and its result is not read until
-      // after triage. Overlapped ONLY on Ollama (refs #427 follow-up): a
-      // server takes concurrent requests, while the on-device runtimes do
-      // not (AICore rate-limits a burst as ErrorCode.BUSY, and Apple FM
-      // serializes), so every other backend keeps the sequential order
-      // below. The no-op catch is deliberate: a turn that never awaits this
-      // (triage said chat, or an abort) must not surface an unhandled
-      // rejection; the awaiting path below still sees the real error.
       const timezone = currentProfile?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-      const earlyTimeframes =
-        providerConfig.backend === 'ollama' && !isAssistantTestMode()
-          ? extractTimeframes(text, provider, new Date(), timezone, controller.signal)
-          : null;
-      earlyTimeframes?.catch(() => {});
 
       // Four independent context reads, fetched together: none depends on
       // another, all are cached or cheap, and sequential awaits cost a full
@@ -690,10 +676,19 @@ export function AskPanel() {
       let turnSystem = kind === 'zoneminder' ? system : buildNoToolPrompt(system, kind);
       let plannedCalls: PlannedToolCall[] | undefined;
       if (kind === 'zoneminder' && !isAssistantTestMode()) {
-        // The overlapped Ollama call from above when there is one, the
-        // sequential call otherwise; same result either way.
-        const { phrases, resolved, abstained } = await (earlyTimeframes ??
-          extractTimeframes(text, provider, new Date(), timezone, controller.signal));
+        // With a roster the parse already copied the time phrases, so this
+        // makes no extraction model call of its own (refs #434): scan union,
+        // provenance, containment dedup, and the cached interpreter calls
+        // run on the parsed phrases. A roster-less turn (verdict.when
+        // undefined) keeps the old extraction call.
+        const { phrases, resolved, abstained } = await extractTimeframes(
+          text,
+          provider,
+          new Date(),
+          timezone,
+          controller.signal,
+          verdict.when,
+        );
         if (abstained) {
           append(profileId, { role: 'assistant', text: `${I18N_SENTINEL}assistant.timeframe_unclear` });
           return;

--- a/app/src/lib/assistant/__tests__/event-range.test.ts
+++ b/app/src/lib/assistant/__tests__/event-range.test.ts
@@ -238,3 +238,48 @@ describe('no window', () => {
     expect(at({})).toBeUndefined();
   });
 });
+
+/**
+ * Refs #434, observed live: "between mon and tue" had no weekday-range shape,
+ * so the model computed fromDate/toDate itself and started the window on
+ * Sunday. The range is two weekday fields the code resolves: the end is the
+ * most recent toWeekday (today included), the start the fromWeekday at or
+ * before it. NOW is Thursday 2026-07-16.
+ */
+describe('weekday ranges', () => {
+  it('resolves the most recent such span', () => {
+    // Monday Jul 13 through Tuesday Jul 14 (inclusive: closes Wed midnight).
+    expect(at({ fromWeekday: 'monday', toWeekday: 'tuesday' })).toEqual({
+      startDateTime: '2026-07-13 00:00:00',
+      endDateTime: '2026-07-15 00:00:00',
+    });
+  });
+
+  it('wraps across the weekend', () => {
+    // Friday Jul 10 through Monday Jul 13.
+    expect(at({ fromWeekday: 'friday', toWeekday: 'monday' })).toEqual({
+      startDateTime: '2026-07-10 00:00:00',
+      endDateTime: '2026-07-14 00:00:00',
+    });
+  });
+
+  it('caps the end at now when the span ends today', () => {
+    // Wednesday Jul 15 through Thursday Jul 16 (today): closes at now.
+    expect(at({ fromWeekday: 'wednesday', toWeekday: 'thursday' })).toEqual({
+      startDateTime: '2026-07-15 00:00:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+  });
+
+  it('rejects a half-open range and unknown day names', () => {
+    expect(at({ fromWeekday: 'monday' })).toHaveProperty('error');
+    expect(at({ fromWeekday: 'monday', toWeekday: 'blursday' })).toHaveProperty('error');
+  });
+
+  it('rejects mixing a weekday range with other day shapes or clock bands', () => {
+    expect(at({ fromWeekday: 'monday', toWeekday: 'tuesday', daysAgo: 1 })).toHaveProperty('error');
+    expect(at({ fromWeekday: 'monday', toWeekday: 'tuesday', fromTime: '09:00', toTime: '17:00' })).toHaveProperty(
+      'error',
+    );
+  });
+});

--- a/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
@@ -354,3 +354,56 @@ describe('scanTimeExpressions lunch band', () => {
     expect(scanTimeExpressions('anything around lunchtime')).toEqual(['lunchtime']);
   });
 });
+
+/**
+ * Refs #434: with a roster, the parse call already copied the time phrases,
+ * so extractTimeframes takes them as `statedPhrases` and makes NO extraction
+ * model call of its own; the interpreter calls (and the scan, provenance,
+ * and abstain logic) are unchanged. `undefined` statedPhrases keeps the old
+ * extraction call: roster-less installs and group mode still extract.
+ */
+describe('extractTimeframes with parse-stated phrases', () => {
+  beforeEach(() => resetWindowInterpreterCacheForTests());
+
+  it('skips the extraction model call and unions stated phrases with the scan', async () => {
+    const p = makeProvider(
+      () => {
+        throw new Error('extraction must not be called');
+      },
+      () => '{"daysAgo":1}',
+    );
+    const result = await extractTimeframes('was war letzte Woche los, and yesterday', p, NOW, TZ, signal(), [
+      'letzte Woche',
+    ]);
+    // Scan found "yesterday"; the stated phrase adds what regex cannot see.
+    expect(result.phrases).toEqual(['yesterday', 'letzte Woche']);
+    expect(result.abstained).toBe(false);
+    // Only interpreter calls happened.
+    for (const [system] of vi.mocked(p.complete).mock.calls) {
+      expect(system).not.toContain('find the time expressions');
+    }
+  });
+
+  it('drops a stated phrase that is not a substring of the question', async () => {
+    const p = makeProvider(() => '', () => '{"daysAgo":0}');
+    const result = await extractTimeframes('what happened today', p, NOW, TZ, signal(), ['2026-07-16', 'today']);
+    expect(result.phrases).toEqual(['today']);
+  });
+
+  // Containment dedup (refs #434): the scan emits the halves ("lunch",
+  // "5 days ago"), the parse copies the compound; only the compound survives,
+  // so the planner never queries the whole day next to the lunch band.
+  it('absorbs scan phrases contained in a stated compound', async () => {
+    const p = makeProvider(() => '', () => '{"daysAgo":5,"fromTime":"11:00","toTime":"13:00"}');
+    const result = await extractTimeframes('who came at lunch 5 days ago', p, NOW, TZ, signal(), [
+      'at lunch 5 days ago',
+    ]);
+    expect(result.phrases).toEqual(['at lunch 5 days ago']);
+  });
+
+  it('still answers on the scan alone when stated phrases are empty', async () => {
+    const p = makeProvider(() => '', () => '{"daysAgo":0}');
+    const result = await extractTimeframes('what happened today', p, NOW, TZ, signal(), []);
+    expect(result.phrases).toEqual(['today']);
+  });
+});

--- a/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
@@ -305,3 +305,52 @@ describe('buildTimeframeSystemLine', () => {
     );
   });
 });
+
+/**
+ * Refs #434, observed live: "How may folks came..." matched the bare
+ * month-name class as the month of May, and the obedient planner then issued
+ * a wasted whole-of-May query. The four month/season names that double as
+ * everyday words match only behind a determiner; the unambiguous names stay
+ * bare, and "<month> <day>" keeps the full list.
+ */
+describe('scanTimeExpressions month-word guard', () => {
+  it('ignores may/march/fall/spring used as ordinary words', () => {
+    expect(scanTimeExpressions('How may folks came to the front of my house?')).toEqual([]);
+    expect(scanTimeExpressions('did the camera fall over')).toEqual([]);
+    expect(scanTimeExpressions('march the recording out')).toEqual([]);
+  });
+
+  it('still finds them behind a determiner, verbatim', () => {
+    expect(scanTimeExpressions('how busy was it in may')).toEqual(['in may']);
+    expect(scanTimeExpressions('summarize this march')).toEqual(['this march']);
+    expect(scanTimeExpressions('what happened last fall')).toEqual(['last fall']);
+  });
+
+  it('keeps unambiguous months bare and month+day with the full list', () => {
+    expect(scanTimeExpressions('how busy was april')).toEqual(['april']);
+    expect(scanTimeExpressions('what happened on may 15')).toEqual(['may 15']);
+  });
+});
+
+/** Refs #434: "between mon and tue" had no scan class and no interpreter
+ *  branch, so the model computed the dates itself and started on Sunday. */
+describe('scanTimeExpressions weekday ranges', () => {
+  it('finds a between-weekdays span, abbreviations included', () => {
+    expect(scanTimeExpressions('who came by between mon and tue?')).toEqual(['between mon and tue']);
+    expect(scanTimeExpressions('what happened from friday to sunday')).toEqual(['from friday to sunday']);
+  });
+
+  it('does not fire a bare abbreviation outside the range shape', () => {
+    expect(scanTimeExpressions('the cat sat on the mat')).toEqual([]);
+  });
+});
+
+describe('scanTimeExpressions lunch band', () => {
+  // Two adjacent phrases, not one: the compound "at lunch 5 days ago" is the
+  // extraction model's to copy whole, and containment dedup then absorbs
+  // these halves into it (refs #434).
+  it('finds lunch as a part of the day', () => {
+    expect(scanTimeExpressions('who came at lunch 5 days ago')).toEqual(['lunch', '5 days ago']);
+    expect(scanTimeExpressions('anything around lunchtime')).toEqual(['lunchtime']);
+  });
+});

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -204,7 +204,7 @@ describe('classifyRequest with a roster and vocabulary', () => {
         objects: { type: 'array', items: { enum: labels } },
         covered: { type: 'boolean' },
       },
-      required: ['kind', 'place', 'covered', 'monitors', 'subject', 'objects'],
+      required: ['kind', 'place', 'covered', 'monitors', 'subject', 'objects', 'when'],
     });
     expect(verdict).toEqual({
       kind: 'zoneminder',
@@ -254,6 +254,26 @@ describe('classifyRequest with a roster and vocabulary', () => {
     expect(verdict).toEqual({ kind: 'zoneminder', subject: 'events', objects: ['person'] });
   });
 
+  // The whole roster is not a pin: it equals an unpinned query, and it is
+  // how a false cover manifests (refs #434).
+  it('leaves monitors unset when the model selects every camera', async () => {
+    const provider = providerSaying(
+      '{"kind":"ZONEMINDER","place":"front door","covered":true,"monitors":["FrontDoor","Garage Outdoor"],"subject":"events","objects":["person"],"when":["yesterday"]}',
+    );
+    const verdict = await classifyRequest(
+      provider,
+      'how many people came to my front door yesterday',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor', 'Garage Outdoor'],
+      ['person'],
+    );
+    expect(verdict.monitors).toBeUndefined();
+    expect(verdict.noMatch).toBeUndefined();
+  });
+
   // An unconstrained backend can reply anything; values outside the enums
   // are dropped, never trusted.
   it('drops monitors, subjects, and objects outside the enums', async () => {
@@ -272,5 +292,53 @@ describe('classifyRequest with a roster and vocabulary', () => {
     );
     const verdict = await ask(provider, 'summarize today');
     expect(verdict).toEqual({ kind: 'zoneminder', monitors: [], subject: 'events', objects: [] });
+  });
+});
+
+/** Refs #434: the parse call copies the time phrases too, so the separate
+ *  extraction model call is not needed on the roster lane. */
+describe('classifyRequest when-phrase slot', () => {
+  it('asks for and returns verbatim time phrases with the roster', async () => {
+    const provider = providerSaying(
+      '{"kind":"ZONEMINDER","place":"","covered":false,"monitors":[],"subject":"events","objects":[],"when":["between mon and tue"]}',
+    );
+    const verdict = await classifyRequest(
+      provider,
+      'who came between mon and tue',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor'],
+      ['person'],
+    );
+    const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
+    expect(system).toContain('"when"');
+    expect(schema).toMatchObject({
+      properties: { when: { type: 'array', items: { type: 'string' } } },
+      required: ['kind', 'place', 'covered', 'monitors', 'subject', 'objects', 'when'],
+    });
+    expect(verdict.when).toEqual(['between mon and tue']);
+  });
+
+  it('drops junk when values and leaves the slot unset without a roster', async () => {
+    const junk = providerSaying(
+      '{"kind":"ZONEMINDER","place":"","covered":false,"monitors":[],"subject":"events","objects":[],"when":["", 42]}',
+    );
+    const verdict = await classifyRequest(
+      junk,
+      'summarize',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor'],
+      ['person'],
+    );
+    expect(verdict.when).toEqual([]);
+
+    const bare = providerSaying('{"kind":"CHAT"}');
+    const none = await classifyRequest(bare, 'hello', new AbortController().signal);
+    expect(none.when).toBeUndefined();
   });
 });

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -6,7 +6,7 @@
  * (scripts/prompt-eval.mts interpret stage), not unit tests.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { interpretWhen, resetWindowInterpreterCacheForTests, selectBranches, WINDOW_SCHEMA } from '../window-interpreter';
+import { interpretWhen, resetWindowInterpreterCacheForTests, selectBranches, WINDOW_SCHEMA, buildInterpreterPrompt } from '../window-interpreter';
 import type { AssistantProvider } from '../types';
 
 const NOW = new Date('2026-07-16T14:30:00Z');
@@ -263,5 +263,33 @@ describe('selectBranches', () => {
     expect(sent).not.toBe(WINDOW_SCHEMA);
     const sets = requiredSets(sent);
     expect(sets.every((req) => req.includes('fromTime') || req.includes('weekday'))).toBe(true);
+  });
+});
+
+/** Refs #434: the weekday-range branch, so "between mon and tue" never forces
+ *  the model into date arithmetic. */
+describe('weekday-range branch', () => {
+  it('exists in the schema with both fields required', () => {
+    const branches = (WINDOW_SCHEMA.anyOf as Array<{ required: string[] }>);
+    expect(branches.some((b) => b.required.includes('fromWeekday') && b.required.includes('toWeekday'))).toBe(true);
+  });
+
+  it('is the only branch offered for a two-weekday phrase, abbreviations included', () => {
+    for (const phrase of ['between mon and tue', 'from friday to sunday']) {
+      const picked = selectBranches(phrase) as { properties?: Record<string, unknown>; anyOf?: unknown[] };
+      // One branch decodes as a bare object (see wrap()).
+      expect(picked.properties).toHaveProperty('fromWeekday');
+      expect(picked.anyOf).toBeUndefined();
+    }
+  });
+
+  // One weekday word is not a range: the phrase keeps the full schema
+  // (fail-open, as before), never the range-only narrowing.
+  it('does not narrow a single-weekday phrase to the range branch', () => {
+    expect(selectBranches('last tuesday')).toBe(WINDOW_SCHEMA);
+  });
+
+  it('teaches the field in the prompt', () => {
+    expect(buildInterpreterPrompt(new Date('2026-07-16T14:30:00Z'), 'UTC')).toContain('fromWeekday');
   });
 });

--- a/app/src/lib/assistant/event-range.ts
+++ b/app/src/lib/assistant/event-range.ts
@@ -46,6 +46,12 @@ export interface WindowFields {
   lastUnit?: string;
   daysAgo?: number;
   weekday?: string;
+  /** A span between two weekdays ("between mon and tue"), most recent such
+   *  span ending on or before today. Code resolves both dates, because the
+   *  model anchored the wrong calendar day when forced to compute them
+   *  (refs #434). */
+  fromWeekday?: string;
+  toWeekday?: string;
   /** Most recent past day with this day-of-month number (1-31): "the 21st".
    *  Code finds the date, exactly as `weekday` finds the most recent weekday,
    *  because a small model resolves a bare ordinal to the wrong ISO date. */
@@ -136,17 +142,40 @@ export function resolveWindow(
   now: Date,
   timezone: string,
 ): ResolvedEventRange | { error: string } | undefined {
-  const { lastCount, lastUnit, daysAgo, weekday, dayOfMonth, weekend, date, fromDate, toDate, fromTime, toTime } = fields;
+  const { lastCount, lastUnit, daysAgo, weekday, fromWeekday, toWeekday, dayOfMonth, weekend, date, fromDate, toDate, fromTime, toTime } = fields;
   const dayPickers = [daysAgo !== undefined, weekday !== undefined, dayOfMonth !== undefined, date !== undefined].filter(Boolean).length;
   const rolling = lastCount !== undefined || lastUnit !== undefined;
   const ranged = fromDate !== undefined || toDate !== undefined;
   const weekendShape = weekend !== undefined;
+  const weekdayRange = fromWeekday !== undefined || toWeekday !== undefined;
 
-  if ([rolling, dayPickers > 0, ranged, weekendShape].filter(Boolean).length > 1) {
-    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, dayOfMonth, or date), a weekend, or a span (fromDate/toDate).' };
+  if ([rolling, dayPickers > 0, ranged, weekendShape, weekdayRange].filter(Boolean).length > 1) {
+    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, dayOfMonth, or date), a weekday span (fromWeekday+toWeekday), a weekend, or a span (fromDate/toDate).' };
   }
   if (dayPickers > 1) {
     return { error: 'Send only one of daysAgo, weekday, dayOfMonth, or date.' };
+  }
+
+  if (weekdayRange) {
+    if (fromTime !== undefined || toTime !== undefined) {
+      return { error: 'fromTime/toTime narrow a single day; use daysAgo, weekday, or date alongside them.' };
+    }
+    const fromIdx = WEEKDAYS.indexOf(String(fromWeekday).toLowerCase() as (typeof WEEKDAYS)[number]);
+    const toIdx = WEEKDAYS.indexOf(String(toWeekday).toLowerCase() as (typeof WEEKDAYS)[number]);
+    if (fromIdx === -1 || toIdx === -1) {
+      return { error: `fromWeekday and toWeekday must BOTH be one of: ${WEEKDAYS.join(', ')}. Received "${String(fromWeekday)}" and "${String(toWeekday)}".` };
+    }
+    // Most recent end day (today included), then back to the start weekday at
+    // or before it; a same-day pair spans that one day.
+    const zonedNow = toZonedTime(now, timezone);
+    const endDay = startOfDay(subDays(zonedNow, (zonedNow.getDay() - toIdx + 7) % 7));
+    const startDay = subDays(endDay, (toIdx - fromIdx + 7) % 7);
+    const start = fromZonedTime(startDay, timezone);
+    // Inclusive of the end day: the window closes at the following midnight,
+    // capped at now, mirroring the weekend and toDate shapes.
+    const endRaw = fromZonedTime(subDays(endDay, -1), timezone);
+    const end = endRaw.getTime() > now.getTime() ? now : endRaw;
+    return { startDateTime: formatForZm(start, timezone), endDateTime: formatForZm(end, timezone) };
   }
 
   if (weekendShape) {

--- a/app/src/lib/assistant/time-eval-cases.ts
+++ b/app/src/lib/assistant/time-eval-cases.ts
@@ -100,6 +100,12 @@ export const TIME_INTERPRET_CASES: TimeInterpretCase[] = [
   // weekday references (resolved range, so weekday/daysAgo/date branches all pass)
   { phrase: 'on sunday', cls: 'weekday', ok: (_f, r) => startsOn(r, '2026-07-19') },
   { phrase: 'last tuesday night', cls: 'weekday', ok: (f, r) => startsOn(r, '2026-07-14') && band(f.fromTime, '17:00', '23:00') },
+  // weekday ranges (refs #434): the fromWeekday/toWeekday branch exists so
+  // the model never computes the dates; checked on the resolved range.
+  { phrase: 'between mon and tue', cls: 'weekday', ok: (_f, r) => startsOn(r, '2026-07-13') },
+  { phrase: 'from friday to sunday', cls: 'weekday', ok: (_f, r) => startsOn(r, '2026-07-17') },
+  // lunch is a part-of-day band (refs #434)
+  { phrase: 'at lunch 5 days ago', cls: 'part-of-day', ok: (f, r) => startsOn(r, '2026-07-14') && band(f.fromTime, '10:00', '12:00') && band(f.toTime, '12:00', '14:00') },
   // weekend (code computes the two dates from the `weekend` field; resolved
   // range checked so either the field or a correct fromDate/toDate passes)
   { phrase: 'this weekend', cls: 'weekend', ok: (_f, r) => startsOn(r, '2026-07-18') && endsOnDate(r, '2026-07-19') },
@@ -161,6 +167,12 @@ export const TIME_EXTRACT_CASES: TimeExtractCase[] = [
   { question: 'were there cars in the driveway yesterday afternoon', expect: ['yesterday', 'afternoon'] },
   { question: 'give me a recap of last month', expect: ['last month'] },
   { question: 'how busy was it in april', expect: ['april'] },
+  // Weekday ranges and the month-word guard (refs #434): the range phrase
+  // must surface whole, and the "may" typo must not scan as a month (the
+  // guard is unit-tested; here the range keeps the case answerable).
+  { question: 'who came by between mon and tue?', expect: ['between mon and tue'] },
+  { question: 'How may folks came to the front of my house between mon and tue?', expect: ['between mon and tue'] },
+  { question: 'who came at lunch 5 days ago', expect: ['lunch', '5 days ago'] },
   { question: 'was war letzte Woche bei mir los', expect: ['letzte woche'] },
   { question: 'what cameras do I have', none: true },
   { question: 'is the server ok', none: true },

--- a/app/src/lib/assistant/timeframe-stage.ts
+++ b/app/src/lib/assistant/timeframe-stage.ts
@@ -211,6 +211,13 @@ export async function extractTimeframes(
   now: Date,
   timezone: string,
   signal: AbortSignal,
+  /** Time phrases the parse call already copied (refs #434). Given (even
+   *  []), the extraction model call is SKIPPED and these stand in for its
+   *  output: the scan union, provenance filter, containment dedup, and
+   *  interpreter calls below are identical either way. `undefined` keeps the
+   *  old extraction call, so a roster-less install and group mode still
+   *  extract. */
+  statedPhrases?: string[],
 ): Promise<ExtractedTimeframes> {
   // Code-first extraction (refs #270): a deterministic scan OWNS every time class
   // it can recognize, so the shapes that flaked on-device (compact clock ranges
@@ -223,18 +230,22 @@ export async function extractTimeframes(
   const scanPhrases = scanTimeExpressions(question);
 
   let extracted: string[] = [];
-  try {
-    const reply = await provider.complete(buildTimeframePrompt(now, timezone), question, signal, TIMEFRAME_SCHEMA);
-    extracted = parsePhrases(reply.text);
-  } catch (error) {
-    if (isAbortError(error)) throw error;
-    log.assistant('Timeframe extraction failed', LogLevel.WARN, {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    // With the scan in hand the turn is not blind when the model call fails: only
-    // fall straight to the default period when the scan also found nothing (the
-    // pre-scan fail-open path). Otherwise proceed on the scan phrases alone.
-    if (scanPhrases.length === 0) return { phrases: ['today'], resolved: [], abstained: false };
+  if (statedPhrases !== undefined) {
+    extracted = statedPhrases;
+  } else {
+    try {
+      const reply = await provider.complete(buildTimeframePrompt(now, timezone), question, signal, TIMEFRAME_SCHEMA);
+      extracted = parsePhrases(reply.text);
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      log.assistant('Timeframe extraction failed', LogLevel.WARN, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // With the scan in hand the turn is not blind when the model call fails: only
+      // fall straight to the default period when the scan also found nothing (the
+      // pre-scan fail-open path). Otherwise proceed on the scan phrases alone.
+      if (scanPhrases.length === 0) return { phrases: ['today'], resolved: [], abstained: false };
+    }
   }
 
   // The model parrots the prompt's own date line (buildTimeframePrompt names
@@ -255,13 +266,24 @@ export async function extractTimeframes(
   // a phrase whose normalized form the scan did not already cover.
   const scanKeys = new Set(scanPhrases.map(normalizeWhenPhrase));
   const seen = new Set<string>();
-  const union: string[] = [];
+  const deduped: string[] = [];
   for (const phrase of [...scanPhrases, ...modelStated]) {
     const key = normalizeWhenPhrase(phrase);
     if (seen.has(key)) continue;
     seen.add(key);
-    union.push(phrase);
+    deduped.push(phrase);
   }
+  // Containment dedup (refs #434): the scan emits the halves of a compound
+  // ("lunch", "5 days ago") while the model copies it whole ("at lunch 5
+  // days ago"); querying both the whole day and the band would double the
+  // fan-out, so a phrase contained in a longer one is absorbed by it.
+  const union = deduped.filter((phrase) => {
+    const key = normalizeWhenPhrase(phrase);
+    return !deduped.some((other) => {
+      const otherKey = normalizeWhenPhrase(other);
+      return otherKey !== key && otherKey.includes(key);
+    });
+  });
   const namedTime = union.length > 0;
 
   const resolved: ResolvedTimeframe[] = [];

--- a/app/src/lib/assistant/timeframe-stage.ts
+++ b/app/src/lib/assistant/timeframe-stage.ts
@@ -22,7 +22,7 @@
  */
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
-import { interpretWhen, PART_OF_DAY_WORDS, WEEKDAY_WORDS, MONTH_SEASON_NAMES } from './window-interpreter';
+import { interpretWhen, PART_OF_DAY_WORDS, WEEKDAY_WORDS, WEEKDAY_ABBREVS, MONTH_SEASON_NAMES, AMBIGUOUS_MONTH_WORDS } from './window-interpreter';
 import { normalizeWhenPhrase } from './tool-helpers';
 import { log, LogLevel } from '../logger';
 import { WINDOW_UNITS, type WindowFields } from './event-range';
@@ -116,16 +116,25 @@ const COUNT_TOKEN = String.raw`\d+|an?|one|two|three|four|five|six|seven|eight|n
  *  "july 15", "yesterday" inside "yesterday afternoon"), so each span is listed
  *  once, at its most specific.
  *
- *  ponytail: month/season names include the everyday words "may", "march",
- *  "fall", "spring", so a non-time use ("it may rain") over-matches to a month.
- *  Upgrade path if that bites: require a leading in/the/this/last for those four. */
+ *  The month/season names that double as everyday words ("may", "march",
+ *  "fall", "spring") match only behind a determiner (in/the/this/last/...):
+ *  "How may folks came" scanned as the month of May and the obedient planner
+ *  issued a wasted whole-of-May query (refs #434). "<month> <day>" keeps the
+ *  full list, since "may 15" is unambiguous. */
 export function scanTimeExpressions(question: string): string[] {
   const months = [...MONTH_SEASON_NAMES].join('|');
+  const plainMonths = [...MONTH_SEASON_NAMES].filter((m) => !AMBIGUOUS_MONTH_WORDS.includes(m)).join('|');
+  const guardedMonths = AMBIGUOUS_MONTH_WORDS.join('|');
+  const weekdays = [...WEEKDAY_WORDS, ...WEEKDAY_ABBREVS].join('|');
   const patterns: RegExp[] = [
     new RegExp(String.raw`\bfrom\s+(?:${CLOCK_TOKEN})\s+(?:to|until|through|till)\s+(?:${CLOCK_TOKEN})`, 'gi'),
     new RegExp(String.raw`\bbetween\s+(?:${CLOCK_TOKEN})\s+and\s+(?:${CLOCK_TOKEN})`, 'gi'),
     new RegExp(String.raw`\b\d{1,2}(?::\d{2})?(?:\s*(?:am|pm))?\s*[-–]\s*\d{1,2}(?::\d{2})?(?:\s*(?:am|pm))?\b`, 'gi'),
     new RegExp(String.raw`\b(?:${months})\s+\d{1,2}(?:st|nd|rd|th)?\b`, 'gi'),
+    // "between mon and tue", "from friday to sunday": a weekday span, with
+    // the English abbreviations accepted only inside this anchored shape so
+    // "sat" alone never scans as a day (refs #434).
+    new RegExp(String.raw`\b(?:between|from)\s+(?:${weekdays})\s+(?:and|to|until|through|till)\s+(?:${weekdays})\b`, 'gi'),
     new RegExp(String.raw`\b(?:past|last|previous)\s+(?:${COUNT_TOKEN})\s+(?:${ROLLING_UNITS})s?\b`, 'gi'),
     // "2 days ago", "two days ago", "an hour ago". Without this the whole
     // family scanned empty and the turn fell through to the today default,
@@ -135,7 +144,7 @@ export function scanTimeExpressions(question: string): string[] {
     new RegExp(String.raw`\b(?:(?:this|last|yesterday)\s+)?(?:${PART_OF_DAY_WORDS.join('|')})\b`, 'gi'),
     new RegExp(String.raw`\b(?:today|tonight|yesterday)\b`, 'gi'),
     new RegExp(String.raw`\b(?:(?:last|this|next|on)\s+)?(?:${WEEKDAY_WORDS.join('|')})\b`, 'gi'),
-    new RegExp(String.raw`\b(?:${months})\b`, 'gi'),
+    new RegExp(String.raw`\b(?:${plainMonths})\b|\b(?:in|the|a|an|this|last|of|during|for)\s+(?:${guardedMonths})\b`, 'gi'),
     new RegExp(String.raw`\b(?:the\s+)?\d{1,2}(?:st|nd|rd|th)\b`, 'gi'),
   ];
 

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -46,6 +46,10 @@ export interface TriageVerdict {
   subject?: QuerySubject;
   /** Recorded labels the question asks about ("folks" -> person). */
   objects?: string[];
+  /** Time phrases copied verbatim from the question (refs #434), for the
+   *  timeframe stage to union with its own scan; provenance and
+   *  interpretation stay there. Absent without a roster. */
+  when?: string[];
 }
 
 /** Model-facing (rule 5 exempt): never rendered, only matched below.
@@ -134,13 +138,18 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
         // substituted the nearest camera for a place the list lacks.
         '"place": the exact place or camera words it names ("" when it names none; time words such as today',
         'or yesterday are not places).',
-        '"covered": true when a listed camera means that place, or when the place is broader and contains',
-        'what listed cameras watch (a house contains its own cameras); false when "place" is "" or when no',
-        'listed camera relates to it. A nearby or merely similar place is still false, never the closest name.',
+        '"covered": true when a listed camera means that place, or when the place is a whole area that',
+        "contains a listed camera's own area (the whole house contains its cameras); false when \"place\" is",
+        '"" or when no listed camera means or sits inside it. A place that is only one PART of the property',
+        '(one door, one corner, one room) is covered only by a camera that means that exact place: nearby',
+        'or merely similar is still false, never the closest name.',
         '"monitors": every listed camera that means the place or watches part of it ([] when "covered" is false).',
         '"subject": what the message asks about. events - what happened, who or what came by, was seen,',
         "detected, or counted. monitors - the camera list or a camera's state. server - health or whether",
         'the system is up. groups - monitor groups. other - anything else.',
+        '"when": every time expression the message names, each copied VERBATIM in its own language',
+        '("today", "letzte Woche", "between mon and tue", "at lunch 5 days ago"); [] when it names none.',
+        'Copy whole compound phrases; never invent, translate, or normalize a time.',
         ...(labels.length > 0
           ? [
               '"objects": every listed label the message asks about, judged by meaning ("folks" or "Leute" mean',
@@ -148,7 +157,7 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
             ]
           : []),
         '',
-        `Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "place", "covered", "monitors", "subject"${labels.length > 0 ? ', and "objects"' : ''}.`,
+        `Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "place", "covered", "monitors", "subject", "when"${labels.length > 0 ? ', and "objects"' : ''}.`,
       ]
     : ['Reply with one word: ZONEMINDER, ACTION, or CHAT.']),
 ];
@@ -194,8 +203,11 @@ export function buildTriageSchema(monitors: readonly string[], labels: readonly 
       monitors: { type: 'array', items: { type: 'string', enum: [...monitors] } },
       subject: { type: 'string', enum: [...QUERY_SUBJECTS] },
       ...(labels.length > 0 ? { objects: { type: 'array', items: { type: 'string', enum: [...labels] } } } : {}),
+      // Free strings by necessity (no enum can list every time phrase); the
+      // timeframe stage's provenance filter distrusts them (refs #434).
+      when: { type: 'array', items: { type: 'string' } },
     },
-    required: ['kind', 'place', 'covered', 'monitors', 'subject', ...(labels.length > 0 ? ['objects'] : [])],
+    required: ['kind', 'place', 'covered', 'monitors', 'subject', ...(labels.length > 0 ? ['objects'] : []), 'when'],
     additionalProperties: false,
   };
 }
@@ -241,7 +253,7 @@ export function parseTriageSlots(
   labels: readonly string[] = [],
 ): Omit<TriageVerdict, 'kind'> {
   if (monitors.length === 0) return {};
-  let raw: { place?: unknown; covered?: unknown; monitors?: unknown; subject?: unknown; objects?: unknown };
+  let raw: { place?: unknown; covered?: unknown; monitors?: unknown; subject?: unknown; objects?: unknown; when?: unknown };
   try {
     raw = JSON.parse(reply) as typeof raw;
   } catch {
@@ -253,7 +265,13 @@ export function parseTriageSlots(
     ? raw.monitors.filter((m): m is string => typeof m === 'string' && monitors.includes(m))
     : undefined;
   if (raw.covered === true && named && named.length > 0) {
-    slots.monitors = named;
+    // Selecting the ENTIRE roster pins nothing an unpinned query would not
+    // already cover, and it is the signature of a false cover: asked about a
+    // "front door" no camera means, the model answered covered:true with
+    // every camera, under two rule wordings (measured 2/2 at temp 0,
+    // refs #434). The slot stays unset and the turn runs unpinned, with no
+    // line asserting a place.
+    if (named.length < monitors.length) slots.monitors = named;
   } else if (raw.covered === false) {
     if (named && named.length > 0) {
       // A contradiction (coverage denied while real roster names are filled
@@ -277,6 +295,12 @@ export function parseTriageSlots(
   }
   if (labels.length > 0 && Array.isArray(raw.objects)) {
     slots.objects = raw.objects.filter((o): o is string => typeof o === 'string' && labels.includes(o));
+  }
+  if (Array.isArray(raw.when)) {
+    slots.when = raw.when
+      .filter((w): w is string => typeof w === 'string')
+      .map((w) => w.trim())
+      .filter((w) => w.length > 0);
   }
   return slots;
 }

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -65,6 +65,9 @@ export const WINDOW_SCHEMA: Record<string, unknown> = {
     // model reads the split as license to stop early. FM wants required fields;
     // qwen needs this one optional; the 150/150 gate decides it.
     { type: 'object', properties: { weekday: { type: 'string', enum: [...WEEKDAYS] }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['weekday'], additionalProperties: false },
+    // a span between two weekdays ("between mon and tue"); code works out the
+    // dates, so the model never anchors the wrong calendar day (refs #434).
+    { type: 'object', properties: { fromWeekday: { type: 'string', enum: [...WEEKDAYS] }, toWeekday: { type: 'string', enum: [...WEEKDAYS] } }, required: ['fromWeekday', 'toWeekday'], additionalProperties: false },
     // a bare ordinal day-of-month ("the 21st").
     { type: 'object', properties: { dayOfMonth: { type: 'number' } }, required: ['dayOfMonth'], additionalProperties: false },
     // that ordinal narrowed to a clock band.
@@ -93,9 +96,10 @@ export const WINDOW_SCHEMA: Record<string, unknown> = {
  *  same part-of-day vocabulary this interpreter does, rather than duplicating it. */
 export const PART_OF_DAY_WORDS = [
   'morning', 'afternoon', 'evening', 'night', 'noon', 'midnight',
-  'matin', 'soir', 'apres-midi', 'nuit',
-  'manana', 'tarde', 'noche',
-  'morgen', 'abend', 'nacht',
+  'lunch', 'lunchtime',
+  'matin', 'soir', 'apres-midi', 'nuit', 'midi',
+  'manana', 'tarde', 'noche', 'mediodia',
+  'morgen', 'abend', 'nacht', 'mittag',
 ];
 const PART_OF_DAY_RE = new RegExp(`\\b(${PART_OF_DAY_WORDS.join('|')})\\b`);
 /** Weekday NAMES across en/de/es/fr, accent-stripped and lowercase (the form
@@ -114,6 +118,16 @@ export const WEEKDAY_WORDS = [
   'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi', 'dimanche',
 ];
 const WEEKDAY_RE = new RegExp(`\\b(${WEEKDAY_WORDS.join('|')})\\b`);
+/** English weekday abbreviations, accepted ONLY where a surrounding shape
+ *  anchors them (the weekday-range scan class and branch pick, refs #434):
+ *  bare, "sat" is a verb and "mon" is French for "my". */
+export const WEEKDAY_ABBREVS = [
+  'mon', 'tue', 'tues', 'wed', 'weds', 'thu', 'thur', 'thurs', 'fri', 'sat', 'sun',
+];
+const WEEKDAYISH_RE = new RegExp(`\\b(${[...WEEKDAY_WORDS, ...WEEKDAY_ABBREVS].join('|')})\\b`, 'g');
+/** The month/season names that double as everyday English words; the scan
+ *  (timeframe-stage.ts) requires a determiner in front of these (refs #434). */
+export const AMBIGUOUS_MONTH_WORDS = ['may', 'march', 'fall', 'spring'];
 /** A wall-clock marker in the phrase: "4pm"/"9 am", "16:30", or a bare numeric
  *  range "4-6". Any of these means the phrase names a clock band. */
 const CLOCK_RE = /\d\s*(am|pm)\b|\d{1,2}:\d{2}|\d+\s*-\s*\d+/;
@@ -182,6 +196,14 @@ export function selectBranches(phrase: string): Record<string, unknown> {
     return wrap(picked);
   }
 
+  // Two weekday words (abbreviations included: the range shape anchors them)
+  // mean a weekday span; offered alone so the decoder cannot anchor on the
+  // simpler single-weekday branch and drop one end (refs #434).
+  const weekdayish = norm.match(WEEKDAYISH_RE) ?? [];
+  if (weekdayish.length >= 2) {
+    return wrap(branches.filter((b) => b.required.includes('fromWeekday')));
+  }
+
   if (!/\d/.test(norm)) {
     const tokens = norm.split(/[^a-z]+/).filter(Boolean);
     const names = tokens.filter((t) => MONTH_SEASON_NAMES.has(t));
@@ -217,12 +239,13 @@ export function buildInterpreterPrompt(now: Date, timezone: string): string {
     '- lastCount + lastUnit: a rolling span ending now. "past 2 weeks" -> {"lastCount":2,"lastUnit":"week"}; "last 6 hours" -> {"lastCount":6,"lastUnit":"hour"}.',
     '- daysAgo: one calendar day. "today" -> {"daysAgo":0}. "yesterday" -> {"daysAgo":1}. "the day before yesterday" -> {"daysAgo":2}.',
     '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}; "last tuesday" -> {"weekday":"tuesday"}.',
+    '- fromWeekday + toWeekday: a span between two weekdays, full names. "between mon and tue" -> {"fromWeekday":"monday","toWeekday":"tuesday"}; "from friday to sunday" -> {"fromWeekday":"friday","toWeekday":"sunday"}. Code works out the dates, so do NOT send fromDate/toDate for these.',
     '- dayOfMonth: a bare ordinal, just the number. "the 21st" -> {"dayOfMonth":21}; "on the 3rd" -> {"dayOfMonth":3}. Code picks the most recent past such day, so do NOT work out the date yourself.',
     '- weekend: which past weekend, ONLY when the phrase literally says "weekend". "this weekend" -> {"weekend":"this"}; "last weekend" -> {"weekend":"last"}; "two weekends ago" -> {"weekend":"two-ago"}. Code works out the two dates.',
     '- date: one explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
     '- fromDate + toDate: a calendar span, both inclusive. "april" -> {"fromDate":"2026-04-01","toDate":"2026-04-30"}. "this month" -> the 1st of the current month through today. "this year" -> {"fromDate":"2026-01-01","toDate":"2026-12-31"}. "june 1 to 15" -> both dates. Either side may stand alone: "since july 1" -> {"fromDate":"2026-07-01"}.',
     '- fromTime/toTime: 24h "HH:MM" from 00:00 to 23:59, narrowing ONE day named by daysAgo/weekday/date. "yesterday from 4pm to 10pm" -> {"daysAgo":1,"fromTime":"16:00","toTime":"22:00"}.',
-    '- A part of the day is a day plus a clock band: morning 06:00-12:00, noon 11:00-13:00, afternoon 12:00-18:00, evening 18:00-23:59, night 20:00-23:59. ALWAYS include the day, defaulting to today (daysAgo 0) when none is named: "this morning" -> {"daysAgo":0,"fromTime":"06:00","toTime":"12:00"}; "around noon" -> {"daysAgo":0,"fromTime":"11:00","toTime":"13:00"}; "last night" -> {"daysAgo":1,"fromTime":"20:00","toTime":"23:59"}; "last tuesday night" -> {"weekday":"tuesday","fromTime":"20:00","toTime":"23:59"}.',
+    '- A part of the day is a day plus a clock band: morning 06:00-12:00, noon or lunch 11:00-13:00, afternoon 12:00-18:00, evening 18:00-23:59, night 20:00-23:59. ALWAYS include the day, defaulting to today (daysAgo 0) when none is named: "this morning" -> {"daysAgo":0,"fromTime":"06:00","toTime":"12:00"}; "around noon" -> {"daysAgo":0,"fromTime":"11:00","toTime":"13:00"}; "last night" -> {"daysAgo":1,"fromTime":"20:00","toTime":"23:59"}; "last tuesday night" -> {"weekday":"tuesday","fromTime":"20:00","toTime":"23:59"}.',
     '- none: true when the phrase asks for no time limit. "all time" -> {"none":true}.',
     'Keep BOTH halves of a compound phrase, in any language: a day word and a part of the day both survive. "yesterday evening" -> {"daysAgo":1,"fromTime":"18:00","toTime":"23:59"}; "hier apres-midi" -> {"daysAgo":1,"fromTime":"12:00","toTime":"18:00"}.',
     'The phrase may be in any language: "letzte Woche" -> {"lastCount":1,"lastUnit":"week"}; "ayer" -> {"daysAgo":1}; "ce matin" -> {"daysAgo":0,"fromTime":"06:00","toTime":"12:00"}; "el fin de semana pasado" -> {"weekend":"last"}.',

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2191,9 +2191,13 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    own place words, copied), ``covered`` (a boolean, because a name enum
    cannot express abstention), ``monitors`` (an ARRAY over the real names,
    because "front of my house" means several monitors), ``subject``
-   (events/monitors/server/groups/other), and ``objects`` (an array over the
+   (events/monitors/server/groups/other), ``objects`` (an array over the
    recorded labels, so "folks" or "Leute" land on ``person`` in any
-   language). ``parseTriageSlots`` derives everything in code: a place
+   language), and ``when`` (the time phrases, copied verbatim - the separate
+   extraction model call and its Ollama overlap are gone on this lane, refs
+   #434; ``extractTimeframes`` unions the parsed phrases with its scan,
+   drops any phrase contained in a longer one, and interprets as before,
+   keeping its own extraction call only for roster-less turns). ``parseTriageSlots`` derives everything in code: a place
    ``covered`` denies with nothing named is ``noMatch``, a place that is only
    time words is none, a contradiction (``covered`` false while real names
    are filled in, observed live, refs #430) leaves the slots unset rather


### PR DESCRIPTION
Fixes #434.

Two commits, the three approved changes:

**1. `fix(assistant)`: scan and interpreter fixes**
- may/march/fall/spring scan as months only behind a determiner; "How may folks came" no longer plans a whole-of-May query. `<month> <day>` keeps the full list.
- `fromWeekday`/`toWeekday` interpreter branch with the dates resolved in code; "between mon and tue" starts on Monday, not Sunday. Scan class for `between/from <weekday> and/to <weekday>` (abbreviations anchored inside the shape only). Clock-band mixing and half-open ranges rejected with corrective errors.
- lunch/lunchtime (+ midi/mittag/mediodia) join the part-of-day words → 11:00-13:00 band.

**2. `feat(assistant)`: extraction merged into the parse**
- Parse schema gains `when` (verbatim copies); the separate extraction model call and the #429 overlap machinery are deleted on the roster lane; roster-less turns keep the old call. Containment dedup absorbs scan halves into the parse's compound phrase.
- Structural regression fix found by the eval: adding the field flipped a borderline coverage case to covered:true with the whole roster; a whole-roster selection now leaves the monitor slot unset (it pins nothing an unpinned query lacks and is the false-cover signature).

## Acceptance
- "'in may' / 'this march' still scan as months; 'how may folks' scans nothing; a planned turn for that question issues no May query." — unit-tested; planner receives no "may" phrase.
- "'between mon and tue' on Tuesday resolves Monday 00:00 through Tuesday, via fromWeekday/toWeekday fields the code resolves; interpreter and time evals cover the range shapes; 'at lunch' resolves to the 11:00-13:00 band deterministically." — unit + eval: every interpret class 100% including the new weekday-range and lunch cases.
- "With a roster, one parse call returns kind, place/covered, monitors, subject, objects, AND when-phrases; the separate extraction call does not run; earlyTimeframes overlap is deleted; roster-less turns still extract via the fallback call." — done, unit-tested (extraction-must-not-be-called assertion).
- "Containment dedup keeps only the most specific overlapping phrase." — done, unit-tested.
- "Evals re-run and recorded: parse, roster-less triage (38/38 must hold), time." — parse 36/36 (3 runs/case, now scoring when-union too), triage 38/38, time interpret classes 100%; the extract stage's model-only multi-phrase misses are byte-identical on main (verified against a main worktree) and covered by the scan union in production. Recorded in `llm-models.md`.

## Eval scores (qwen3:8b, temp 0, reasoning none)
| stage | score |
|---|---|
| parse (with when slot) | 36/36 |
| triage (roster-less) | 38/38 |
| time interpret (incl. new classes) | 62/62 |

Gates: `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5