### PR TITLE
fix(assistant): parseFields round-trips week and weekday-range fields; time eval runs the production parser

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -181,6 +181,12 @@ after any prompt or provider change and put both scores in the PR.
   never fork the prompt text into an eval. A hand-copied prompt drifted
   once and measured phantom failures. Two prompt rewrites shipped
   unmeasured, scored worse, and were reverted (refs #259).
+- The same rule holds for PARSERS: the time eval once raw-JSON.parsed the
+  interpreter's replies instead of running production `parseFields`, so the
+  `week` and weekday-range fields scored 100% while every live call parsed
+  them to {} and errored ("all this week", refs #442). An eval must run the
+  reply through the exact production parse/derive functions, exported for
+  it, or it measures the model instead of the pipeline.
 - Plain `npx tsx` scripts cannot import app modules that read
   `import.meta.env`; use vitest with `// @vitest-environment node` and
   stub `Platform.shouldUseProxy` false, or `lib/http.ts` rewrites absolute

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -370,7 +370,7 @@ const INTERPRET_CASES: Array<{ phrase: string; ok: (f: Record<string, unknown>) 
 ];
 
 async function scoreInterpreter(runs: number) {
-  const { WINDOW_SCHEMA, buildInterpreterPrompt } = await import('../src/lib/assistant/window-interpreter');
+  const { WINDOW_SCHEMA, buildInterpreterPrompt, parseFields } = await import('../src/lib/assistant/window-interpreter');
   // The REAL production prompt: a hand-copied version here drifted behind a
   // schema change and measured a bug the app did not have.
   const system = buildInterpreterPrompt(new Date(), 'America/New_York');
@@ -419,7 +419,7 @@ const TIME_NOW = new Date('2026-07-19T18:00:00Z');
 const TIME_TZ = 'America/New_York';
 
 async function scoreTime(runs: number) {
-  const { WINDOW_SCHEMA, buildInterpreterPrompt } = await import('../src/lib/assistant/window-interpreter');
+  const { WINDOW_SCHEMA, buildInterpreterPrompt, parseFields } = await import('../src/lib/assistant/window-interpreter');
   const { resolveWindow } = await import('../src/lib/assistant/event-range');
   const { buildTimeframePrompt, TIMEFRAME_SCHEMA } = await import('../src/lib/assistant/timeframe-stage');
   const { normalizeWhenPhrase } = await import('../src/lib/assistant/tool-helpers');
@@ -449,7 +449,9 @@ async function scoreTime(runs: number) {
           response_format: { type: 'json_schema', json_schema: { name: 'window', schema: WINDOW_SCHEMA, strict: true } },
         });
         const text = r.choices?.[0]?.message?.content ?? '';
-        const fields = JSON.parse(/\{[\s\S]*\}/.exec(text)?.[0] ?? '{}');
+        // Production parser, never a raw JSON.parse: a field parseFields did
+        // not know scored 100% here while every live call failed (refs #442).
+        const fields = (parseFields(text) ?? {}) as import('../src/lib/assistant/event-range').WindowFields & Record<string, unknown>;
         const range = resolveWindow(fields, TIME_NOW, TIME_TZ);
         const good = c.ok(fields, range);
         bump(c.cls, good);

--- a/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
@@ -426,3 +426,22 @@ describe('resolution-aware containment', () => {
     expect(result.abstained).toBe(false);
   });
 });
+
+/** Refs #442: a container that "resolved" to NO window (none / {}) must not
+ *  absorb a scan-vouched contained phrase - that is how "all this week"
+ *  killed "this week" and left the turn with an unresolvable phrase. */
+describe('windowless containers do not absorb', () => {
+  beforeEach(() => resetWindowInterpreterCacheForTests());
+
+  it('keeps the contained phrase when the compound resolves to no window', async () => {
+    const p = makeProvider(
+      () => '',
+      (phrase) => (phrase === 'all this week' ? '{"none":true}' : '{"meaning":"w","week":"this"}'),
+    );
+    const result = await extractTimeframes('hows the front looking all this week?', p, NOW, TZ, signal(), [
+      'all this week',
+    ]);
+    expect(result.phrases).toContain('this week');
+    expect(result.abstained).toBe(false);
+  });
+});

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -315,3 +315,26 @@ describe('interrogation redesign', () => {
     expect(prompt).toContain('"week"');
   });
 });
+
+/** Refs #442, observed live: the schema and prompt learned week and
+ *  fromWeekday/toWeekday (#435, #439) but parseFields never did, so
+ *  {"week":"this"} parsed to {} and list_events errored "does not name a
+ *  time period". Round-trip every field the schema can emit. */
+describe('parseFields round-trips every schema field', () => {
+  beforeEach(() => resetWindowInterpreterCacheForTests());
+
+  it('keeps the calendar-week field', async () => {
+    const p = providerSaying('{"meaning":"this calendar week","week":"this"}');
+    expect(await interpretWhen('all this week', p, NOW, 'UTC', new AbortController().signal)).toEqual({
+      week: 'this',
+    });
+  });
+
+  it('keeps the weekday-range fields', async () => {
+    const p = providerSaying('{"meaning":"monday through tuesday","fromWeekday":"monday","toWeekday":"tuesday"}');
+    expect(await interpretWhen('between mon and tue', p, NOW, 'UTC', new AbortController().signal)).toEqual({
+      fromWeekday: 'monday',
+      toWeekday: 'tuesday',
+    });
+  });
+});

