### PR TITLE
feat(assistant): one question per judgment - dedicated coverage call, meaning-first interpreter, calendar weeks

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -98,6 +98,17 @@ after any prompt or provider change and put both scores in the PR.
   schema change. The fix is structural, not wording: a whole-roster
   selection leaves the slot unset, since it pins nothing an unpinned query
   lacks and is the false-cover signature.
+- One question per judgment beats one consolidated call (refs #438,
+  measured 2026-09): place coverage judged inside the full parse prompt
+  failed live ("rear of my house" -> no-coverage with a Backyard monitor
+  listed) and a `thinking` self-explanation field only ROTATED the failures
+  across four wordings (each fix broke a previously passing case). The same
+  model on a dedicated three-field coverage prompt scores 18/18 on every
+  one of those cases, reasoning off, no extra rules. The interpreter's
+  `meaning` field (restate which days the phrase covers, decoded first in
+  every branch) is the same pattern at micro scale: "all this week" decoded
+  none:true without it and a real window with it. Split the interrogation
+  before tuning its wording.
 - The full parse (refs #432, `prompt-eval.mts parse`, temp 0, 2026-09):
   slots as array enums (monitors as a SET, subject, objects) with an
   umbrella-coverage rule (a house contains what its monitors watch) scores 30/30
@@ -109,7 +120,9 @@ after any prompt or provider change and put both scores in the PR.
   parse scores 36/36 and the separate extraction call is gone on the roster
   lane; the eval's extract stage still measures the roster-less fallback's
   model-only recall, where multi-phrase misses are pre-existing and the
-  scan union covers them.
+  scan union covers them. After the #438 split, routing scores 24/24 and
+  coverage 18/18, with every interpret class at 100% including the new
+  calendar-week field and the meaning-first branches.
 - Apple Foundation Models invents tool arguments (validate before use) and
   calls real tools on greeting turns; the first tool call on a tool-less
   turn gets a no-tools pushback (578787dc).

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -560,28 +560,14 @@ async function scoreTriage(runs: number) {
   return { pass, total, failures };
 }
 
-/** Parse cases (refs #427, #432): the triage round, handed the roster and
- *  label vocabulary, must fill every slot - cameras as a SET (an umbrella
- *  place means several), subject, and objects mapped by meaning in any
- *  language - and abstain (noMatch) for a place no camera covers, without
- *  disturbing the kind verdict. Scored through the production parser
- *  (parseTriageSlots), so what is measured is what ships. */
+/** Routing-parse cases (refs #432, #438): kind, subject, objects (synonym +
+ *  non-English), and the when-union. Camera coverage is scored separately
+ *  below, through its own dedicated call, mirroring production. */
 const PARSE_LABELS = ['car', 'person', 'truck'];
 const R_PLAIN = ['Garage Outdoor', 'Driveway'];
-const R_DOOR = ['Garage Outdoor', 'Doorbell'];
-const R_HOUSE = ['FrontDoor', 'Front Yard', 'Garage Outdoor'];
 interface ParseCase {
   q: string;
-  roster: string[];
   kind: string;
-  /** Exact expected monitors set, or undefined to skip the check. */
-  monitors?: string[];
-  /** Accept any non-empty subset of these instead of an exact set. */
-  monitorsWithin?: string[];
-  /** Pass when nothing is pinned: monitors unset/empty or noMatch - any
-   *  outcome except a positive pin of wrong cameras. */
-  unpinned?: boolean;
-  noMatch?: boolean;
   subject?: string;
   objects?: string[];
   /** Each must appear (normalized) inside the UNION of the deterministic
@@ -589,19 +575,45 @@ interface ParseCase {
   when?: string[];
 }
 const PARSE_CASES: ParseCase[] = [
-  // The live failures this architecture exists for:
-  { q: 'How may folks came to the front of my house between mon and tue?', roster: R_HOUSE, kind: 'ZONEMINDER', monitorsWithin: ['FrontDoor', 'Front Yard'], subject: 'events', objects: ['person'], when: ['between mon and tue'] },
-  { q: 'how many people came to my front door yesterday', roster: R_PLAIN, kind: 'ZONEMINDER', unpinned: true, subject: 'events', objects: ['person'], when: ['yesterday'] },
-  { q: 'how many people came to my front door yesterday', roster: R_DOOR, kind: 'ZONEMINDER', monitors: ['Doorbell'], subject: 'events', objects: ['person'] },
-  { q: 'any cars in the driveway today', roster: R_PLAIN, kind: 'ZONEMINDER', monitors: ['Driveway'], subject: 'events', objects: ['car'] },
-  { q: 'was war gestern an der Haust\u00fcr los', roster: R_DOOR, kind: 'ZONEMINDER', monitors: ['Doorbell'], subject: 'events' },
-  { q: 'summarize today', roster: R_PLAIN, kind: 'ZONEMINDER', monitors: [], subject: 'events', objects: [], when: ['today'] },
-  { q: 'who came at lunch 5 days ago', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['lunch', '5 days ago'] },
-  { q: 'was war letzte Woche los', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'events', when: ['letzte woche'] },
-  { q: 'is the server ok', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'server' },
-  { q: 'what cameras do I have', roster: R_PLAIN, kind: 'ZONEMINDER', subject: 'monitors' },
-  { q: 'hello', roster: R_PLAIN, kind: 'CHAT' },
-  { q: 'arm the backyard camera', roster: R_PLAIN, kind: 'ACTION' },
+  { q: 'How may folks came to the front of my house between mon and tue?', kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['between mon and tue'] },
+  { q: 'how many people came to my front door yesterday', kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['yesterday'] },
+  { q: 'any cars in the driveway today', kind: 'ZONEMINDER', subject: 'events', objects: ['car'], when: ['today'] },
+  { q: 'was war gestern an der Haust\u00fcr los', kind: 'ZONEMINDER', subject: 'events' },
+  { q: 'summarize today', kind: 'ZONEMINDER', subject: 'events', objects: [], when: ['today'] },
+  { q: 'who came at lunch 5 days ago', kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['lunch', '5 days ago'] },
+  { q: 'how busy was the front of my abode over the week?', kind: 'ZONEMINDER', subject: 'events', objects: [], when: ['over the week'] },
+  { q: 'oh the world is so cool. how is my house doing at the back all of this week?', kind: 'ZONEMINDER', subject: 'events', when: ['all of this week'] },
+  { q: 'is the server ok', kind: 'ZONEMINDER', subject: 'server' },
+  { q: 'what cameras do I have', kind: 'ZONEMINDER', subject: 'monitors' },
+  { q: 'hello', kind: 'CHAT' },
+  { q: 'arm the backyard camera', kind: 'ACTION' },
+];
+
+/** Coverage cases (refs #438), scored through the production coverage call
+ *  and its code derivation - the live failures of the consolidated prompt. */
+const R_HOUSE = ['FrontDoor', 'Backyard(JPEG)', 'Basement', 'Front Yard', 'Garage Indoor', 'Garage Outdoor'];
+const R_DOOR = ['Garage Outdoor', 'Doorbell'];
+interface CoverageCase {
+  q: string;
+  roster: string[];
+  /** Exact expected monitor set. */
+  monitors?: string[];
+  /** Accept any non-empty subset of these. */
+  monitorsWithin?: string[];
+  noMatch?: boolean;
+  /** Pass when nothing is pinned (unset, [], or noMatch). */
+  unpinned?: boolean;
+}
+const COVERAGE_CASES: CoverageCase[] = [
+  { q: 'how was the rear of my house all this week?', roster: R_HOUSE, monitors: ['Backyard(JPEG)'] },
+  { q: 'oh the world is so cool. how is my house doing at the back all of this week?', roster: R_HOUSE, monitorsWithin: ['Backyard(JPEG)'] },
+  { q: 'how many people came to my front door yesterday', roster: R_PLAIN, unpinned: true },
+  { q: 'how many people came to my front door yesterday', roster: R_DOOR, monitors: ['Doorbell'] },
+  { q: 'any cars in the driveway today', roster: R_PLAIN, monitors: ['Driveway'] },
+  { q: 'was war gestern an der Haust\u00fcr los', roster: R_DOOR, monitors: ['Doorbell'] },
+  { q: 'how busy was the front of my abode over the week?', roster: R_HOUSE, monitorsWithin: ['FrontDoor', 'Front Yard'] },
+  { q: 'summarize today', roster: R_PLAIN, unpinned: true },
+  { q: 'who came at lunch 5 days ago', roster: R_PLAIN, unpinned: true },
 ];
 
 function setEq(a: readonly string[] | undefined, b: readonly string[]): boolean {
@@ -610,10 +622,13 @@ function setEq(a: readonly string[] | undefined, b: readonly string[]): boolean 
 
 async function scoreParse(runs: number) {
   const { buildTriagePromptForEval, buildTriageSchema, parseTriageSlots } = await import('../src/lib/assistant/triage');
+  const { buildCoveragePrompt, buildCoverageSchema, deriveMonitorSlots } = await import('../src/lib/assistant/monitor-stage');
   const { scanTimeExpressions } = await import('../src/lib/assistant/timeframe-stage');
   const { normalizeWhenPhrase } = await import('../src/lib/assistant/tool-helpers');
   let pass = 0;
   let total = 0;
+  let coverPass = 0;
+  let coverTotal = 0;
   const failures: string[] = [];
   for (const c of PARSE_CASES) {
     for (let i = 0; i < runs; i++) {
@@ -621,18 +636,48 @@ async function scoreParse(runs: number) {
       try {
         const r = await chat({
           model: MODEL,
-          messages: [{ role: 'system', content: buildTriagePromptForEval(c.roster, PARSE_LABELS) }, { role: 'user', content: c.q }],
+          messages: [{ role: 'system', content: buildTriagePromptForEval(R_PLAIN, PARSE_LABELS) }, { role: 'user', content: c.q }],
           stream: false,
-          max_tokens: 120,
+          max_tokens: 200,
           ...(TEMP === undefined ? {} : { temperature: TEMP }),
           ...REASONING,
-          response_format: { type: 'json_schema', json_schema: { name: 'result', schema: buildTriageSchema(c.roster, PARSE_LABELS), strict: true } },
+          response_format: { type: 'json_schema', json_schema: { name: 'result', schema: buildTriageSchema(R_PLAIN, PARSE_LABELS), strict: true } },
         });
         const text = r.choices?.[0]?.message?.content ?? '';
         const kind = JSON.parse(text)?.kind;
-        const slots = parseTriageSlots(text, c.roster, PARSE_LABELS);
+        const slots = parseTriageSlots(text, R_PLAIN, PARSE_LABELS);
         const bad: string[] = [];
         if (kind !== c.kind) bad.push(`kind ${kind}`);
+        if (c.subject !== undefined && slots.subject !== c.subject) bad.push(`subject ${String(slots.subject)}`);
+        if (c.objects !== undefined && !setEq(slots.objects, c.objects)) bad.push(`objects ${JSON.stringify(slots.objects)}`);
+        if (c.when !== undefined) {
+          const union = [...scanTimeExpressions(c.q), ...(slots.when ?? [])].map(normalizeWhenPhrase);
+          const missing = c.when.filter((w) => !union.some((u) => u.includes(normalizeWhenPhrase(w))));
+          if (missing.length > 0) bad.push(`when missing ${JSON.stringify(missing)}`);
+        }
+        if (bad.length === 0) pass++;
+        else failures.push(`[routing] "${c.q}" -> ${bad.join('; ')} (raw ${text})`);
+      } catch (e) {
+        failures.push(`[routing] "${c.q}" error: ${(e as Error).message}`);
+      }
+    }
+  }
+  for (const c of COVERAGE_CASES) {
+    for (let i = 0; i < runs; i++) {
+      coverTotal++;
+      try {
+        const r = await chat({
+          model: MODEL,
+          messages: [{ role: 'system', content: buildCoveragePrompt(c.roster) }, { role: 'user', content: c.q }],
+          stream: false,
+          max_tokens: 200,
+          ...(TEMP === undefined ? {} : { temperature: TEMP }),
+          ...REASONING,
+          response_format: { type: 'json_schema', json_schema: { name: 'cover', schema: buildCoverageSchema(c.roster), strict: true } },
+        });
+        const text = r.choices?.[0]?.message?.content ?? '';
+        const slots = deriveMonitorSlots(JSON.parse(text), c.roster);
+        const bad: string[] = [];
         if (c.monitors !== undefined && !setEq(slots.monitors, c.monitors)) bad.push(`monitors ${JSON.stringify(slots.monitors)}`);
         if (c.monitorsWithin !== undefined) {
           const within = (slots.monitors?.length ?? 0) > 0 && (slots.monitors ?? []).every((m) => c.monitorsWithin!.includes(m));
@@ -640,21 +685,14 @@ async function scoreParse(runs: number) {
         }
         if (c.noMatch !== undefined && slots.noMatch !== c.noMatch) bad.push(`noMatch ${String(slots.noMatch)}`);
         if (c.unpinned && (slots.monitors?.length ?? 0) > 0) bad.push(`pinned ${JSON.stringify(slots.monitors)}`);
-        if (c.subject !== undefined && slots.subject !== c.subject) bad.push(`subject ${String(slots.subject)}`);
-        if (c.objects !== undefined && !setEq(slots.objects, c.objects)) bad.push(`objects ${JSON.stringify(slots.objects)}`);
-        if (c.when !== undefined) {
-          const union = [...scanTimeExpressions(c.q), ...(slots.when ?? [])].map(normalizeWhenPhrase);
-          const missing = c.when.filter((w) => !union.some((u) => u.includes(normalizeWhenPhrase(w))));
-          if (missing.length > 0) bad.push(`when missing ${JSON.stringify(missing)} (union ${JSON.stringify(union)})`);
-        }
-        if (bad.length === 0) pass++;
-        else failures.push(`[parse] "${c.q}" [${c.roster.join(', ')}] -> ${bad.join('; ')} (raw ${text})`);
+        if (bad.length === 0) coverPass++;
+        else failures.push(`[coverage] "${c.q}" [${c.roster.join(', ')}] -> ${bad.join('; ')} (raw ${text})`);
       } catch (e) {
-        failures.push(`[parse] "${c.q}" error: ${(e as Error).message}`);
+        failures.push(`[coverage] "${c.q}" error: ${(e as Error).message}`);
       }
     }
   }
-  return { pass, total, failures };
+  return { pass, total, coverPass, coverTotal, failures };
 }
 
 const variant = process.argv[2] ?? 'baseline';
@@ -663,7 +701,8 @@ const started = Date.now();
 if (variant === 'parse') {
   const w = await scoreParse(runs);
   console.log(`\n=== parse via ${MODEL}, temp ${TEMP ?? 'default'} ===`);
-  console.log(`parse: ${w.pass}/${w.total}`);
+  console.log(`routing: ${w.pass}/${w.total}`);
+  console.log(`coverage: ${w.coverPass}/${w.coverTotal}`);
   for (const f of w.failures) console.log(`  ${f}`);
   process.exit(0);
 }

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -45,7 +45,7 @@ import { TOOLS, specializeToolSchemas, withServerArg } from '../../lib/assistant
 import { buildScopedServers } from '../../lib/assistant/scoped-servers';
 import { interpretWhen } from '../../lib/assistant/window-interpreter';
 import { extractTimeframes, buildTimeframeSystemLine } from '../../lib/assistant/timeframe-stage';
-import { getMonitorRoster, scanMonitorMentions, resolveMonitorMention, buildMonitorSystemLine } from '../../lib/assistant/monitor-stage';
+import { getMonitorRoster, scanMonitorMentions, resolveMonitorMention, resolveCoverage, buildMonitorSystemLine } from '../../lib/assistant/monitor-stage';
 import { planToolCalls, type PlannedToolCall } from '../../lib/assistant/plan';
 import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
 import { classifyRequest, buildNoToolPrompt, type RequestKind } from '../../lib/assistant/triage';
@@ -658,10 +658,9 @@ export function AskPanel() {
       const kind: RequestKind = verdict.kind;
       log.assistant('Request classified', LogLevel.DEBUG, {
         kind,
-        monitors: verdict.monitors,
-        noMatch: verdict.noMatch,
         subject: verdict.subject,
         objects: verdict.objects,
+        when: verdict.when,
       });
 
       // Every timeframe the question names is extracted and resolved BEFORE the
@@ -697,12 +696,19 @@ export function AskPanel() {
         ctx.resolvedTimeframes = resolved;
         turnSystem = `${system}\n${buildTimeframeSystemLine(phrases)}`;
 
-        // The camera slots become one system line, exactly like the
-        // timeframe line (refs #427, #432): resolved monitors pin their
+        // Coverage is its own focused model call (refs #438): judged inside
+        // the consolidated parse it failed live and every rewording rotated
+        // the failures; this call measures 8/8 on the same cases. It runs
+        // only when the deterministic scan found nothing, and a failure
+        // degrades to an unpinned turn. The slots become one system line,
+        // exactly like the timeframe line: resolved monitors pin their
         // monitorIds, a no-coverage place gets the do-not-attribute guard,
-        // no place adds nothing. The scan outvotes the model; a roster-less
-        // turn (group mode, fetch failure) resolves to none.
-        const resolution = resolveMonitorMention(monitorScanHits, verdict, monitorRoster);
+        // no place adds nothing.
+        const coverageSlots =
+          monitorScanHits.length === 0 && monitorRoster.length > 0
+            ? await resolveCoverage(text, monitorRoster, provider, controller.signal, collectTrace)
+            : {};
+        const resolution = resolveMonitorMention(monitorScanHits, coverageSlots, monitorRoster);
         const monitorLine = buildMonitorSystemLine(resolution);
         if (monitorLine) turnSystem = `${turnSystem}\n${monitorLine}`;
 

--- a/app/src/lib/assistant/__tests__/event-range.test.ts
+++ b/app/src/lib/assistant/__tests__/event-range.test.ts
@@ -283,3 +283,27 @@ describe('weekday ranges', () => {
     );
   });
 });
+
+/** Refs #438: calendar weeks were missing vocabulary, so "this week" forced
+ *  the model into date arithmetic. Monday-anchored, resolved in code;
+ *  NOW is Thursday 2026-07-16. */
+describe('calendar weeks', () => {
+  it('resolves this week from Monday through now', () => {
+    expect(at({ week: 'this' })).toEqual({
+      startDateTime: '2026-07-13 00:00:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+  });
+
+  it('resolves last week as the previous Monday through Sunday', () => {
+    expect(at({ week: 'last' })).toEqual({
+      startDateTime: '2026-07-06 00:00:00',
+      endDateTime: '2026-07-13 00:00:00',
+    });
+  });
+
+  it('rejects unknown week values and mixing with other shapes', () => {
+    expect(at({ week: 'next' })).toHaveProperty('error');
+    expect(at({ week: 'this', daysAgo: 1 })).toHaveProperty('error');
+  });
+});

--- a/app/src/lib/assistant/__tests__/monitor-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/monitor-stage.test.ts
@@ -124,3 +124,66 @@ describe('buildMonitorSystemLine', () => {
     expect(buildMonitorSystemLine({ kind: 'none' })).toBe('');
   });
 });
+
+import { resolveCoverage, buildCoveragePrompt, buildCoverageSchema, deriveMonitorSlots } from '../monitor-stage';
+import type { AssistantProvider } from '../types';
+import { vi } from 'vitest';
+
+/**
+ * The dedicated coverage call (refs #438). Judged inside the consolidated
+ * parse prompt, place coverage failed live twice ("rear of my house" ->
+ * NO_MATCH with a Backyard camera present) and every rewording rotated the
+ * failures; the same model on this focused prompt measures 8/8 across every
+ * failure case. One question per judgment.
+ */
+describe('coverage call', () => {
+  const roster = [
+    { id: '2', name: 'Backyard(JPEG)' },
+    { id: '3', name: 'FrontDoor' },
+  ];
+
+  it('sends the focused prompt and constrained schema, deriving the slots', async () => {
+    const provider = {
+      complete: vi.fn().mockResolvedValue({ text: '{"place":"rear of my house","covered":true,"monitors":["Backyard(JPEG)"]}' }),
+    } as unknown as AssistantProvider;
+    const slots = await resolveCoverage('how was the rear of my house all this week?', roster, provider, new AbortController().signal);
+
+    const [system, question, , schema] = vi.mocked(provider.complete).mock.calls[0];
+    expect(system).toBe(buildCoveragePrompt(roster.map((m) => m.name)));
+    expect(system).toContain('Backyard(JPEG), FrontDoor');
+    expect(question).toBe('how was the rear of my house all this week?');
+    expect(schema).toEqual(buildCoverageSchema(roster.map((m) => m.name)));
+    expect(slots).toEqual({ monitors: ['Backyard(JPEG)'] });
+  });
+
+  it('degrades to empty slots when the call fails', async () => {
+    const provider = { complete: vi.fn().mockRejectedValue(new Error('offline')) } as unknown as AssistantProvider;
+    await expect(resolveCoverage('q', roster, provider, new AbortController().signal)).resolves.toEqual({});
+  });
+});
+
+/** The derivation guards live on, in code: they are bookkeeping over the
+ *  constrained reply, not language rules (refs #430, #432, #438). */
+describe('deriveMonitorSlots', () => {
+  const names = ['FrontDoor', 'Garage Outdoor'];
+
+  it('maps covered names, derives noMatch, and drops junk', () => {
+    expect(deriveMonitorSlots({ place: 'front door', covered: true, monitors: ['FrontDoor'] }, names)).toEqual({
+      monitors: ['FrontDoor'],
+    });
+    expect(deriveMonitorSlots({ place: 'basement stairs', covered: false, monitors: [] }, names)).toEqual({
+      noMatch: true,
+    });
+    expect(deriveMonitorSlots({ place: '', covered: false, monitors: [] }, names)).toEqual({ monitors: [] });
+    expect(deriveMonitorSlots({ place: 'x', covered: true, monitors: ['Bogus'] }, names)).toEqual({});
+  });
+
+  it('keeps the contradiction and whole-roster guards', () => {
+    expect(deriveMonitorSlots({ place: 'front door', covered: false, monitors: ['FrontDoor'] }, names)).toEqual({});
+    expect(deriveMonitorSlots({ place: 'front door', covered: true, monitors: names }, names)).toEqual({});
+  });
+
+  it('treats a time-word place as no place', () => {
+    expect(deriveMonitorSlots({ place: 'today', covered: false, monitors: [] }, names)).toEqual({ monitors: [] });
+  });
+});

--- a/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
@@ -407,3 +407,22 @@ describe('extractTimeframes with parse-stated phrases', () => {
     expect(result.phrases).toEqual(['today']);
   });
 });
+
+/** Refs #438: containment absorbs a contained phrase only when its container
+ *  actually resolved. "all this week" once swallowed the scan-vouched "this
+ *  week" and then failed to interpret, leaving the turn with nothing. */
+describe('resolution-aware containment', () => {
+  beforeEach(() => resetWindowInterpreterCacheForTests());
+
+  it('keeps the contained scan phrases when the compound fails to resolve', async () => {
+    const p = makeProvider(
+      () => '',
+      (phrase) => (phrase === 'at lunch 5 days ago' ? 'garbage' : '{"daysAgo":5}'),
+    );
+    const result = await extractTimeframes('who came at lunch 5 days ago', p, NOW, TZ, signal(), [
+      'at lunch 5 days ago',
+    ]);
+    expect(result.phrases).toEqual(['lunch', '5 days ago']);
+    expect(result.abstained).toBe(false);
+  });
+});

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -175,12 +175,13 @@ describe('classifyRequest inside a server group', () => {
 });
 
 /**
- * The parse dimension (refs #427, #430, #432). When the caller hands the
- * roster (and the label vocabulary), the same triage round parses the whole
- * question into slots: which cameras a place means (a SET, because "front of
- * my house" means both front cameras), what the question is about, and which
- * recorded labels it asks after ("folks" means person, in any language).
- * Everything is an enum or a copied string; every derivation happens in code.
+ * The parse dimension (refs #432, #438). With a roster and the label
+ * vocabulary, the triage round parses ROUTING slots: subject, objects
+ * ("folks" means person, in any language), and the verbatim time phrases.
+ * Camera coverage is deliberately NOT here any more: judged inside this
+ * consolidated prompt it failed live twice and every wording rotated the
+ * failures; a dedicated coverage call (monitor-stage.ts) measures 8/8 on
+ * the same cases. Everything here is an enum or a copied string.
  */
 describe('classifyRequest with a roster and vocabulary', () => {
   const roster = ['FrontDoor', 'Front Yard', 'Garage Outdoor'];
@@ -188,29 +189,29 @@ describe('classifyRequest with a roster and vocabulary', () => {
   const ask = (provider: AssistantProvider, question: string) =>
     classifyRequest(provider, question, new AbortController().signal, undefined, undefined, [], roster, labels);
 
-  it('constrains monitors, subject, and objects to the real values', async () => {
+  it('constrains subject and objects to the real values and copies when', async () => {
     const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"front of my house","covered":true,"monitors":["FrontDoor","Front Yard"],"subject":"events","objects":["person"]}',
+      '{"kind":"ZONEMINDER","subject":"events","objects":["person"],"when":["between mon and tue"]}',
     );
     const verdict = await ask(provider, 'How may folks came to the front of my house between mon and tue?');
 
     const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
-    expect(system).toContain('FrontDoor, Front Yard, Garage Outdoor');
     expect(system).toContain('car, person, truck');
+    expect(system).not.toContain('"covered"');
     expect(schema).toMatchObject({
       properties: {
-        monitors: { type: 'array', items: { enum: roster } },
         subject: { enum: ['events', 'monitors', 'server', 'groups', 'other'] },
         objects: { type: 'array', items: { enum: labels } },
-        covered: { type: 'boolean' },
+        when: { type: 'array', items: { type: 'string' } },
       },
-      required: ['kind', 'place', 'covered', 'monitors', 'subject', 'objects', 'when'],
+      required: ['kind', 'subject', 'objects', 'when'],
     });
+    expect((schema as { properties: object }).properties).not.toHaveProperty('monitors');
     expect(verdict).toEqual({
       kind: 'zoneminder',
-      monitors: ['FrontDoor', 'Front Yard'],
       subject: 'events',
       objects: ['person'],
+      when: ['between mon and tue'],
     });
   });
 
@@ -219,79 +220,36 @@ describe('classifyRequest with a roster and vocabulary', () => {
     const verdict = await classifyRequest(provider, 'hello', new AbortController().signal);
 
     const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
-    expect(system).not.toContain("This system's cameras are");
+    expect(system).not.toContain('Detected object labels');
     expect(schema).toMatchObject({ required: ['kind'] });
-    expect((schema as { properties: object }).properties).not.toHaveProperty('monitors');
     expect(verdict).toEqual({ kind: 'chat' });
-  });
-
-  // noMatch is derived in code from place + covered, never decoded from a
-  // name enum: asked to choose a name directly, the model substituted the
-  // nearest camera for a place the list lacks (measured 12/16).
-  it('derives noMatch when a named place is covered by no camera', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"basement stairs","covered":false,"monitors":[],"subject":"events","objects":[]}',
-    );
-    const verdict = await ask(provider, 'who was on the basement stairs');
-    expect(verdict).toEqual({ kind: 'zoneminder', noMatch: true, subject: 'events', objects: [] });
-  });
-
-  it('derives an empty monitor set when the question names no place', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"","covered":false,"monitors":[],"subject":"events","objects":[]}',
-    );
-    const verdict = await ask(provider, 'summarize today');
-    expect(verdict).toEqual({ kind: 'zoneminder', monitors: [], subject: 'events', objects: [] });
-  });
-
-  // Refs #430: coverage denied while real names are filled in is uncertainty;
-  // neither a pin nor a no-coverage claim is safe, so both slots stay unset.
-  it('resolves a covered:false verdict that still names real monitors to unset', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"front of my door","covered":false,"monitors":["FrontDoor"],"subject":"events","objects":["person"]}',
-    );
-    const verdict = await ask(provider, 'how many people came to the front of my door yesterday?');
-    expect(verdict).toEqual({ kind: 'zoneminder', subject: 'events', objects: ['person'] });
-  });
-
-  // The whole roster is not a pin: it equals an unpinned query, and it is
-  // how a false cover manifests (refs #434).
-  it('leaves monitors unset when the model selects every camera', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"front door","covered":true,"monitors":["FrontDoor","Garage Outdoor"],"subject":"events","objects":["person"],"when":["yesterday"]}',
-    );
-    const verdict = await classifyRequest(
-      provider,
-      'how many people came to my front door yesterday',
-      new AbortController().signal,
-      undefined,
-      undefined,
-      [],
-      ['FrontDoor', 'Garage Outdoor'],
-      ['person'],
-    );
-    expect(verdict.monitors).toBeUndefined();
-    expect(verdict.noMatch).toBeUndefined();
   });
 
   // An unconstrained backend can reply anything; values outside the enums
   // are dropped, never trusted.
