### PR TITLE
feat(assistant): status questions default to the system, follow-ups parse with context, chat lane cannot state system facts

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -122,7 +122,14 @@ after any prompt or provider change and put both scores in the PR.
   model-only recall, where multi-phrase misses are pre-existing and the
   scan union covers them. After the #438 split, routing scores 24/24 and
   coverage 18/18, with every interpret class at 100% including the new
-  calendar-week field and the meaning-first branches.
+  calendar-week field and the meaning-first branches. With the #440
+  context and app-default additions, routing scores 36/36 (standalone
+  status questions, bare follow-ups with the previous exchange embedded)
+  and coverage 20/20; the tool-less chat lane fabricated a healthy-system
+  report when handed a misrouted question ("no recent events detected"
+  after a turn reporting 86), so it now carries the action lane's
+  never-state wording and the kind/subject contradiction flip backs it in
+  code.
 - Apple Foundation Models invents tool arguments (validate before use) and
   calls real tools on greeting turns; the first tool call on a tool-less
   turn gets a no-tools pushback (578787dc).

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -567,6 +567,8 @@ const PARSE_LABELS = ['car', 'person', 'truck'];
 const R_PLAIN = ['Garage Outdoor', 'Driveway'];
 interface ParseCase {
   q: string;
+  /** Previous exchange to classify in light of (refs #440). */
+  context?: { user: string; assistant: string };
   kind: string;
   subject?: string;
   objects?: string[];
@@ -587,6 +589,15 @@ const PARSE_CASES: ParseCase[] = [
   { q: 'what cameras do I have', kind: 'ZONEMINDER', subject: 'monitors' },
   { q: 'hello', kind: 'CHAT' },
   { q: 'arm the backyard camera', kind: 'ACTION' },
+  // Standalone status questions default to the system (refs #440, observed
+  // live: "how today looking?" went CHAT and the tool-less turn fabricated).
+  { q: 'how today looking?', kind: 'ZONEMINDER', subject: 'events', when: ['today'] },
+  { q: 'anything happening?', kind: 'ZONEMINDER', subject: 'events' },
+  { q: 'see you tomorrow', kind: 'CHAT' },
+  // Follow-ups carry the previous exchange (refs #440).
+  { q: 'yes', context: { user: 'how was the rear of my house this week?', assistant: 'Backyard(JPEG) had 86 events this week. Want a breakdown?' }, kind: 'ZONEMINDER', subject: 'events' },
+  { q: 'what about the garage?', context: { user: 'how was the rear of my house this week?', assistant: 'Backyard(JPEG) had 86 events this week.' }, kind: 'ZONEMINDER', subject: 'events' },
+  { q: 'thanks!', context: { user: 'how was the rear of my house this week?', assistant: 'Backyard(JPEG) had 86 events this week.' }, kind: 'CHAT' },
 ];
 
 /** Coverage cases (refs #438), scored through the production coverage call
@@ -595,6 +606,7 @@ const R_HOUSE = ['FrontDoor', 'Backyard(JPEG)', 'Basement', 'Front Yard', 'Garag
 const R_DOOR = ['Garage Outdoor', 'Doorbell'];
 interface CoverageCase {
   q: string;
+  context?: { user: string; assistant: string };
   roster: string[];
   /** Exact expected monitor set. */
   monitors?: string[];
@@ -614,6 +626,7 @@ const COVERAGE_CASES: CoverageCase[] = [
   { q: 'how busy was the front of my abode over the week?', roster: R_HOUSE, monitorsWithin: ['FrontDoor', 'Front Yard'] },
   { q: 'summarize today', roster: R_PLAIN, unpinned: true },
   { q: 'who came at lunch 5 days ago', roster: R_PLAIN, unpinned: true },
+  { q: 'what about the garage?', context: { user: 'how was the rear of my house this week?', assistant: 'Backyard(JPEG) had 86 events.' }, roster: R_HOUSE, monitorsWithin: ['Garage Indoor', 'Garage Outdoor'] },
 ];
 
 function setEq(a: readonly string[] | undefined, b: readonly string[]): boolean {
@@ -621,8 +634,9 @@ function setEq(a: readonly string[] | undefined, b: readonly string[]): boolean 
 }
 
 async function scoreParse(runs: number) {
-  const { buildTriagePromptForEval, buildTriageSchema, parseTriageSlots } = await import('../src/lib/assistant/triage');
+  const { buildTriagePromptForEval, buildTriageSchema, parseTriageSlots, buildContextualQuestion } = await import('../src/lib/assistant/triage');
   const { buildCoveragePrompt, buildCoverageSchema, deriveMonitorSlots } = await import('../src/lib/assistant/monitor-stage');
+  const { buildContextualQuestion: wrapQ } = await import('../src/lib/assistant/triage');
   const { scanTimeExpressions } = await import('../src/lib/assistant/timeframe-stage');
   const { normalizeWhenPhrase } = await import('../src/lib/assistant/tool-helpers');
   let pass = 0;
@@ -636,7 +650,7 @@ async function scoreParse(runs: number) {
       try {
         const r = await chat({
           model: MODEL,
-          messages: [{ role: 'system', content: buildTriagePromptForEval(R_PLAIN, PARSE_LABELS) }, { role: 'user', content: c.q }],
+          messages: [{ role: 'system', content: buildTriagePromptForEval(R_PLAIN, PARSE_LABELS) }, { role: 'user', content: buildContextualQuestion(c.q, c.context) }],
           stream: false,
           max_tokens: 200,
           ...(TEMP === undefined ? {} : { temperature: TEMP }),
@@ -668,7 +682,7 @@ async function scoreParse(runs: number) {
       try {
         const r = await chat({
           model: MODEL,
-          messages: [{ role: 'system', content: buildCoveragePrompt(c.roster) }, { role: 'user', content: c.q }],
+          messages: [{ role: 'system', content: buildCoveragePrompt(c.roster) }, { role: 'user', content: wrapQ(c.q, c.context) }],
           stream: false,
           max_tokens: 200,
           ...(TEMP === undefined ? {} : { temperature: TEMP }),

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -48,7 +48,7 @@ import { extractTimeframes, buildTimeframeSystemLine } from '../../lib/assistant
 import { getMonitorRoster, scanMonitorMentions, resolveMonitorMention, resolveCoverage, buildMonitorSystemLine } from '../../lib/assistant/monitor-stage';
 import { planToolCalls, type PlannedToolCall } from '../../lib/assistant/plan';
 import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
-import { classifyRequest, buildNoToolPrompt, type RequestKind } from '../../lib/assistant/triage';
+import { classifyRequest, buildNoToolPrompt, latestExchange, type RequestKind } from '../../lib/assistant/triage';
 import type { AssistantBackend, AssistantMessage, AssistantTurn, ProviderConfig, ToolActivity, ToolContext, TraceEntry } from '../../lib/assistant/types';
 import { log, LogLevel } from '../../lib/logger';
 import { getSecureValue } from '../../lib/security/secureStorage';
@@ -654,6 +654,9 @@ export function AskPanel() {
             serverNames,
             monitorRoster.map((m) => m.name),
             monitorRoster.length > 0 ? objectLabels : [],
+            // The previous exchange, so "yes" and "how today looking?"
+            // classify with their topic (refs #440).
+            latestExchange(history),
           );
       const kind: RequestKind = verdict.kind;
       log.assistant('Request classified', LogLevel.DEBUG, {
@@ -706,7 +709,7 @@ export function AskPanel() {
         // no place adds nothing.
         const coverageSlots =
           monitorScanHits.length === 0 && monitorRoster.length > 0
-            ? await resolveCoverage(text, monitorRoster, provider, controller.signal, collectTrace)
+            ? await resolveCoverage(text, monitorRoster, provider, controller.signal, collectTrace, latestExchange(history))
             : {};
         const resolution = resolveMonitorMention(monitorScanHits, coverageSlots, monitorRoster);
         const monitorLine = buildMonitorSystemLine(resolution);

--- a/app/src/lib/assistant/__tests__/monitor-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/monitor-stage.test.ts
@@ -187,3 +187,25 @@ describe('deriveMonitorSlots', () => {
     expect(deriveMonitorSlots({ place: 'today', covered: false, monitors: [] }, names)).toEqual({ monitors: [] });
   });
 });
+
+/** Refs #440: a follow-up's place lives in the previous exchange. */
+describe('resolveCoverage with context', () => {
+  it('wraps the question with the previous exchange', async () => {
+    const provider = {
+      complete: vi.fn().mockResolvedValue({ text: '{"place":"garage","covered":true,"monitors":["Garage Outdoor"]}' }),
+    } as unknown as AssistantProvider;
+    const roster = [{ id: '5', name: 'Garage Outdoor' }, { id: '2', name: 'Backyard(JPEG)' }];
+    const slots = await resolveCoverage(
+      'what about the garage?',
+      roster,
+      provider,
+      new AbortController().signal,
+      undefined,
+      { user: 'how was the rear this week?', assistant: 'Backyard had 86 events.' },
+    );
+    const [, question] = vi.mocked(provider.complete).mock.calls[0];
+    expect(question).toContain('how was the rear this week?');
+    expect((question as string).trim().endsWith('what about the garage?')).toBe(true);
+    expect(slots).toEqual({ monitors: ['Garage Outdoor'] });
+  });
+});

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -340,3 +340,98 @@ describe('classifyRequest objects creep guard', () => {
     expect(verdict.objects).toEqual(['car', 'truck']);
   });
 });
+
+import { buildContextualQuestion, latestExchange } from '../triage';
+
+/**
+ * Refs #440, observed live: standalone "how today looking?" classified CHAT
+ * and the tool-less turn fabricated a healthy-system report. Follow-ups and
+ * app-default status questions.
+ */
+describe('contextual classification', () => {
+  it('embeds the previous exchange around the latest message', () => {
+    const q = buildContextualQuestion('yes', { user: 'how was the rear this week?', assistant: 'Backyard had 86 events.' });
+    expect(q).toContain('how was the rear this week?');
+    expect(q).toContain('Backyard had 86 events.');
+    expect(q.trim().endsWith('yes')).toBe(true);
+  });
+
+  it('returns the bare question without context', () => {
+    expect(buildContextualQuestion('hello')).toBe('hello');
+  });
+
+  it('trims oversized context turns', () => {
+    const q = buildContextualQuestion('yes', { user: 'x'.repeat(2000), assistant: 'y' });
+    expect(q.length).toBeLessThan(1000);
+  });
+
+  it('finds the latest completed exchange in a thread', () => {
+    expect(
+      latestExchange([
+        { role: 'user', text: 'older q' },
+        { role: 'assistant', text: 'older a' },
+        { role: 'user', text: 'rear this week?' },
+        { role: 'assistant', text: '86 events.' },
+        { role: 'user', text: 'yes' },
+      ]),
+    ).toEqual({ user: 'rear this week?', assistant: '86 events.' });
+    expect(latestExchange([{ role: 'user', text: 'first ever' }])).toBeUndefined();
+  });
+
+  it('passes the contextual question to the provider', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","subject":"events","objects":[],"when":["today"]}');
+    await classifyRequest(
+      provider,
+      'how today looking?',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor'],
+      ['person'],
+      { user: 'rear this week?', assistant: '86 events.' },
+    );
+    const [, text] = vi.mocked(provider.complete).mock.calls[0];
+    expect(text).toContain('rear this week?');
+    expect((text as string).trim().endsWith('how today looking?')).toBe(true);
+  });
+
+  // A CHAT verdict whose own slots say the message is about the system is
+  // self-contradictory; routing a real question to the tool-less lane is
+  // the worse failure (it fabricates), so code flips it (refs #440).
+  it('flips CHAT with a system subject to zoneminder', async () => {
+    const provider = providerSaying('{"kind":"CHAT","subject":"events","objects":[],"when":["today"]}');
+    const verdict = await classifyRequest(
+      provider,
+      'how today looking?',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor'],
+      ['person'],
+    );
+    expect(verdict.kind).toBe('zoneminder');
+  });
+
+  it('leaves CHAT with subject other alone', async () => {
+    const provider = providerSaying('{"kind":"CHAT","subject":"other","objects":[],"when":[]}');
+    const verdict = await classifyRequest(
+      provider,
+      'see you tomorrow',
+      new AbortController().signal,
+      undefined,
+      undefined,
+      [],
+      ['FrontDoor'],
+      ['person'],
+    );
+    expect(verdict.kind).toBe('chat');
+  });
+
+  it('forbids the chat lane from stating or offering system facts', () => {
+    const prompt = buildNoToolPrompt('BASE', 'chat');
+    expect(prompt).toContain('never state any camera, event, or server condition');
+    expect(prompt).toContain('Never say you will check');
+  });
+});

--- a/app/src/lib/assistant/monitor-stage.ts
+++ b/app/src/lib/assistant/monitor-stage.ts
@@ -24,6 +24,7 @@ import { scanTimeExpressions } from './timeframe-stage';
 import { sanitizeModelText } from './sanitize';
 import { isAbortError } from '../is-abort-error';
 import type { AssistantProvider, TraceEntry } from './types';
+import { buildContextualQuestion, type ParseContext } from './triage';
 import { ASSISTANT } from '../zmninja-ng-constants';
 import { log, LogLevel } from '../logger';
 
@@ -169,6 +170,7 @@ export function buildCoveragePrompt(names: readonly string[]): string {
   return [
     'You match a place in one message to the security cameras of a home. Reply with ONLY one JSON object.',
     `Cameras: ${names.join(', ')}.`,
+    'The message may include an earlier exchange for context: the place can come from it ("what about the garage?" after a garage answer).',
     '"place": the exact place or camera words the message contains ("" when none; time words such as today or yesterday are not places).',
     '"covered": true when a listed camera means that place, in any language, or the place is an area containing a camera\'s own area; false when "place" is "" or no listed camera truly watches it: a camera elsewhere on the property is false, never the closest one.',
     '"monitors": every listed camera that watches the place or sits inside it ([] when "covered" is false).',
@@ -225,11 +227,13 @@ export async function resolveCoverage(
   provider: AssistantProvider,
   signal: AbortSignal,
   onTrace?: (entry: TraceEntry) => void,
+  /** The previous exchange, so a follow-up's place resolves (refs #440). */
+  context?: ParseContext,
 ): Promise<ParsedMonitorSlots> {
   if (roster.length === 0) return {};
   const names = roster.map((entry) => entry.name);
   try {
-    const result = await provider.complete(buildCoveragePrompt(names), question, signal, buildCoverageSchema(names));
+    const result = await provider.complete(buildCoveragePrompt(names), buildContextualQuestion(question, context), signal, buildCoverageSchema(names));
     if (result.exchange) {
       onTrace?.({ kind: 'exchange', exchange: { ...result.exchange, backend: `${result.exchange.backend} (coverage)` } });
     }

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -18,9 +18,49 @@
  */
 import type { AssistantMessage, AssistantProvider, AssistantStatus, TraceEntry } from './types';
 import { sanitizeModelText } from './sanitize';
+import { log, LogLevel } from '../logger';
 import { isAbortError } from '../is-abort-error';
+import { ASSISTANT } from '../zmninja-ng-constants';
 
 export type RequestKind = 'zoneminder' | 'chat' | 'action';
+
+/** The previous completed exchange, for classifying a follow-up (refs #440):
+ *  "yes" or "what about the garage?" is unreadable without it. */
+export interface ParseContext {
+  user: string;
+  assistant: string;
+}
+
+/** The latest completed user+assistant exchange BEFORE the message currently
+ *  being classified, or undefined on a fresh thread. */
+export function latestExchange(history: ReadonlyArray<{ role: string; text?: string }>): ParseContext | undefined {
+  for (let i = history.length - 1; i >= 1; i--) {
+    const assistant = history[i];
+    if (assistant.role !== 'assistant' || !assistant.text) continue;
+    for (let j = i - 1; j >= 0; j--) {
+      const user = history[j];
+      if (user.role === 'user' && user.text) return { user: user.text, assistant: assistant.text };
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/** The question as the parse and coverage calls receive it: bare, or wrapped
+ *  with the previous exchange so a short follow-up carries its topic. Both
+ *  turns are trimmed hard - the context is a hint, not a transcript. */
+export function buildContextualQuestion(question: string, context?: ParseContext): string {
+  if (!context) return question;
+  const trim = (text: string) =>
+    text.length > ASSISTANT.parseContextCharacters ? `${text.slice(0, ASSISTANT.parseContextCharacters)}...` : text;
+  return [
+    'Earlier exchange, for context only:',
+    `user: ${trim(context.user)}`,
+    `assistant: ${trim(context.assistant)}`,
+    '',
+    `The LATEST message, the one to classify: ${question}`,
+  ].join('\n');
+}
 
 /** What the events/monitors/server question is about; `other` falls back to
  *  the free tool loop (refs #432). */
@@ -97,7 +137,9 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
   '  screen in the app. Questions and commands alike, in any language: "summarize <any period>",',
   '  "what happened <any period>", "how many <thing> came <any period>", "did anyone come by",',
   '  "show me <camera>". A message that mixes a greeting or small talk with such a question is',
-  '  still ZONEMINDER: any part asking about their place decides.',
+  '  still ZONEMINDER: any part asking about their place decides. A status question about a period',
+  '  with no other topic ("how is today looking", "how are things", "anything happening?") is',
+  '  ZONEMINDER too: in this app it asks what the cameras saw.',
   // Refs #337, observed live: "compare warehouse and cabin" classified CHAT, and
   // the tool-less turn answered it with a greeting. The names of the user's
   // own servers are the one piece of context that decides such a message, and
@@ -122,6 +164,8 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
   ...(monitors.length > 0
     ? [
         ...(labels.length > 0 ? [`Detected object labels on this installation: ${labels.join(', ')}.`] : []),
+        'The message may arrive with an earlier exchange shown for context: classify the LATEST message',
+        'read in its light - a bare "yes", "do it", or a short follow-up continues that exchange\'s topic.',
         'Also fill these fields about the message, judged by meaning in any language:',
         '"subject": what the message asks about. events - what happened, who or what came by, was seen,',
         "detected, or counted. monitors - the camera list or a camera's state. server - health or whether",
@@ -284,6 +328,9 @@ export async function classifyRequest(
   /** Recorded object labels, so the parse can map "folks"/"Leute" onto the
    *  install's own vocabulary (refs #432). Only used with a roster. */
   objectLabels: readonly string[] = [],
+  /** The previous exchange, so follow-ups classify with their topic
+   *  (refs #440). */
+  context?: ParseContext,
 ): Promise<TriageVerdict> {
   try {
     // `complete`, not `chat`: a classifier handed the tool catalog, the
@@ -291,12 +338,23 @@ export async function classifyRequest(
     // instead of returning a verdict. The schema constrains a backend that
     // can enforce it to `{"kind":"..."}`; the parser still accepts the loose
     // one-word reply from a backend that cannot.
-    const result = await provider.complete(buildTriagePrompt(servers, monitors, objectLabels), question, signal, buildTriageSchema(monitors, objectLabels), onStatus);
+    const result = await provider.complete(buildTriagePrompt(servers, monitors, objectLabels), buildContextualQuestion(question, context), signal, buildTriageSchema(monitors, objectLabels), onStatus);
     if (result.exchange) {
       onTrace?.({ kind: 'exchange', exchange: { ...result.exchange, backend: `${result.exchange.backend} (triage)` } });
     }
     const text = sanitizeModelText(result.text, 'triage');
-    return { kind: parseRequestKind(text), ...parseTriageSlots(text, monitors, objectLabels) };
+    const slots = parseTriageSlots(text, monitors, objectLabels);
+    let kind = parseRequestKind(text);
+    // A CHAT verdict whose own slots say the message is about the system is
+    // self-contradictory (refs #440), and routing a real question to the
+    // tool-less lane is the worse failure: it fabricates. Code flips it.
+    if (kind === 'chat' && slots.subject !== undefined && slots.subject !== 'other') {
+      log.assistant('CHAT verdict contradicts its own subject; routing to the data lane', LogLevel.WARN, {
+        subject: slots.subject,
+      });
+      kind = 'zoneminder';
+    }
+    return { kind, ...slots };
   } catch (error) {
     if (isAbortError(error)) throw error;
     return { kind: 'zoneminder' };
@@ -333,6 +391,13 @@ export const NO_TOOL_INSTRUCTIONS: Record<Exclude<RequestKind, 'zoneminder'>, st
     'yourself, and mention once that you are an AI assistant for the user\'s ZoneMinder system. A greeting,',
     'a thank you, or small talk gets one short warm reply. Never call a tool, and never invent any camera,',
     'event, or server information.',
+    // Observed live (refs #440): a misrouted follow-up got "the system is
+    // running smoothly... no recent events detected" - every clause invented,
+    // no tool had run. Same wording that measurably stopped this on the
+    // action lane (refs #270).
+    'Never say you will check, look up, or fetch anything, and never ask whether to: you cannot on this',
+    'turn - and never state any camera, event, or server condition, count, or status: no tool has run, so',
+    'you have retrieved nothing and have nothing to report.',
   ].join('\n'),
 };
 

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -713,6 +713,10 @@ export const ASSISTANT = {
   // Monitor names change when someone renames a camera, which is rarer still;
   // same session-length cache as the object vocabulary (monitor-stage.ts).
   monitorRosterCacheMs: 30 * 60 * 1000,
+  // Each turn of the previous exchange is trimmed to this many characters
+  // before riding the parse and coverage calls as context (refs #440): a
+  // hint, not a transcript.
+  parseContextCharacters: 240,
   // A parsed question fans out one list_events per window x monitor
   // (plan.ts); past this many calls the free tool loop's judgment beats a
   // mechanical fan-out.

--- a/docs/developer-guide/call-flows.rst
+++ b/docs/developer-guide/call-flows.rst
@@ -2186,7 +2186,13 @@ tool and ``ToolDefinition`` cannot express one), never a runtime decision.
    than maintained as a vocabulary.
 
    The same round is the ROUTING PARSE (refs #432, #438): with a roster,
-   the prompt carries the install's label vocabulary and the schema extends
+   the prompt carries the install's label vocabulary, the previous exchange
+   rides along trimmed so a bare "yes" or "what about the garage?"
+   classifies with its topic (``latestExchange`` /
+   ``buildContextualQuestion``, refs #440), a status question about a period
+   with no other topic defaults to the system, and a CHAT verdict that
+   contradicts its own subject is flipped to the data lane in code (the
+   tool-less lane fabricates when handed a real question). The schema extends
    the verdict with ``subject`` (events/monitors/server/groups/other),
    ``objects`` (an array over the recorded labels, so "folks" or "Leute"
    land on ``person`` in any language), and ``when`` (the time phrases,


### PR DESCRIPTION
Fixes #440.

## Acceptance
- "Standalone 'how today looking?' parses ZONEMINDER / events / when ['today'] and plans a summary; 'see you tomorrow' stays CHAT." — done; eval cases pass 2/2 each, and 'anything happening?' rides along.
- "'yes' and 'what about the garage?' after a system exchange parse ZONEMINDER with the inherited topic; coverage resolves 'the garage' from context." — done via `latestExchange` + `buildContextualQuestion` (both calls); 'thanks!' after a data answer stays CHAT.
- "kind CHAT with a system subject flips to zoneminder in code." — done, unit-tested both directions (subject `other` stays chat).
- "The chat-lane prompt forbids stating or offering any system fact." — done, the action lane's measured wording (refs #270).
- "Routing eval gains the standalone and context cases; roster-less triage 38/38 holds." — routing 36/36, coverage 20/20, triage 38/38.

Gates: `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5