### PR TITLE
fix(assistant): coalesce same-window planned fan-outs, guard objects creep, tolerate bracketed SHOW ids

### DIFF
--- a/app/src/lib/assistant/__tests__/agent.test.ts
+++ b/app/src/lib/assistant/__tests__/agent.test.ts
@@ -1010,8 +1010,11 @@ describe('planned tool calls', () => {
     const answer = produced[produced.length - 1];
     expect(answer.role).toBe('assistant');
     expect(answer.text).toBe('3 events on FrontDoor.');
-    // The planned results ride into history as an ordinary tool round.
-    expect(produced.some((m) => m.role === 'tool' && m.toolResults?.length === 2)).toBe(true);
+    // The planned results ride into history as an ordinary tool round -
+    // merged to one when they share the window (refs #436).
+    const toolMsg = produced.find((m) => m.role === 'tool');
+    expect(toolMsg?.toolResults).toHaveLength(1);
+    expect(JSON.parse(toolMsg!.toolResults![0].output).matchCount).toBe(6);
     // Result cards from planned calls surface like any other.
     expect(answer.display).toEqual([{ kind: 'event', id: 'e1' }]);
   });
@@ -1032,5 +1035,43 @@ describe('planned tool calls', () => {
 
     // Executed once by the plan; the model's identical repeat is refused.
     expect(execute).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** Refs #436: same-window planned calls reach the model as ONE merged result,
+ *  so cross-monitor totals are code arithmetic, never the model's. */
+describe('planned call coalescing', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('replays a merged single tool round to the model', async () => {
+    const outputs = [
+      '{"summary":"s1","window":{"from":"a","to":"b"},"matchCount":5,"countsByMonitor":{"FrontDoor":5},"objectCounts":{"person":5},"countsByHour":{"h1":5},"events":[{"id":"10","monitor":"FrontDoor","objects":["person"]}]}',
+      '{"summary":"s2","window":{"from":"a","to":"b"},"matchCount":12,"countsByMonitor":{"Front Yard":12},"objectCounts":{"person":8,"truck":4},"countsByHour":{"h1":3},"events":[{"id":"11","monitor":"Front Yard","objects":["person"]}]}',
+    ];
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ output: outputs[0] })
+      .mockResolvedValueOnce({ output: outputs[1] });
+    const tool = { name: 'list_events', description: 'd', schema: { type: 'object', properties: {} }, execute } as never;
+    const p = new MockProvider();
+    p.setScript([{ text: 'answer', toolCalls: [] }]);
+
+    const produced = await runAssistantTurn({
+      ...baseOpts(p, host(), [{ role: 'user', text: 'how busy was the front over the week?' }]),
+      tools: [tool],
+      plannedCalls: [
+        { name: 'list_events', input: { when: 'over the week', monitorId: '1', objectType: 'person' } },
+        { name: 'list_events', input: { when: 'over the week', monitorId: '4', objectType: 'person' } },
+      ],
+    });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    const toolMsg = produced.find((m) => m.role === 'tool');
+    expect(toolMsg?.toolResults).toHaveLength(1);
+    const body = JSON.parse(toolMsg!.toolResults![0].output);
+    expect(body.matchCount).toBe(17);
+    expect(body.objectCounts).toEqual({ person: 13, truck: 4 });
+    const assistantCallMsg = produced.find((m) => m.role === 'assistant' && m.toolCalls?.length);
+    expect(assistantCallMsg?.toolCalls).toHaveLength(1);
   });
 });

--- a/app/src/lib/assistant/__tests__/display.test.ts
+++ b/app/src/lib/assistant/__tests__/display.test.ts
@@ -71,3 +71,12 @@ describe('filterDisplayByShow', () => {
     expect(kept.map((c) => `${c.kind}:${c.id}`)).toEqual(['event:3']);
   });
 });
+
+// Refs #436, observed live: the model wrote "SHOW: events=[1,2] monitors=[4]"
+// and the bracketed ids matched nothing, silently degrading to all cards.
+describe('extractShowDirective bracket tolerance', () => {
+  it('reads ids wrapped in brackets like bare ids', () => {
+    const { show } = extractShowDirective('answer\nSHOW: events=[342702,342701] monitors=[1,4]');
+    expect(show).toEqual({ events: ['342702', '342701'], monitors: ['1', '4'] });
+  });
+});