-  it('drops monitors, subjects, and objects outside the enums', async () => {
+  it('drops subjects and objects outside the enums', async () => {
     const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"backyard","covered":true,"monitors":["Backyard"],"subject":"weather","objects":["unicorn"]}',
+      '{"kind":"ZONEMINDER","subject":"weather","objects":["unicorn"],"when":[]}',
     );
     const verdict = await ask(provider, 'anything in the backyard');
-    expect(verdict).toEqual({ kind: 'zoneminder', objects: [] });
+    expect(verdict).toEqual({ kind: 'zoneminder', objects: [], when: [] });
   });
 
-  // A place that is only time words is no place: "summarize today" once
-  // copied "today" into place and turned into a false no-coverage claim.
-  it('does not derive noMatch from a place that is only time words', async () => {
+  // Refs #436: selecting the whole vocabulary is the creep signature.
+  it('derives no filter when the model selects every recorded label', async () => {
     const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"today","covered":false,"monitors":[],"subject":"events","objects":[]}',
+      '{"kind":"ZONEMINDER","subject":"events","objects":["person","car","truck"],"when":["over the week"]}',
     );
-    const verdict = await ask(provider, 'summarize today');
-    expect(verdict).toEqual({ kind: 'zoneminder', monitors: [], subject: 'events', objects: [] });
+    const verdict = await ask(provider, 'how busy was the front of my abode over the week?');
+    expect(verdict.objects).toEqual([]);
+  });
+
+  it('keeps a proper subset as the filter', async () => {
+    const provider = providerSaying(
+      '{"kind":"ZONEMINDER","subject":"events","objects":["car","truck"],"when":["today"]}',
+    );
+    const verdict = await ask(provider, 'any vehicles today');
+    expect(verdict.objects).toEqual(['car', 'truck']);
   });
 });
 