--- a/app/src/lib/assistant/timeframe-stage.ts
+++ b/app/src/lib/assistant/timeframe-stage.ts
@@ -25,7 +25,7 @@ import { toZonedTime } from 'date-fns-tz';
 import { interpretWhen, PART_OF_DAY_WORDS, WEEKDAY_WORDS, WEEKDAY_ABBREVS, MONTH_SEASON_NAMES, AMBIGUOUS_MONTH_WORDS } from './window-interpreter';
 import { normalizeWhenPhrase } from './tool-helpers';
 import { log, LogLevel } from '../logger';
-import { WINDOW_UNITS, type WindowFields } from './event-range';
+import { WINDOW_UNITS, resolveWindow, type WindowFields } from './event-range';
 import type { AssistantProvider, ResolvedTimeframe } from './types';
 import { isAbortError } from '../is-abort-error';
 
@@ -276,10 +276,18 @@ export async function extractTimeframes(
   const namedTime = deduped.length > 0;
 
   const resolvedByKey = new Map<string, WindowFields>();
+  const windowfulKeys = new Set<string>();
   for (const phrase of namedTime ? deduped : ['today']) {
     const fields = await interpretWhen(phrase, provider, now, timezone, signal);
     if ('error' in fields && fields.error) continue;
-    resolvedByKey.set(normalizeWhenPhrase(phrase), fields as WindowFields);
+    const key = normalizeWhenPhrase(phrase);
+    resolvedByKey.set(key, fields as WindowFields);
+    // "Resolved" and "resolved to a WINDOW" differ: none/{} interprets
+    // cleanly but names no period, and such a container must not absorb a
+    // scan-vouched contained phrase (refs #442: "all this week" once
+    // interpreted to nothing and killed "this week" with it).
+    const window = resolveWindow(fields as WindowFields, now, timezone);
+    if (window !== undefined && !('error' in window)) windowfulKeys.add(key);
   }
 
   // Containment dedup, resolution-aware (refs #434, #438): the scan emits
@@ -292,7 +300,7 @@ export async function extractTimeframes(
     const key = normalizeWhenPhrase(phrase);
     return !deduped.some((other) => {
       const otherKey = normalizeWhenPhrase(other);
-      return otherKey !== key && otherKey.includes(key) && resolvedByKey.has(otherKey);
+      return otherKey !== key && otherKey.includes(key) && windowfulKeys.has(otherKey);
     });
   });
 

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -306,7 +306,11 @@ export async function interpretWhen(
 
 /** The first JSON object in `text` as WindowFields, or undefined. Defensive:
  *  an unconstrained backend may wrap the object in prose. */
-function parseFields(text: string): WindowFields | undefined {
+/** Exported for the eval harness (prompt-eval.mts time stage): replies MUST
+ *  be interpreted through this exact function, never raw-parsed - a field
+ *  this parser did not know scored 100% in an eval that bypassed it while
+ *  every production call failed (refs #442). */
+export function parseFields(text: string): WindowFields | undefined {
   const match = /\{[\s\S]*\}/.exec(text);
   if (!match) return undefined;
   try {
@@ -317,6 +321,15 @@ function parseFields(text: string): WindowFields | undefined {
     if (raw.lastUnit !== undefined) fields.lastUnit = String(raw.lastUnit);
     if (raw.daysAgo !== undefined) fields.daysAgo = Number(raw.daysAgo);
     if (raw.weekday !== undefined) fields.weekday = String(raw.weekday);
+    // Every field the schema can emit MUST round-trip here: week and the
+    // weekday range were taught to the prompt and schema (#435, #439) but
+    // not to this parser, so {"week":"this"} parsed to {} and the tool
+    // errored "does not name a time period" while the eval - which
+    // raw-parsed replies instead of running this function - scored 100%
+    // (refs #442).
+    if (raw.week !== undefined) fields.week = String(raw.week);
+    if (raw.fromWeekday !== undefined) fields.fromWeekday = String(raw.fromWeekday);
+    if (raw.toWeekday !== undefined) fields.toWeekday = String(raw.toWeekday);
     if (raw.dayOfMonth !== undefined) fields.dayOfMonth = Number(raw.dayOfMonth);
     // Pass the weekend value through as sent: the schema now emits a string enum
     // ("this"/"last"/"two-ago"), which resolveWindow maps to a weekends-ago


### PR DESCRIPTION
Fixes #442.

## Acceptance
- "parseFields round-trips week, fromWeekday, and toWeekday; interpretWhen unit tests cover a reply for each (they would have caught this)." — done.
- "The time eval interprets replies through production parseFields, so a parser omission can never score 100% again." — done; `parseFields` exported for the harness, lesson recorded in `llm-models.md` beside the forked-prompt rule it rhymes with (M2/P6).
- "A windowless container phrase no longer absorbs a scan-vouched contained phrase in the timeframe union." — done, unit-tested ("all this week" interpreting to none leaves "this week" alive).
- "Time eval re-run through the production parser holds its scores." — every interpret class 100% (weekday 14/14, weeks included).

Root cause of the pasted transcript: the model was right, the parser dropped the field, and the eval bypassed the parser — the gate measured the model instead of the pipeline.

Gates: `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5