--- a/app/src/lib/assistant/__tests__/plan.test.ts
+++ b/app/src/lib/assistant/__tests__/plan.test.ts
@@ -79,3 +79,88 @@ describe('planToolCalls', () => {
     ).toBeNull();
   });
 });
+
+import { mergePlannedEventResults } from '../plan';
+
+/**
+ * Refs #436, observed live: two per-monitor results reached the model
+ * separately; the answer summed totals itself and quoted only one monitor's
+ * objectCounts and busiest hour (5 where the combined truth was 8). Same
+ * window, same filter, different monitorId merges into ONE result the model
+ * can only quote.
+ */
+describe('mergePlannedEventResults', () => {
+  const call = (id: string, monitorId: string) => ({
+    id,
+    name: 'list_events',
+    input: { when: 'over the week', monitorId, objectType: ['person'] },
+  });
+  const output = (monitor: string, ids: number[], hours: Record<string, number>, objects: Record<string, number>) =>
+    JSON.stringify({
+      summary: 'per-call summary',
+      window: { from: 'Aug 25, 12:38:12 PM', to: 'Sep 1, 12:38:12 PM' },
+      matchCount: ids.length,
+      countsByMonitor: { [monitor]: ids.length },
+      objectCounts: objects,
+      countsByHour: hours,
+      events: ids.map((id) => ({ id: String(id), monitor, start: 'x', durationSec: 30, objects: ['person'] })),
+    });
+  const ok = (out: string) => ({ callId: 'c', output: out, isError: false as const });
+
+  it('merges counts, hours, and rows into one result with a code-built summary', () => {
+    const merged = mergePlannedEventResults(
+      [call('planned-1', '1'), call('planned-2', '4')],
+      [
+        ok(output('FrontDoor', [5, 3, 1], { 'Aug 25, 1:00:00 PM': 3 }, { person: 5 })),
+        ok(output('Front Yard', [6, 4, 2], { 'Aug 25, 1:00:00 PM': 5, 'Aug 31, 6:00:00 PM': 1 }, { person: 8, truck: 3 })),
+      ],
+    );
+    expect(merged).not.toBeNull();
+    const body = JSON.parse(merged!.result.output);
+    expect(body.matchCount).toBe(6);
+    expect(body.countsByMonitor).toEqual({ FrontDoor: 3, 'Front Yard': 3 });
+    expect(body.objectCounts).toEqual({ person: 13, truck: 3 });
+    expect(body.busiestHour).toEqual({ label: 'Aug 25, 1:00:00 PM', count: 8 });
+    // Rows merged newest-first by id (ZoneMinder ids are monotonic).
+    expect(body.events.map((e: { id: string }) => e.id)).toEqual(['6', '5', '4', '3', '2', '1']);
+    expect(body.summary).toContain('6 events');
+    expect(body.summary).toContain('person 13');
+    // The synthetic call names the shared window and filter, without a
+    // single-monitor pin it did not have.
+    expect(merged!.call.input).toMatchObject({ when: 'over the week' });
+    expect(merged!.call.input.monitorId).toBeUndefined();
+  });
+
+  it('declines to merge a single call, mixed windows, or an errored result', () => {
+    const a = call('planned-1', '1');
+    const b = { ...call('planned-2', '4'), input: { when: 'yesterday', monitorId: '4', objectType: ['person'] } };
+    expect(mergePlannedEventResults([a], [ok(output('FrontDoor', [1], {}, {}))])).toBeNull();
+    expect(
+      mergePlannedEventResults([a, b], [ok(output('FrontDoor', [1], {}, {})), ok(output('Front Yard', [2], {}, {}))]),
+    ).toBeNull();
+    expect(
+      mergePlannedEventResults(
+        [a, call('planned-2', '4')],
+        [ok(output('FrontDoor', [1], {}, {})), { callId: 'c', output: 'boom', isError: true }],
+      ),
+    ).toBeNull();
+  });
+
+  it('omits objectCounts and busiestHour when any source result lacks them', () => {
+    const noCounts = JSON.stringify({
+      summary: 's',
+      window: { from: 'a', to: 'b' },
+      matchCount: 30,
+      countsByMonitor: { Backyard: 30 },
+      events: [],
+    });
+    const merged = mergePlannedEventResults(
+      [call('planned-1', '1'), call('planned-2', '4')],
+      [ok(output('FrontDoor', [5], { h: 1 }, { person: 5 })), ok(noCounts)],
+    );
+    const body = JSON.parse(merged!.result.output);
+    expect(body.matchCount).toBe(31);
+    expect(body.objectCounts).toBeUndefined();
+    expect(body.busiestHour).toBeUndefined();
+  });
+});

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -342,3 +342,43 @@ describe('classifyRequest when-phrase slot', () => {
     expect(none.when).toBeUndefined();
   });
 });