@@ -300,7 +258,7 @@ describe('classifyRequest with a roster and vocabulary', () => {
 describe('classifyRequest when-phrase slot', () => {
   it('asks for and returns verbatim time phrases with the roster', async () => {
     const provider = providerSaying(
-      '{"kind":"ZONEMINDER","place":"","covered":false,"monitors":[],"subject":"events","objects":[],"when":["between mon and tue"]}',
+      '{"kind":"ZONEMINDER","subject":"events","objects":[],"when":["between mon and tue"]}',
     );
     const verdict = await classifyRequest(
       provider,
@@ -316,14 +274,14 @@ describe('classifyRequest when-phrase slot', () => {
     expect(system).toContain('"when"');
     expect(schema).toMatchObject({
       properties: { when: { type: 'array', items: { type: 'string' } } },
-      required: ['kind', 'place', 'covered', 'monitors', 'subject', 'objects', 'when'],
+      required: ['kind', 'subject', 'objects', 'when'],
     });
     expect(verdict.when).toEqual(['between mon and tue']);
   });
 
   it('drops junk when values and leaves the slot unset without a roster', async () => {
     const junk = providerSaying(
-      '{"kind":"ZONEMINDER","place":"","covered":false,"monitors":[],"subject":"events","objects":[],"when":["", 42]}',
+      '{"kind":"ZONEMINDER","subject":"events","objects":[],"when":["", 42]}',
     );
     const verdict = await classifyRequest(
       junk,

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -180,7 +180,8 @@ describe('WINDOW_SCHEMA', () => {
     const rolling = branches.find((b) => b.required.includes('lastCount'));
     expect(rolling?.required).toEqual(expect.arrayContaining(['lastCount', 'lastUnit']));
     const weekendBranch = branches.find((b) => b.required.includes('weekend'));
-    expect(Object.keys(weekendBranch?.properties ?? {})).toEqual(['weekend']);
+    // 'meaning' is the universal self-explanation (refs #438), not a day field.
+    expect(Object.keys(weekendBranch?.properties ?? {})).toEqual(['meaning', 'weekend']);
   });
 
   it('constrains weekend to a string enum the model is exact on', () => {
@@ -242,7 +243,7 @@ describe('selectBranches', () => {
   it('offers only the both-ends span for a bare month or season', () => {
     for (const phrase of ['april', 'in april', 'this summer']) {
       const sets = requiredSets(selectBranches(phrase));
-      expect(sets).toEqual([['fromDate', 'toDate']]);
+      expect(sets).toEqual([['fromDate', 'meaning', 'toDate']]);
     }
   });
 
@@ -291,5 +292,26 @@ describe('weekday-range branch', () => {
 
   it('teaches the field in the prompt', () => {
     expect(buildInterpreterPrompt(new Date('2026-07-16T14:30:00Z'), 'UTC')).toContain('fromWeekday');
+  });
+});
+
+/** Refs #438: the interrogation redesign. Every branch decodes a required
+ *  "meaning" restatement FIRST (measured: "all this week" decoded none:true
+ *  without it and a real window with it), and the calendar-week branch
+ *  exists so week phrases never need model date arithmetic. */
+describe('interrogation redesign', () => {
+  it('requires meaning first in every branch', () => {
+    for (const b of WINDOW_SCHEMA.anyOf as Array<{ properties: Record<string, unknown>; required: string[] }>) {
+      expect(Object.keys(b.properties)[0]).toBe('meaning');
+      expect(b.required[0]).toBe('meaning');
+    }
+  });
+
+  it('has a calendar-week branch and teaches both in the prompt', () => {
+    const branches = WINDOW_SCHEMA.anyOf as Array<{ required: string[] }>;
+    expect(branches.some((b) => b.required.includes('week'))).toBe(true);
+    const prompt = buildInterpreterPrompt(new Date('2026-07-16T14:30:00Z'), 'UTC');
+    expect(prompt).toContain('"meaning"');
+    expect(prompt).toContain('"week"');
   });
 });

--- a/app/src/lib/assistant/event-range.ts
+++ b/app/src/lib/assistant/event-range.ts
@@ -52,6 +52,10 @@ export interface WindowFields {
    *  (refs #434). */
   fromWeekday?: string;
   toWeekday?: string;
+  /** A calendar week, Monday-anchored, resolved in code (refs #438): "this"
+   *  is Monday 00:00 through now, "last" the previous Monday through
+   *  Sunday. Distinct from a rolling lastUnit:"week", which ends now. */
+  week?: string;
   /** Most recent past day with this day-of-month number (1-31): "the 21st".
    *  Code finds the date, exactly as `weekday` finds the most recent weekday,
    *  because a small model resolves a bare ordinal to the wrong ISO date. */
@@ -142,15 +146,29 @@ export function resolveWindow(
   now: Date,
   timezone: string,
 ): ResolvedEventRange | { error: string } | undefined {
-  const { lastCount, lastUnit, daysAgo, weekday, fromWeekday, toWeekday, dayOfMonth, weekend, date, fromDate, toDate, fromTime, toTime } = fields;
+  const { lastCount, lastUnit, daysAgo, weekday, fromWeekday, toWeekday, week, dayOfMonth, weekend, date, fromDate, toDate, fromTime, toTime } = fields;
   const dayPickers = [daysAgo !== undefined, weekday !== undefined, dayOfMonth !== undefined, date !== undefined].filter(Boolean).length;
   const rolling = lastCount !== undefined || lastUnit !== undefined;
   const ranged = fromDate !== undefined || toDate !== undefined;
   const weekendShape = weekend !== undefined;
   const weekdayRange = fromWeekday !== undefined || toWeekday !== undefined;
+  const weekShape = week !== undefined;
 
-  if ([rolling, dayPickers > 0, ranged, weekendShape, weekdayRange].filter(Boolean).length > 1) {
-    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, dayOfMonth, or date), a weekday span (fromWeekday+toWeekday), a weekend, or a span (fromDate/toDate).' };
+  if ([rolling, dayPickers > 0, ranged, weekendShape, weekdayRange, weekShape].filter(Boolean).length > 1) {
+    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, dayOfMonth, or date), a weekday span (fromWeekday+toWeekday), a calendar week, a weekend, or a span (fromDate/toDate).' };
+  }
+
+  if (weekShape) {
+    if (week !== 'this' && week !== 'last') {
+      return { error: `week must be "this" or "last". Received "${String(week)}".` };
+    }
+    const zonedToday = startOfDay(toZonedTime(now, timezone));
+    const daysSinceMonday = (toZonedTime(now, timezone).getDay() + 6) % 7;
+    const monday = subDays(zonedToday, daysSinceMonday + (week === 'last' ? 7 : 0));
+    const start = fromZonedTime(monday, timezone);
+    const endRaw = fromZonedTime(subDays(monday, -7), timezone);
+    const end = endRaw.getTime() > now.getTime() ? now : endRaw;
+    return { startDateTime: formatForZm(start, timezone), endDateTime: formatForZm(end, timezone) };
   }
   if (dayPickers > 1) {
     return { error: 'Send only one of daysAgo, weekday, dayOfMonth, or date.' };

--- a/app/src/lib/assistant/monitor-stage.ts
+++ b/app/src/lib/assistant/monitor-stage.ts
@@ -20,6 +20,10 @@ import { getMonitors } from '../../api/monitors';
 import { getSession } from '../../services/sessions';
 import { asProfileId } from '../../api/types';
 import { normalizeMonitorName } from './monitor-ref';
+import { scanTimeExpressions } from './timeframe-stage';
+import { sanitizeModelText } from './sanitize';
+import { isAbortError } from '../is-abort-error';
+import type { AssistantProvider, TraceEntry } from './types';
 import { ASSISTANT } from '../zmninja-ng-constants';
 import { log, LogLevel } from '../logger';
 
@@ -154,4 +158,87 @@ export function buildMonitorSystemLine(resolution: MonitorMentionResolution): st
     );
   }
   return '';
+}
+
+/** Model-facing (rule 5 exempt): the DEDICATED coverage interrogation
+ *  (refs #438). Judged inside the consolidated parse prompt, place coverage
+ *  failed live twice and every rewording rotated the failures; this focused
+ *  prompt, same model, measures 8/8 across all of them. One question per
+ *  judgment. */
+export function buildCoveragePrompt(names: readonly string[]): string {
+  return [
+    'You match a place in one message to the security cameras of a home. Reply with ONLY one JSON object.',
+    `Cameras: ${names.join(', ')}.`,
+    '"place": the exact place or camera words the message contains ("" when none; time words such as today or yesterday are not places).',
+    '"covered": true when a listed camera means that place, in any language, or the place is an area containing a camera\'s own area; false when "place" is "" or no listed camera truly watches it: a camera elsewhere on the property is false, never the closest one.',
+    '"monitors": every listed camera that watches the place or sits inside it ([] when "covered" is false).',
+  ].join('\n');
+}
+
+/** The coverage reply as a schema: monitors constrained to the real names,
+ *  so nothing can be hallucinated. */
+export function buildCoverageSchema(names: readonly string[]): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      place: { type: 'string' },
+      covered: { type: 'boolean' },
+      monitors: { type: 'array', items: { type: 'string', enum: [...names] } },
+    },
+    required: ['place', 'covered', 'monitors'],
+    additionalProperties: false,
+  };
+}
+
+/** The camera slots out of one coverage reply, every guard in code: names
+ *  filtered to the roster; a contradiction (covered false with real names)
+ *  and a whole-roster selection both leave the slots unset (refs #430,
+ *  #432); a place that is only time words is no place. Bookkeeping over the
+ *  constrained reply, not language rules. */
+export function deriveMonitorSlots(
+  raw: { place?: unknown; covered?: unknown; monitors?: unknown },
+  names: readonly string[],
+): ParsedMonitorSlots {
+  const named = Array.isArray(raw.monitors)
+    ? raw.monitors.filter((m): m is string => typeof m === 'string' && names.includes(m))
+    : undefined;
+  if (raw.covered === true && named && named.length > 0) {
+    return named.length < names.length ? { monitors: named } : {};
+  }
+  if (raw.covered === false) {
+    if (named && named.length > 0) return {};
+    const place = typeof raw.place === 'string' ? raw.place : '';
+    const rest = scanTimeExpressions(place).reduce((text, phrase) => text.replace(phrase, ' '), place);
+    return /[\p{L}\p{N}]/u.test(rest) ? { noMatch: true } : { monitors: [] };
+  }
+  return {};
+}
+
+/**
+ * One focused model call resolving which cameras the question's place means
+ * (refs #438). Runs only when the deterministic scan found nothing; a failed
+ * call degrades to empty slots, which is exactly the pre-coverage behavior.
+ */
+export async function resolveCoverage(
+  question: string,
+  roster: MonitorRosterEntry[],
+  provider: AssistantProvider,
+  signal: AbortSignal,
+  onTrace?: (entry: TraceEntry) => void,
+): Promise<ParsedMonitorSlots> {
+  if (roster.length === 0) return {};
+  const names = roster.map((entry) => entry.name);
+  try {
+    const result = await provider.complete(buildCoveragePrompt(names), question, signal, buildCoverageSchema(names));
+    if (result.exchange) {
+      onTrace?.({ kind: 'exchange', exchange: { ...result.exchange, backend: `${result.exchange.backend} (coverage)` } });
+    }
+    return deriveMonitorSlots(JSON.parse(sanitizeModelText(result.text, 'coverage')) as Record<string, unknown>, names);
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    log.assistant('Coverage call failed; running unpinned', LogLevel.WARN, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {};
+  }
 }

--- a/app/src/lib/assistant/time-eval-cases.ts
+++ b/app/src/lib/assistant/time-eval-cases.ts
@@ -104,6 +104,12 @@ export const TIME_INTERPRET_CASES: TimeInterpretCase[] = [
   // the model never computes the dates; checked on the resolved range.
   { phrase: 'between mon and tue', cls: 'weekday', ok: (_f, r) => startsOn(r, '2026-07-13') },
   { phrase: 'from friday to sunday', cls: 'weekday', ok: (_f, r) => startsOn(r, '2026-07-17') },
+  // calendar weeks (refs #438): the week field exists so "this week" never
+  // needs model date arithmetic; the rolling reading stays acceptable where
+  // both are defensible.
+  { phrase: 'this week', cls: 'weekday', ok: (f, r) => f.week === 'this' || startsOn(r, '2026-07-13') },
+  { phrase: 'all this week', cls: 'weekday', ok: (f, r) => f.week === 'this' || startsOn(r, '2026-07-13') },
+  { phrase: 'last week', cls: 'weekday', ok: (f, r) => f.week === 'last' || (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) || startsOn(r, '2026-07-06') },
   // lunch is a part-of-day band (refs #434)
   { phrase: 'at lunch 5 days ago', cls: 'part-of-day', ok: (f, r) => startsOn(r, '2026-07-14') && band(f.fromTime, '10:00', '12:00') && band(f.toTime, '12:00', '14:00') },
   // weekend (code computes the two dates from the `weekend` field; resolved
@@ -130,7 +136,7 @@ export const TIME_INTERPRET_CASES: TimeInterpretCase[] = [
   { phrase: 'all time', cls: 'no-time', ok: (f) => f.none === true || Object.keys(f).length === 0 },
   { phrase: 'ever', cls: 'no-time', ok: (f) => f.none === true || Object.keys(f).length === 0 },
   // non-English (de / es / fr)
-  { phrase: 'letzte Woche', cls: 'non-english', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) },
+  { phrase: 'letzte Woche', cls: 'non-english', ok: (f) => (f.lastUnit === 'week' && f.lastCount === 1) || (f.lastUnit === 'day' && f.lastCount === 7) || f.week === 'last' },
   { phrase: 'ayer', cls: 'non-english', ok: (_f, r) => startsOn(r, '2026-07-18') },
   { phrase: 'ce matin', cls: 'non-english', ok: (f, r) => startsOn(r, '2026-07-19') && band(f.fromTime, '05:00', '08:00') && band(f.toTime, '11:00', '13:00') },
   { phrase: 'el fin de semana pasado', cls: 'non-english', ok: (_f, r) => startsOn(r, '2026-07-11') && endsOnDate(r, '2026-07-13') },
@@ -173,6 +179,7 @@ export const TIME_EXTRACT_CASES: TimeExtractCase[] = [
   { question: 'who came by between mon and tue?', expect: ['between mon and tue'] },
   { question: 'How may folks came to the front of my house between mon and tue?', expect: ['between mon and tue'] },
   { question: 'who came at lunch 5 days ago', expect: ['lunch', '5 days ago'] },
+  { question: 'how was the rear of my house all this week?', expect: ['all this week'] },
   { question: 'was war letzte Woche bei mir los', expect: ['letzte woche'] },
   { question: 'what cameras do I have', none: true },
   { question: 'is the server ok', none: true },

--- a/app/src/lib/assistant/timeframe-stage.ts
+++ b/app/src/lib/assistant/timeframe-stage.ts
@@ -273,24 +273,33 @@ export async function extractTimeframes(
     seen.add(key);
     deduped.push(phrase);
   }
-  // Containment dedup (refs #434): the scan emits the halves of a compound
-  // ("lunch", "5 days ago") while the model copies it whole ("at lunch 5
-  // days ago"); querying both the whole day and the band would double the
-  // fan-out, so a phrase contained in a longer one is absorbed by it.
+  const namedTime = deduped.length > 0;
+
+  const resolvedByKey = new Map<string, WindowFields>();
+  for (const phrase of namedTime ? deduped : ['today']) {
+    const fields = await interpretWhen(phrase, provider, now, timezone, signal);
+    if ('error' in fields && fields.error) continue;
+    resolvedByKey.set(normalizeWhenPhrase(phrase), fields as WindowFields);
+  }
+
+  // Containment dedup, resolution-aware (refs #434, #438): the scan emits
+  // the halves of a compound ("lunch", "5 days ago") while the model copies
+  // it whole; querying both the whole day and the band would double the
+  // fan-out, so a contained phrase is absorbed - but ONLY by a container
+  // that actually resolved. "all this week" once swallowed the scan-vouched
+  // "this week" and then failed to interpret, leaving the turn nothing.
   const union = deduped.filter((phrase) => {
     const key = normalizeWhenPhrase(phrase);
     return !deduped.some((other) => {
       const otherKey = normalizeWhenPhrase(other);
-      return otherKey !== key && otherKey.includes(key);
+      return otherKey !== key && otherKey.includes(key) && resolvedByKey.has(otherKey);
     });
   });
-  const namedTime = union.length > 0;
 
   const resolved: ResolvedTimeframe[] = [];
   for (const phrase of namedTime ? union : ['today']) {
-    const fields = await interpretWhen(phrase, provider, now, timezone, signal);
-    if ('error' in fields && fields.error) continue;
-    resolved.push({ phrase, fields: fields as WindowFields });
+    const fields = resolvedByKey.get(normalizeWhenPhrase(phrase));
+    if (fields !== undefined) resolved.push({ phrase, fields });
   }
 
   // Neither path named a time: the default period, kept even if it failed to

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -19,7 +19,6 @@
 import type { AssistantMessage, AssistantProvider, AssistantStatus, TraceEntry } from './types';
 import { sanitizeModelText } from './sanitize';
 import { isAbortError } from '../is-abort-error';
-import { scanTimeExpressions } from './timeframe-stage';
 
 export type RequestKind = 'zoneminder' | 'chat' | 'action';
 
@@ -29,20 +28,14 @@ export type QuerySubject = 'events' | 'monitors' | 'server' | 'groups' | 'other'
 
 const QUERY_SUBJECTS: readonly QuerySubject[] = ['events', 'monitors', 'server', 'groups', 'other'];
 
-/** What one triage round decided (refs #427, #432): the request kind, and,
- *  when the caller handed it the roster (and label vocabulary), the parsed
- *  slots. Every slot is validated here and absent rather than guessed:
- *  `monitors` only holds real roster names (a SET, because "front of my
- *  house" means several cameras), `noMatch` is set only for a place no
- *  camera covers, `objects` only holds recorded labels. An unconstrained
- *  backend can reply anything, so values outside the enums are dropped. */
+/** What one triage round decided (refs #432, #438): the request kind and
+ *  the ROUTING slots, each validated here and absent rather than guessed.
+ *  Camera coverage is deliberately not part of this round any more: judged
+ *  inside this consolidated prompt it failed live and every rewording
+ *  rotated the failures; the dedicated coverage call (monitor-stage.ts)
+ *  measures 8/8 on the same cases. One question per judgment. */
 export interface TriageVerdict {
   kind: RequestKind;
-  /** Cameras the question is about, roster-validated. [] = no place named.
-   *  Absent = no roster, unparseable, or a contradictory verdict. */
-  monitors?: string[];
-  /** The question names a place no listed camera covers. */
-  noMatch?: boolean;
   subject?: QuerySubject;
   /** Recorded labels the question asks about ("folks" -> person). */
   objects?: string[];
@@ -103,7 +96,8 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
   '  cameras, monitors, events, detections, recordings, activity, or server health, or to be taken to a',
   '  screen in the app. Questions and commands alike, in any language: "summarize <any period>",',
   '  "what happened <any period>", "how many <thing> came <any period>", "did anyone come by",',
-  '  "show me <camera>".',
+  '  "show me <camera>". A message that mixes a greeting or small talk with such a question is',
+  '  still ZONEMINDER: any part asking about their place decides.',
   // Refs #337, observed live: "compare warehouse and cabin" classified CHAT, and
   // the tool-less turn answered it with a greeting. The names of the user's
   // own servers are the one piece of context that decides such a message, and
@@ -118,32 +112,17 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
   'CHAT - anything NOT about this system: greetings, thanks, small talk, questions about you, general',
   '  knowledge, or summarizing something that is not this system\'s activity.',
   '',
-  // The parse block (refs #427, #430, #432). This round is the one model
-  // call that can map the user's words onto their own camera names and this
-  // install's label vocabulary, in any language; the schemas constrain every
-  // field to real values so nothing can be hallucinated (buildTriageSchema),
-  // and every derivation happens in code (parseTriageSlots). Appended only
-  // when the caller has a roster, so the roster-less prompt stays
-  // byte-identical to what the eval harness scores.
+  // The routing parse block (refs #432, #438), appended only when the
+  // caller has a roster (a configured install), so the roster-less prompt
+  // stays byte-identical to what the eval harness scores. Subject, objects,
+  // and the verbatim time phrases are all enums or copies; the place and
+  // coverage judgment lives in its own focused call (monitor-stage.ts),
+  // where the same model measures 8/8 on the cases this consolidated
+  // prompt failed.
   ...(monitors.length > 0
     ? [
-        `This system's cameras are: ${monitors.join(', ')}.`,
         ...(labels.length > 0 ? [`Detected object labels on this installation: ${labels.join(', ')}.`] : []),
         'Also fill these fields about the message, judged by meaning in any language:',
-        // Copy-then-judge (refs #265's copy-interpret pattern, applied here
-        // after direct classification force-picked the nearest camera):
-        // "place" makes the model write down what the message actually named,
-        // and "covered" asks the yes/no question on its own before any name
-        // can be decoded. Asked to pick from the list directly, the model
-        // substituted the nearest camera for a place the list lacks.
-        '"place": the exact place or camera words it names ("" when it names none; time words such as today',
-        'or yesterday are not places).',
-        '"covered": true when a listed camera means that place, or when the place is a whole area that',
-        "contains a listed camera's own area (the whole house contains its cameras); false when \"place\" is",
-        '"" or when no listed camera means or sits inside it. A place that is only one PART of the property',
-        '(one door, one corner, one room) is covered only by a camera that means that exact place: nearby',
-        'or merely similar is still false, never the closest name.',
-        '"monitors": every listed camera that means the place or watches part of it ([] when "covered" is false).',
         '"subject": what the message asks about. events - what happened, who or what came by, was seen,',
         "detected, or counted. monitors - the camera list or a camera's state. server - health or whether",
         'the system is up. groups - monitor groups. other - anything else.',
@@ -153,11 +132,12 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
         ...(labels.length > 0
           ? [
               '"objects": every listed label the message asks about, judged by meaning ("folks" or "Leute" mean',
-              'person, "vehicles" means car and truck); [] when it asks about no particular thing.',
+              'person, "vehicles" means car and truck); [] when it asks about no particular thing - a summary,',
+              'recap, "how busy", or "what happened" question names none.',
             ]
           : []),
         '',
-        `Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "place", "covered", "monitors", "subject", "when"${labels.length > 0 ? ', and "objects"' : ''}.`,
+        `Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "subject", "when"${labels.length > 0 ? ', and "objects"' : ''}.`,
       ]
     : ['Reply with one word: ZONEMINDER, ACTION, or CHAT.']),
 ];
@@ -191,23 +171,13 @@ export function buildTriageSchema(monitors: readonly string[], labels: readonly 
     type: 'object',
     properties: {
       kind: { type: 'string', enum: ['ZONEMINDER', 'ACTION', 'CHAT'] },
-      // Decoded BEFORE `covered` and `monitors` on purpose (property order is
-      // generation order under constrained decoding): copying the message's
-      // own place words first puts the mismatch in front of the model.
-      place: { type: 'string' },
-      // The abstention as its own yes/no question. Asked to choose from the
-      // name enum directly, the model substituted the nearest camera for a
-      // place the list lacks, under three prompt wordings and both enum
-      // orders (12/16); the boolean is what made it abstain.
-      covered: { type: 'boolean' },
-      monitors: { type: 'array', items: { type: 'string', enum: [...monitors] } },
       subject: { type: 'string', enum: [...QUERY_SUBJECTS] },
       ...(labels.length > 0 ? { objects: { type: 'array', items: { type: 'string', enum: [...labels] } } } : {}),
       // Free strings by necessity (no enum can list every time phrase); the
       // timeframe stage's provenance filter distrusts them (refs #434).
       when: { type: 'array', items: { type: 'string' } },
     },
-    required: ['kind', 'place', 'covered', 'monitors', 'subject', ...(labels.length > 0 ? ['objects'] : []), 'when'],
+    required: ['kind', 'subject', ...(labels.length > 0 ? ['objects'] : []), 'when'],
     additionalProperties: false,
   };
 }
@@ -253,43 +223,13 @@ export function parseTriageSlots(
   labels: readonly string[] = [],
 ): Omit<TriageVerdict, 'kind'> {
   if (monitors.length === 0) return {};
-  let raw: { place?: unknown; covered?: unknown; monitors?: unknown; subject?: unknown; objects?: unknown; when?: unknown };
+  let raw: { subject?: unknown; objects?: unknown; when?: unknown };
   try {
     raw = JSON.parse(reply) as typeof raw;
   } catch {
     return {};
   }
   const slots: Omit<TriageVerdict, 'kind'> = {};
-
-  const named = Array.isArray(raw.monitors)
-    ? raw.monitors.filter((m): m is string => typeof m === 'string' && monitors.includes(m))
-    : undefined;
-  if (raw.covered === true && named && named.length > 0) {
-    // Selecting the ENTIRE roster pins nothing an unpinned query would not
-    // already cover, and it is the signature of a false cover: asked about a
-    // "front door" no camera means, the model answered covered:true with
-    // every camera, under two rule wordings (measured 2/2 at temp 0,
-    // refs #434). The slot stays unset and the turn runs unpinned, with no
-    // line asserting a place.
-    if (named.length < monitors.length) slots.monitors = named;
-  } else if (raw.covered === false) {
-    if (named && named.length > 0) {
-      // A contradiction (coverage denied while real roster names are filled
-      // in) is uncertainty, observed live: {"place":"front of my door",
-      // "covered":false,"monitor":"FrontDoor"} (refs #430). Neither a pin
-      // nor a no-coverage claim is safe, so both slots stay unset.
-    } else {
-      const place = typeof raw.place === 'string' ? raw.place : '';
-      // "summarize today" copied "today" into place (2/2 at temp 0), and the
-      // prompt's "time words are not places" line did not stop it. Decidable
-      // in code: strip every time expression the timeframe scan owns, and a
-      // place with nothing else left named no place at all.
-      const rest = scanTimeExpressions(place).reduce((text, phrase) => text.replace(phrase, ' '), place);
-      if (/[\p{L}\p{N}]/u.test(rest)) slots.noMatch = true;
-      else slots.monitors = [];
-    }
-  }
-
   if (typeof raw.subject === 'string' && (QUERY_SUBJECTS as readonly string[]).includes(raw.subject)) {
     slots.subject = raw.subject as QuerySubject;
   }
@@ -297,8 +237,7 @@ export function parseTriageSlots(
     const objects = raw.objects.filter((o): o is string => typeof o === 'string' && labels.includes(o));
     // Selecting the ENTIRE vocabulary is the objectType-creep signature
     // (observed live on "how busy...", refs #436), and as a filter it
-    // silently EXCLUDES events with no detection at all. Mirror of the
-    // whole-roster monitors rule: derive no filter instead.
+    // silently EXCLUDES events with no detection at all: derive no filter.
     slots.objects = labels.length > 1 && objects.length === labels.length ? [] : objects;
   }
   if (Array.isArray(raw.when)) {

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -51,11 +51,11 @@ import { isAbortError } from '../is-abort-error';
 export const WINDOW_SCHEMA: Record<string, unknown> = {
   anyOf: [
     // rolling span ending now: both halves are meaningless alone.
-    { type: 'object', properties: { lastCount: { type: 'number' }, lastUnit: { type: 'string', enum: [...WINDOW_UNITS] } }, required: ['lastCount', 'lastUnit'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, lastCount: { type: 'number' }, lastUnit: { type: 'string', enum: [...WINDOW_UNITS] } }, required: ['meaning', 'lastCount', 'lastUnit'], additionalProperties: false },
     // one calendar day ("yesterday").
-    { type: 'object', properties: { daysAgo: { type: 'number' } }, required: ['daysAgo'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, daysAgo: { type: 'number' } }, required: ['meaning', 'daysAgo'], additionalProperties: false },
     // one calendar day narrowed to a clock band ("this morning").
-    { type: 'object', properties: { daysAgo: { type: 'number' }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['daysAgo', 'fromTime', 'toTime'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, daysAgo: { type: 'number' }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['meaning', 'daysAgo', 'fromTime', 'toTime'], additionalProperties: false },
     // most recent such weekday, optionally narrowed to a clock band
     // ("on sunday", "last tuesday night"). The lone branch that KEEPS fromTime/
     // toTime optional: splitting it into a bare and a with-times branch (as the
@@ -64,28 +64,30 @@ export const WINDOW_SCHEMA: Record<string, unknown> = {
     // Unlike the day branches, the weekday word dominates the phrase, so the
     // model reads the split as license to stop early. FM wants required fields;
     // qwen needs this one optional; the 150/150 gate decides it.
-    { type: 'object', properties: { weekday: { type: 'string', enum: [...WEEKDAYS] }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['weekday'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, weekday: { type: 'string', enum: [...WEEKDAYS] }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['meaning', 'weekday'], additionalProperties: false },
+    // a calendar week, Monday-anchored; code works out the dates (refs #438).
+    { type: 'object', properties: { meaning: { type: 'string' }, week: { type: 'string', enum: ['this', 'last'] } }, required: ['meaning', 'week'], additionalProperties: false },
     // a span between two weekdays ("between mon and tue"); code works out the
     // dates, so the model never anchors the wrong calendar day (refs #434).
-    { type: 'object', properties: { fromWeekday: { type: 'string', enum: [...WEEKDAYS] }, toWeekday: { type: 'string', enum: [...WEEKDAYS] } }, required: ['fromWeekday', 'toWeekday'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, fromWeekday: { type: 'string', enum: [...WEEKDAYS] }, toWeekday: { type: 'string', enum: [...WEEKDAYS] } }, required: ['meaning', 'fromWeekday', 'toWeekday'], additionalProperties: false },
     // a bare ordinal day-of-month ("the 21st").
-    { type: 'object', properties: { dayOfMonth: { type: 'number' } }, required: ['dayOfMonth'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, dayOfMonth: { type: 'number' } }, required: ['meaning', 'dayOfMonth'], additionalProperties: false },
     // that ordinal narrowed to a clock band.
-    { type: 'object', properties: { dayOfMonth: { type: 'number' }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['dayOfMonth', 'fromTime', 'toTime'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, dayOfMonth: { type: 'number' }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['meaning', 'dayOfMonth', 'fromTime', 'toTime'], additionalProperties: false },
     // one explicit calendar date ("July 15").
-    { type: 'object', properties: { date: { type: 'string' } }, required: ['date'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, date: { type: 'string' } }, required: ['meaning', 'date'], additionalProperties: false },
     // that date narrowed to a clock band ("July 15 morning").
-    { type: 'object', properties: { date: { type: 'string' }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['date', 'fromTime', 'toTime'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, date: { type: 'string' }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['meaning', 'date', 'fromTime', 'toTime'], additionalProperties: false },
     // whole weekends ago; code computes the two dates.
-    { type: 'object', properties: { weekend: { type: 'string', enum: ['this', 'last', 'two-ago'] } }, required: ['weekend'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, weekend: { type: 'string', enum: ['this', 'last', 'two-ago'] } }, required: ['meaning', 'weekend'], additionalProperties: false },
     // calendar span, both ends inclusive ("april", "june 1 to 15").
-    { type: 'object', properties: { fromDate: { type: 'string' }, toDate: { type: 'string' } }, required: ['fromDate', 'toDate'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, fromDate: { type: 'string' }, toDate: { type: 'string' } }, required: ['meaning', 'fromDate', 'toDate'], additionalProperties: false },
     // calendar span open at the end ("since july 1").
-    { type: 'object', properties: { fromDate: { type: 'string' } }, required: ['fromDate'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, fromDate: { type: 'string' } }, required: ['meaning', 'fromDate'], additionalProperties: false },
     // calendar span open at the start ("until july 15").
-    { type: 'object', properties: { toDate: { type: 'string' } }, required: ['toDate'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, toDate: { type: 'string' } }, required: ['meaning', 'toDate'], additionalProperties: false },
     // no time limit at all.
-    { type: 'object', properties: { none: { type: 'boolean' } }, required: ['none'], additionalProperties: false },
+    { type: 'object', properties: { meaning: { type: 'string' }, none: { type: 'boolean' } }, required: ['meaning', 'none'], additionalProperties: false },
   ],
 };
 
@@ -240,6 +242,7 @@ export function buildInterpreterPrompt(now: Date, timezone: string): string {
     '- daysAgo: one calendar day. "today" -> {"daysAgo":0}. "yesterday" -> {"daysAgo":1}. "the day before yesterday" -> {"daysAgo":2}.',
     '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}; "last tuesday" -> {"weekday":"tuesday"}.',
     '- fromWeekday + toWeekday: a span between two weekdays, full names. "between mon and tue" -> {"fromWeekday":"monday","toWeekday":"tuesday"}; "from friday to sunday" -> {"fromWeekday":"friday","toWeekday":"sunday"}. Code works out the dates, so do NOT send fromDate/toDate for these.',
+    '- "week": a calendar week, Monday-anchored. "this week" or "all this week" -> {"week":"this"}; "last week" -> {"week":"last"}. Code works out the dates; never send fromDate/toDate for these.',
     '- dayOfMonth: a bare ordinal, just the number. "the 21st" -> {"dayOfMonth":21}; "on the 3rd" -> {"dayOfMonth":3}. Code picks the most recent past such day, so do NOT work out the date yourself.',
     '- weekend: which past weekend, ONLY when the phrase literally says "weekend". "this weekend" -> {"weekend":"this"}; "last weekend" -> {"weekend":"last"}; "two weekends ago" -> {"weekend":"two-ago"}. Code works out the two dates.',
     '- date: one explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
@@ -250,6 +253,11 @@ export function buildInterpreterPrompt(now: Date, timezone: string): string {
     'Keep BOTH halves of a compound phrase, in any language: a day word and a part of the day both survive. "yesterday evening" -> {"daysAgo":1,"fromTime":"18:00","toTime":"23:59"}; "hier apres-midi" -> {"daysAgo":1,"fromTime":"12:00","toTime":"18:00"}.',
     'The phrase may be in any language: "letzte Woche" -> {"lastCount":1,"lastUnit":"week"}; "ayer" -> {"daysAgo":1}; "ce matin" -> {"daysAgo":0,"fromTime":"06:00","toTime":"12:00"}; "el fin de semana pasado" -> {"weekend":"last"}.',
     'A calendar day word is never a rolling span: "today" is daysAgo 0, NOT lastCount 1 day. A part of the day is never a rolling span either.',
+    // The self-explanation, decoded FIRST in every branch (refs #438).
+    // Measured: "all this week" decoded none:true (no time limit) without
+    // it and a real window with it; restating the meaning puts the phrase's
+    // actual coverage in front of the decoder before any field is chosen.
+    'ALWAYS fill "meaning" first: one short sentence saying exactly which days (and hours) the phrase covers. Then the fields that express it.',
   ].join('\n');
 }
 

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2185,38 +2185,27 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    old English keyword overrule (``requiresLiveData``) is deleted rather
    than maintained as a vocabulary.
 
-   The same round is the PARSE (refs #427, #432): with a roster, the prompt
-   carries the monitor names and the install's label vocabulary, and
-   ``buildTriageSchema`` extends the verdict with ``place`` (the question's
-   own place words, copied), ``covered`` (a boolean, because a name enum
-   cannot express abstention), ``monitors`` (an ARRAY over the real names,
-   because "front of my house" means several monitors), ``subject``
-   (events/monitors/server/groups/other), ``objects`` (an array over the
-   recorded labels, so "folks" or "Leute" land on ``person`` in any
-   language), and ``when`` (the time phrases, copied verbatim - the separate
-   extraction model call and its Ollama overlap are gone on this lane, refs
-   #434; ``extractTimeframes`` unions the parsed phrases with its scan,
-   drops any phrase contained in a longer one, and interprets as before,
-   keeping its own extraction call only for roster-less turns). ``parseTriageSlots`` derives everything in code: a place
-   ``covered`` denies with nothing named is ``noMatch``, a place that is only
-   time words is none, a contradiction (``covered`` false while real names
-   are filled in, observed live, refs #430) leaves the slots unset rather
-   than asserting a false no-coverage claim, and values outside the enums
-   are dropped. ``buildMonitorSystemLine`` turns the outcome into one
-   system line (resolved monitors pin their ``monitorId``\ s; ``noMatch``
-   gets the never-attribute guard), and ``planToolCalls`` (``plan.ts``)
-   composes the tool calls the slots determine - one ``list_events`` per
-   window x monitor with the parsed ``objectType`` - handing them to the
-   loop as ``plannedCalls``; a same-window fan-out is merged back into ONE
-   result in code (``mergePlannedEventResults``: summed counts, recomputed
-   busiest hour, one summary sentence), so cross-monitor totals are never
-   the model's arithmetic (refs #436). A whole-vocabulary ``objects``
-   selection derives no filter (the creep signature; a filter of every
-   label would exclude no-detection events). A null plan is today's free
-   loop, unchanged.
-   Asked "how many people came to my front door yesterday" with no door
-   monitor, the assistant used to answer "3 people came to your front door"
-   from a garage monitor's events.
+   The same round is the ROUTING PARSE (refs #432, #438): with a roster,
+   the prompt carries the install's label vocabulary and the schema extends
+   the verdict with ``subject`` (events/monitors/server/groups/other),
+   ``objects`` (an array over the recorded labels, so "folks" or "Leute"
+   land on ``person`` in any language), and ``when`` (the time phrases,
+   copied verbatim; ``extractTimeframes`` unions them with its scan, keeps a
+   contained phrase unless its container actually resolved, and interprets
+   as before, running its own extraction call only for roster-less turns).
+   ``parseTriageSlots`` validates everything in code; a whole-vocabulary
+   ``objects`` selection derives no filter (the creep signature).
+
+   Place coverage is deliberately a SEPARATE, focused call (refs #438):
+   judged inside the consolidated prompt it failed live twice and every
+   rewording rotated the failures, while ``resolveCoverage``
+   (``monitor-stage.ts``) - a three-field prompt asking only place, covered,
+   and monitors - measures perfectly on the same cases. It runs only when
+   the deterministic scan found nothing; ``deriveMonitorSlots`` keeps the
+   code guards (roster-validated names, the covered/named contradiction and
+   whole-roster selections resolve to unset, a time-word place is no place),
+   and a failed call degrades to an unpinned turn. The slots feed
+   ``buildMonitorSystemLine`` and ``planToolCalls`` exactly as before.
    `source <https://github.com/ZoneMinder/zmNinjaNg/blob/main/app/src/lib/assistant/triage.ts>`__
    · → :doc:`15-assistant`
 


### PR DESCRIPTION
Fixes #438.

## Acceptance
- ~~"The parse schema decodes a required thinking sentence before the slots"~~ — **measured and rejected**: four wordings of the thinking field each fixed some cases and broke others (rotating failures, transcripts in the session). Replaced by the stronger form of the same intent: a **dedicated coverage call** (`resolveCoverage`, three-field prompt), which scores 18/18 on every live-failure case including "rear of my house" → Backyard(JPEG) and the small-talk-preamble question. The triage round slims to routing (kind/subject/objects/when): 24/24, with the roster-less prompt byte-identical (triage 38/38).
- "Every interpreter branch decodes a required meaning sentence first; 'all this week' resolves to a real window; interpret/time evals hold or improve." — done; every interpret class 100%.
- "New WindowFields week: this|last, Monday-anchored, resolved in code; rolling last-N-weeks unchanged; eval predicates accept the calendar reading alongside the rolling one." — done, unit-tested (this/last, cap-at-now, conflicts).
- "Containment dedup only absorbs a contained phrase when the containing phrase actually resolved." — done, unit-tested.
- "No new output-gating rules; the proposed none-branch gate is dropped as superseded." — done; the code guards that remain (roster validation, contradiction/whole-set unset, time-word place) are bookkeeping over constrained replies, not language rules.

## Scores (qwen3:8b, temp 0, reasoning none)
| stage | score |
|---|---|
| routing (slimmed triage) | 24/24 |
| coverage (new dedicated call) | 18/18 |
| triage (roster-less) | 38/38 |
| time interpret classes | 100% (weekday 14/14 incl. calendar weeks) |

Cost: one extra small model call per turn where the deterministic name scan misses (~0.5-1s Ollama); a failed call degrades to an unpinned turn. Recorded in `llm-models.md` as the measured pattern: split the interrogation before tuning its wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5