+
+/** Refs #436, observed live: "how busy" names no object, yet objects came
+ *  back as the ENTIRE vocabulary, silently excluding no-detection events
+ *  from a busyness summary. The whole vocabulary is the creep signature,
+ *  mirror of the whole-roster monitors rule: no filter at all. */
+describe('classifyRequest objects creep guard', () => {
+  it('derives no filter when the model selects every recorded label', async () => {
+    const provider = providerSaying(
+      '{"kind":"ZONEMINDER","place":"front of my abode","covered":true,"monitors":["FrontDoor"],"subject":"events","objects":["person","car","truck"],"when":["over the week"]}',
+    );
+    const verdict = await classifyRequest(
+      provider,
+      'how busy was the front of my abode over the week?',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor', 'Garage Outdoor'],
+      ['car', 'person', 'truck'],
+    );
+    expect(verdict.objects).toEqual([]);
+  });
+
+  it('keeps a proper subset as the filter', async () => {
+    const provider = providerSaying(
+      '{"kind":"ZONEMINDER","place":"","covered":false,"monitors":[],"subject":"events","objects":["car","truck"],"when":["today"]}',
+    );
+    const verdict = await classifyRequest(
+      provider,
+      'any vehicles today',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor'],
+      ['car', 'person', 'truck'],
+    );
+    expect(verdict.objects).toEqual(['car', 'truck']);
+  });
+});

--- a/app/src/lib/assistant/agent.ts
+++ b/app/src/lib/assistant/agent.ts
@@ -9,7 +9,7 @@
  * talk its way past (see tools.ts for why the actions were removed).
  */
 import type { AssistantMessage, AssistantProvider, AssistantHost, DisplayEntity, TokenUsage, TraceEntry, ToolCall, ToolContext, ToolDefinition, ToolResult } from './types';
-import type { PlannedToolCall } from './plan';
+import { mergePlannedEventResults, type PlannedToolCall } from './plan';
 import { getToolByName, isWithheldToolName, TOOLS } from './tools';
 import { validateToolInput, objectQuestionMismatch, toolCallSignature, stripOmittedArgs, repairCountEventsInterval } from './tool-helpers';
 import { executeScoped } from './server-scope';
@@ -454,7 +454,6 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
   // registry stays open, so a drill-down or a corrected retry still works.
   if (opts.plannedCalls?.length) {
     const calls: ToolCall[] = opts.plannedCalls.map((c, i) => ({ id: `planned-${i + 1}`, name: c.name, input: c.input }));
-    push({ role: 'assistant', toolCalls: calls });
     anyToolCallAttempted = true;
     const results: ToolResult[] = [];
     for (const call of calls) {
@@ -462,7 +461,15 @@ export async function runAssistantTurn(opts: RunOpts): Promise<AssistantMessage[
       results.push(await runOneCall(call));
     }
     turnDisplay.push(...results.flatMap((r) => r.display ?? []));
-    push({ role: 'tool', toolResults: results });
+    // A same-window fan-out reaches the model as ONE merged result
+    // (refs #436): handed the per-monitor results separately, it summed the
+    // totals itself and quoted one monitor's counts as the whole answer.
+    // The real calls stay in the trace and keep their signatures; only what
+    // the model is replayed changes.
+    const merged = mergePlannedEventResults(calls, results);
+    if (merged) toolOutputs.push(merged.result.output);
+    push({ role: 'assistant', toolCalls: merged ? [merged.call] : calls });
+    push({ role: 'tool', toolResults: merged ? [merged.result] : results });
   }
 
   for (let i = 0; i < ASSISTANT.maxToolIterations; i++) {

--- a/app/src/lib/assistant/display.ts
+++ b/app/src/lib/assistant/display.ts
@@ -101,9 +101,11 @@ export function extractShowDirective(text: string): { text: string; show?: ShowD
     // No whitespace tolerated around '=': a lax match swallowed the NEXT
     // list's name as this list's value on "events= monitors=".
     const part = new RegExp(`\\b${name}=([^\\s]*)`, 'i').exec(match[1]);
+    // Models wrap the list in brackets ("events=[1,2]", observed live,
+    // refs #436); the ids are the same either way.
     return (part?.[1] ?? '')
       .split(',')
-      .map((id) => id.trim())
+      .map((id) => id.trim().replace(/^\[|\]$/g, ''))
       .filter((id) => id.length > 0);
   };
   return {

--- a/app/src/lib/assistant/plan.ts
+++ b/app/src/lib/assistant/plan.ts
@@ -14,6 +14,7 @@
 import type { RequestKind, QuerySubject } from './triage';
 import type { MonitorRosterEntry } from './monitor-stage';
 import { ASSISTANT } from '../zmninja-ng-constants';
+import { buildResultSummary, type ResultWindow } from './result-summary';
 
 export interface PlannedToolCall {
   name: string;
@@ -57,4 +58,101 @@ export function planToolCalls(q: QueryPlanInput): PlannedToolCall[] | null {
   // the cap the free loop's own judgment beats a mechanical fan-out.
   if (calls.length > ASSISTANT.maxPlannedToolCalls) return null;
   return calls;
+}
+
+/** The subset of a list_events result body the merge reads and rebuilds. */
+interface EventResultBody {
+  window?: { from?: string; to?: string } | string;
+  matchCount?: number;
+  countsByMonitor?: Record<string, number>;
+  objectCounts?: Record<string, number>;
+  countsByHour?: Record<string, number>;
+  events?: Array<{ id?: unknown }>;
+  moreMatchesExist?: boolean;
+}
+
+/** Adds `extra`'s numeric entries into `into`. */
+function addCounts(into: Record<string, number>, extra: Record<string, number> | undefined): void {
+  for (const [key, value] of Object.entries(extra ?? {})) {
+    into[key] = (into[key] ?? 0) + Number(value);
+  }
+}
+
+/**
+ * One merged result for a plan that fanned the SAME window and filter over
+ * several monitors, or null when the calls are not that shape (refs #436).
+ *
+ * Observed live: handed two per-monitor results, the model summed the totals
+ * itself and quoted ONE monitor's objectCounts and busiest hour (5 where the
+ * combined truth was 8). Cross-result arithmetic is exactly what the
+ * per-result summary sentence exists to spare it, so the merge happens here,
+ * in code: summed matchCount, merged per-monitor / per-object / per-hour
+ * counts, the busiest hour recomputed, rows re-sorted newest-first by id
+ * (ZoneMinder ids are monotonic) and re-capped, and one summary sentence the
+ * model can only quote. objectCounts and busiestHour are omitted whenever any
+ * source result lacks them: a partial sum would be stated as a total.
+ *
+ * The synthetic call carries the shared window and filter WITHOUT a
+ * monitorId, which is exactly what it now describes; the real per-monitor
+ * calls stay in the trace, and their signatures stay registered.
+ */
+export function mergePlannedEventResults(
+  calls: ReadonlyArray<{ id?: string; name: string; input: Record<string, unknown> }>,
+  results: ReadonlyArray<{ callId?: string; output: string; isError?: boolean; display?: unknown[] }>,
+): { call: { id: string; name: string; input: Record<string, unknown> }; result: { callId: string; output: string; isError: false; display?: never[] } } | null {
+  if (calls.length < 2 || calls.length !== results.length) return null;
+  if (!calls.every((c) => c.name === 'list_events')) return null;
+  if (results.some((r) => r.isError)) return null;
+  const sharedKey = (input: Record<string, unknown>) => JSON.stringify({ when: input.when, objectType: input.objectType });
+  if (!calls.every((c) => sharedKey(c.input) === sharedKey(calls[0].input))) return null;
+
+  const bodies: EventResultBody[] = [];
+  for (const r of results) {
+    try {
+      bodies.push(JSON.parse(r.output) as EventResultBody);
+    } catch {
+      return null;
+    }
+  }
+
+  const matchCount = bodies.reduce((sum, b) => sum + (Number(b.matchCount) || 0), 0);
+  const countsByMonitor: Record<string, number> = {};
+  for (const b of bodies) addCounts(countsByMonitor, b.countsByMonitor);
+
+  const haveObjects = bodies.every((b) => b.objectCounts !== undefined);
+  const objectCounts: Record<string, number> = {};
+  if (haveObjects) for (const b of bodies) addCounts(objectCounts, b.objectCounts);
+
+  const haveHours = bodies.every((b) => b.countsByHour !== undefined);
+  const countsByHour: Record<string, number> = {};
+  if (haveHours) for (const b of bodies) addCounts(countsByHour, b.countsByHour);
+  const busiest = Object.entries(countsByHour).sort(([, a], [, b]) => b - a)[0];
+
+  const allRows = bodies.flatMap((b) => (Array.isArray(b.events) ? b.events : []));
+  const rows = [...allRows].sort((a, b) => Number(b.id) - Number(a.id)).slice(0, ASSISTANT.maxListEventsLimit);
+  const capped = rows.length < allRows.length || bodies.some((b) => b.moreMatchesExist === true);
+
+  const window = bodies[0].window;
+  const body: Record<string, unknown> = {
+    summary: buildResultSummary({
+      window: window as ResultWindow,
+      matchCount,
+      countsByMonitor,
+      objectCounts: haveObjects ? objectCounts : {},
+      partial: capped,
+    }),
+    window,
+    matchCount,
+    countsByMonitor,
+    ...(haveObjects ? { objectCounts } : {}),
+    ...(haveHours && busiest ? { busiestHour: { label: busiest[0], count: busiest[1] }, countsByHour } : {}),
+    events: rows,
+    ...(capped ? { shownEvents: rows.length, moreMatchesExist: true } : {}),
+  };
+
+  const { monitorId: _dropped, ...sharedInput } = calls[0].input;
+  return {
+    call: { id: 'planned-1', name: 'list_events', input: sharedInput },
+    result: { callId: 'planned-1', output: JSON.stringify(body), isError: false },
+  };
 }

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -294,7 +294,12 @@ export function parseTriageSlots(
     slots.subject = raw.subject as QuerySubject;
   }
   if (labels.length > 0 && Array.isArray(raw.objects)) {
-    slots.objects = raw.objects.filter((o): o is string => typeof o === 'string' && labels.includes(o));
+    const objects = raw.objects.filter((o): o is string => typeof o === 'string' && labels.includes(o));
+    // Selecting the ENTIRE vocabulary is the objectType-creep signature
+    // (observed live on "how busy...", refs #436), and as a filter it
+    // silently EXCLUDES events with no detection at all. Mirror of the
+    // whole-roster monitors rule: derive no filter instead.
+    slots.objects = labels.length > 1 && objects.length === labels.length ? [] : objects;
   }
   if (Array.isArray(raw.when)) {
     slots.when = raw.when

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2207,7 +2207,13 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    gets the never-attribute guard), and ``planToolCalls`` (``plan.ts``)
    composes the tool calls the slots determine - one ``list_events`` per
    window x monitor with the parsed ``objectType`` - handing them to the
-   loop as ``plannedCalls``. A null plan is today's free loop, unchanged.
+   loop as ``plannedCalls``; a same-window fan-out is merged back into ONE
+   result in code (``mergePlannedEventResults``: summed counts, recomputed
+   busiest hour, one summary sentence), so cross-monitor totals are never
+   the model's arithmetic (refs #436). A whole-vocabulary ``objects``
+   selection derives no filter (the creep signature; a filter of every
+   label would exclude no-detection events). A null plan is today's free
+   loop, unchanged.
    Asked "how many people came to my front door yesterday" with no door
    monitor, the assistant used to answer "3 people came to your front door"
    from a garage monitor's events.


### PR DESCRIPTION
Fixes #436.

## Acceptance
- "Two planned list_events over the same window reach the model as one merged result whose summary line carries the combined total, per-monitor and per-object counts, and recomputed busiest hour; the transcript still shows each real call." — `mergePlannedEventResults`, wired in the loop's planned block; unit-tested (merge math, busiest-hour recompute, row re-sort/re-cap, decline conditions, partial-source omission) plus an agent-level test asserting the model is replayed exactly one tool result.
- "A parse that selects every recorded label derives objects [] (no filter); a proper subset still filters." — done, unit-tested both ways.
- "SHOW ids wrapped in brackets select cards identically to bare ids." — done, unit-tested.

The live failure this fixes: the answer claimed "8 people, 3 trucks, 2 cars" for a week in which 13 people were detected (one monitor's counts quoted as the whole), and its busiest hour was undercounted 5 vs the combined 8. With the merge, those numbers arrive as one code-built sentence the model can only quote.

Evals: parse 24/24 (prompt untouched); `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5