### PR TITLE
feat(assistant): whole-question time interrogation on every backend, copy step deleted

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -74,9 +74,17 @@ after any prompt or provider change and put both scores in the PR.
   unreachable without a real tool result (4ee2bbbf), failure paths append
   a correct-and-retry guard instead of echoing raw errors (0a720c01).
 - Small models copy phrases perfectly but fail direct field-filling: time
-  windows use copy-interpret-compute (model copies the phrase verbatim, a
-  constrained interpreter call maps it to fields, code does arithmetic);
-  measured direct fills scored 27/36 (qwen) and 15/36 (llama), refs #265.
+  windows used copy-interpret-compute (refs #265; direct fills then scored
+  27/36 qwen, 15/36 llama). SUPERSEDED for time (refs #444): copying itself
+  proved the fragile step ("same day, last week" copied as "last week"),
+  and the rebuilt interrogation - whole question in, a windows ARRAY of
+  meaning-first branch shapes out, rolling branch offered only when the
+  question shows a rolling marker, code resolving every window - scores
+  124/124 across every time class on qwen3:8b, comparisons included. The
+  copy pattern still holds where it never broke (place words). On-device
+  backends run the same path but are UNMEASURED there (array-of-anyOf
+  schemas untested on Apple FM / Gemini Nano): run the settings time eval
+  on-device before trusting those numbers.
 - Prompt classification teaches dimensions (intent by subject), never
   instance lists; instance-based triage misclassified every combination
   outside its examples, four times.

--- a/app/scripts/prompt-eval.mts
+++ b/app/scripts/prompt-eval.mts
@@ -421,11 +421,9 @@ const TIME_TZ = 'America/New_York';
 async function scoreTime(runs: number) {
   const { WINDOW_SCHEMA, buildInterpreterPrompt, parseFields } = await import('../src/lib/assistant/window-interpreter');
   const { resolveWindow } = await import('../src/lib/assistant/event-range');
-  const { buildTimeframePrompt, TIMEFRAME_SCHEMA } = await import('../src/lib/assistant/timeframe-stage');
   const { normalizeWhenPhrase } = await import('../src/lib/assistant/tool-helpers');
-  const { TIME_INTERPRET_CASES, TIME_EXTRACT_CASES } = await import('../src/lib/assistant/time-eval-cases');
+  const { TIME_INTERPRET_CASES, TIME_QUESTION_CASES } = await import('../src/lib/assistant/time-eval-cases');
   const interpretSystem = buildInterpreterPrompt(TIME_NOW, TIME_TZ);
-  const extractSystem = buildTimeframePrompt(TIME_NOW, TIME_TZ);
 
   const byClass = new Map<string, { pass: number; total: number }>();
   const bump = (cls: string, ok: boolean) => {
@@ -463,37 +461,41 @@ async function scoreTime(runs: number) {
     }
   }
 
-  for (const c of TIME_EXTRACT_CASES) {
+  // The question-window stage (refs #444): the production function end to
+  // end, driven through a provider shim over the same HTTP endpoint - never
+  // a re-implementation (refs #442's lesson).
+  const { resolveTimeframesFromQuestion } = await import('../src/lib/assistant/timeframe-stage');
+  const shim = {
+    complete: async (system: string, text: string, _signal: AbortSignal, schema?: Record<string, unknown>) => {
+      const r = await chat({
+        model: MODEL,
+        messages: [{ role: 'system', content: system }, { role: 'user', content: text }],
+        stream: false,
+        max_tokens: 700,
+        ...(TEMP === undefined ? {} : { temperature: TEMP }),
+        ...REASONING,
+        ...(schema ? { response_format: { type: 'json_schema', json_schema: { name: 'w', schema, strict: true } } } : {}),
+      });
+      return { text: r.choices?.[0]?.message?.content ?? '' };
+    },
+  } as unknown as import('../src/lib/assistant/types').AssistantProvider;
+  for (const c of TIME_QUESTION_CASES) {
     for (let i = 0; i < runs; i++) {
       try {
-        const r = await chat({
-          model: MODEL,
-          messages: [{ role: 'system', content: extractSystem }, { role: 'user', content: c.question }],
-          stream: false,
-          max_tokens: 200,
-          ...(TEMP === undefined ? {} : { temperature: TEMP }),
-          ...REASONING,
-          response_format: { type: 'json_schema', json_schema: { name: 'timeframe', schema: TIMEFRAME_SCHEMA, strict: true } },
-        });
-        const text = r.choices?.[0]?.message?.content ?? '';
-        const raw = JSON.parse(/\{[\s\S]*\}/.exec(text)?.[0] ?? '{}');
-        const phrasesRaw = Array.isArray(raw.phrases) ? raw.phrases.map((p: unknown) => String(p)) : [];
-        // The extractor parrots the prompt's date line; production filters phrases
-        // that are not substrings of the question, so score the same way.
-        const nq = normalizeWhenPhrase(c.question);
-        const phrases = phrasesRaw.filter((p) => nq.includes(normalizeWhenPhrase(p)));
-        const joined = phrases.map((p) => normalizeWhenPhrase(p)).join(' | ');
-        const good = c.none
-          ? phrases.length === 0
-          : phrases.length > 0 && (c.expect ?? []).every((e) => joined.includes(e.toLowerCase()));
-        bump('extract', good);
-        if (!good) failures.push(`[extract] "${c.question}" -> ${JSON.stringify(phrases)}`);
+        const { resetWindowInterpreterCacheForTests } = await import('../src/lib/assistant/window-interpreter');
+        resetWindowInterpreterCacheForTests();
+        const result = await resolveTimeframesFromQuestion(c.question, shim, TIME_NOW, TIME_TZ, new AbortController().signal, c.context);
+        const windows = result.resolved.map((tf) => ({ fields: tf.fields as Record<string, unknown>, range: resolveWindow(tf.fields, TIME_NOW, TIME_TZ) }));
+        const good = !result.abstained && c.ok(windows);
+        bump(c.cls ?? 'question', good);
+        if (!good) failures.push(`[question] "${c.question}" -> ${JSON.stringify(result.resolved.map((tf) => tf.fields))}`);
       } catch (e) {
-        bump('extract', false);
-        failures.push(`[extract] "${c.q}" error: ${(e as Error).message}`);
+        bump(c.cls ?? 'question', false);
+        failures.push(`[question] "${c.question}" error: ${(e as Error).message}`);
       }
     }
   }
+
   return { byClass, failures };
 }
 
@@ -574,26 +576,23 @@ interface ParseCase {
   kind: string;
   subject?: string;
   objects?: string[];
-  /** Each must appear (normalized) inside the UNION of the deterministic
-   *  scan and the parse's when slot - the same union production queries. */
-  when?: string[];
 }
 const PARSE_CASES: ParseCase[] = [
-  { q: 'How may folks came to the front of my house between mon and tue?', kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['between mon and tue'] },
-  { q: 'how many people came to my front door yesterday', kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['yesterday'] },
-  { q: 'any cars in the driveway today', kind: 'ZONEMINDER', subject: 'events', objects: ['car'], when: ['today'] },
+  { q: 'How may folks came to the front of my house between mon and tue?', kind: 'ZONEMINDER', subject: 'events', objects: ['person'] },
+  { q: 'how many people came to my front door yesterday', kind: 'ZONEMINDER', subject: 'events', objects: ['person'] },
+  { q: 'any cars in the driveway today', kind: 'ZONEMINDER', subject: 'events', objects: ['car'] },
   { q: 'was war gestern an der Haust\u00fcr los', kind: 'ZONEMINDER', subject: 'events' },
-  { q: 'summarize today', kind: 'ZONEMINDER', subject: 'events', objects: [], when: ['today'] },
-  { q: 'who came at lunch 5 days ago', kind: 'ZONEMINDER', subject: 'events', objects: ['person'], when: ['lunch', '5 days ago'] },
-  { q: 'how busy was the front of my abode over the week?', kind: 'ZONEMINDER', subject: 'events', objects: [], when: ['over the week'] },
-  { q: 'oh the world is so cool. how is my house doing at the back all of this week?', kind: 'ZONEMINDER', subject: 'events', when: ['all of this week'] },
+  { q: 'summarize today', kind: 'ZONEMINDER', subject: 'events', objects: [] },
+  { q: 'who came at lunch 5 days ago', kind: 'ZONEMINDER', subject: 'events', objects: ['person'] },
+  { q: 'how busy was the front of my abode over the week?', kind: 'ZONEMINDER', subject: 'events', objects: [] },
+  { q: 'oh the world is so cool. how is my house doing at the back all of this week?', kind: 'ZONEMINDER', subject: 'events' },
   { q: 'is the server ok', kind: 'ZONEMINDER', subject: 'server' },
   { q: 'what cameras do I have', kind: 'ZONEMINDER', subject: 'monitors' },
   { q: 'hello', kind: 'CHAT' },
   { q: 'arm the backyard camera', kind: 'ACTION' },
   // Standalone status questions default to the system (refs #440, observed
   // live: "how today looking?" went CHAT and the tool-less turn fabricated).
-  { q: 'how today looking?', kind: 'ZONEMINDER', subject: 'events', when: ['today'] },
+  { q: 'how today looking?', kind: 'ZONEMINDER', subject: 'events' },
   { q: 'anything happening?', kind: 'ZONEMINDER', subject: 'events' },
   { q: 'see you tomorrow', kind: 'CHAT' },
   // Follow-ups carry the previous exchange (refs #440).
@@ -666,11 +665,6 @@ async function scoreParse(runs: number) {
         if (kind !== c.kind) bad.push(`kind ${kind}`);
         if (c.subject !== undefined && slots.subject !== c.subject) bad.push(`subject ${String(slots.subject)}`);
         if (c.objects !== undefined && !setEq(slots.objects, c.objects)) bad.push(`objects ${JSON.stringify(slots.objects)}`);
-        if (c.when !== undefined) {
-          const union = [...scanTimeExpressions(c.q), ...(slots.when ?? [])].map(normalizeWhenPhrase);
-          const missing = c.when.filter((w) => !union.some((u) => u.includes(normalizeWhenPhrase(w))));
-          if (missing.length > 0) bad.push(`when missing ${JSON.stringify(missing)}`);
-        }
         if (bad.length === 0) pass++;
         else failures.push(`[routing] "${c.q}" -> ${bad.join('; ')} (raw ${text})`);
       } catch (e) {
@@ -741,7 +735,7 @@ if (variant === 'time') {
   console.log(`\n=== time via ${MODEL}, temp ${TEMP ?? 'default'}, ${runs} runs/case ===`);
   let pass = 0;
   let total = 0;
-  const order = ['relative-day', 'rolling', 'part-of-day', 'weekday', 'weekend', 'ordinal-date', 'month-year', 'clock-range', 'no-time', 'non-english', 'extract'];
+  const order = ['relative-day', 'rolling', 'part-of-day', 'weekday', 'weekend', 'ordinal-date', 'month-year', 'clock-range', 'no-time', 'non-english', 'question', 'no-time-default'];
   for (const cls of order) {
     const e = w.byClass.get(cls);
     if (!e) continue;

--- a/app/src/components/assistant/AskPanel.tsx
+++ b/app/src/components/assistant/AskPanel.tsx
@@ -44,7 +44,7 @@ import { getObjectLabels } from '../../lib/assistant/object-labels';
 import { TOOLS, specializeToolSchemas, withServerArg } from '../../lib/assistant/tools';
 import { buildScopedServers } from '../../lib/assistant/scoped-servers';
 import { interpretWhen } from '../../lib/assistant/window-interpreter';
-import { extractTimeframes, buildTimeframeSystemLine } from '../../lib/assistant/timeframe-stage';
+import { resolveTimeframesFromQuestion, buildTimeframeSystemLine } from '../../lib/assistant/timeframe-stage';
 import { getMonitorRoster, scanMonitorMentions, resolveMonitorMention, resolveCoverage, buildMonitorSystemLine } from '../../lib/assistant/monitor-stage';
 import { planToolCalls, type PlannedToolCall } from '../../lib/assistant/plan';
 import { suggestOllamaBaseUrl, warmOllamaModel } from '../../lib/assistant/providers/openai';
@@ -663,7 +663,6 @@ export function AskPanel() {
         kind,
         subject: verdict.subject,
         objects: verdict.objects,
-        when: verdict.when,
       });
 
       // Every timeframe the question names is extracted and resolved BEFORE the
@@ -678,18 +677,18 @@ export function AskPanel() {
       let turnSystem = kind === 'zoneminder' ? system : buildNoToolPrompt(system, kind);
       let plannedCalls: PlannedToolCall[] | undefined;
       if (kind === 'zoneminder' && !isAssistantTestMode()) {
-        // With a roster the parse already copied the time phrases, so this
-        // makes no extraction model call of its own (refs #434): scan union,
-        // provenance, containment dedup, and the cached interpreter calls
-        // run on the parsed phrases. A roster-less turn (verdict.when
-        // undefined) keeps the old extraction call.
-        const { phrases, resolved, abstained } = await extractTimeframes(
+        // The whole-question windows interrogation (refs #444), the same
+        // path on every backend: each period the question means arrives as a
+        // structured window, resolved in code and cache-seeded, so the tool
+        // round never re-interprets. Falls back to the deterministic scan
+        // floor inside the stage on any failure.
+        const { phrases, resolved, abstained } = await resolveTimeframesFromQuestion(
           text,
           provider,
           new Date(),
           timezone,
           controller.signal,
-          verdict.when,
+          latestExchange(history),
         );
         if (abstained) {
           append(profileId, { role: 'assistant', text: `${I18N_SENTINEL}assistant.timeframe_unclear` });

--- a/app/src/lib/assistant/__tests__/fm-eval.test.ts
+++ b/app/src/lib/assistant/__tests__/fm-eval.test.ts
@@ -8,21 +8,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AssistantProvider, AssistantTurn, CompletionResult } from '../types';
 import { runFmTimeEval, FM_EVAL_NOW, FM_EVAL_TZ } from '../fm-eval';
 
-// Two interpretation cases (one class) and two extraction cases (an `expect`
-// and a `none`), enough to exercise both stages and both scoring paths.
+// Two interpretation cases (one class) and two question cases, enough to
+// exercise both stages and both scoring paths (refs #444).
 vi.mock('../time-eval-cases', () => ({
   TIME_INTERPRET_CASES: [
     { phrase: 'today', cls: 'relative-day', ok: (f: Record<string, unknown>) => f.daysAgo === 0 },
     { phrase: 'yesterday', cls: 'relative-day', ok: (f: Record<string, unknown>) => f.daysAgo === 1 },
   ],
-  TIME_EXTRACT_CASES: [
-    // A non-English phrase the deterministic scanner cannot see (scanTimeExpressions
-    // owns the English classes), so extraction rides on the model alone and the
-    // failure path is reachable when the model misses. A 'today' expect would be
-    // the extractor's default fallback and could never fail; an English phrase the
-    // scanner recognizes could never fail either.
-    { question: 'was war letzte woche los', expect: ['letzte woche'] },
-    { question: 'what cameras do I have', none: true },
+  TIME_QUESTION_CASES: [
+    {
+      question: 'was war letzte woche los',
+      ok: (ws: Array<{ fields: Record<string, unknown> }>) =>
+        ws.length === 1 && ws[0].fields.lastUnit === 'week' && ws[0].fields.lastCount === 1,
+    },
+    {
+      question: 'what cameras do I have',
+      cls: 'no-time-default',
+      ok: (ws: Array<{ fields: Record<string, unknown> }>) => ws.length === 1 && ws[0].fields.daysAgo === 0,
+    },
   ],
 }));
 
@@ -43,8 +46,8 @@ class ScriptProvider implements AssistantProvider {
     jsonSchema?: Record<string, unknown>,
   ): Promise<CompletionResult> {
     this.completeCalls += 1;
-    const isExtract = !!(jsonSchema?.properties as Record<string, unknown> | undefined)?.phrases;
-    const key = `${isExtract ? 'q' : 'p'}:${text.trim().toLowerCase()}`;
+    const isQuestion = !!(jsonSchema?.properties as Record<string, unknown> | undefined)?.windows;
+    const key = `${isQuestion ? 'q' : 'p'}:${text.trim().toLowerCase()}`;
     return { text: this.replies[key] ?? '{}' };
   }
   async chat(): Promise<AssistantTurn> {
@@ -55,9 +58,10 @@ class ScriptProvider implements AssistantProvider {
 const ALL_CORRECT: Record<string, string> = {
   'p:today': '{"daysAgo":0}',
   'p:yesterday': '{"daysAgo":1}',
-  'p:letzte woche': '{"lastCount":1,"lastUnit":"week"}',
-  'q:was war letzte woche los': '{"phrases":["letzte woche"]}',
-  'q:what cameras do i have': '{"phrases":[]}',
+  'q:was war letzte woche los': '{"windows":[{"meaning":"last calendar week","lastCount":1,"lastUnit":"week"}]}',
+  // No windows and no scan hit: the stage falls to the scan floor, whose
+  // default 'today' phrase resolves through the per-phrase interpreter.
+  'q:what cameras do i have': '{"windows":[]}',
 };
 
 describe('runFmTimeEval', () => {
@@ -73,11 +77,10 @@ describe('runFmTimeEval', () => {
     expect(report.total).toEqual({ pass: 4, total: 4 });
     expect(report.failures).toEqual([]);
     expect(report.durationMs).toBeGreaterThanOrEqual(0);
-    // 2 interpret cases (today, yesterday) + 2 extract questions + the
-    // 'letzte woche' interpretation the first extraction resolves = 5. The
-    // none-case's default 'today' interpretation hits the cache (today was
-    // already interpreted), so it adds no call.
-    expect(provider.completeCalls).toBe(5);
+    // 2 interpret cases + 2 question calls = 4; the no-time case's default
+    // 'today' interpretation hits the cache seeded by the interpret stage,
+    // so the fallback adds no call.
+    expect(provider.completeCalls).toBe(4);
   });
 
   it('captures a failed interpretation case with its input, expected class, and got', async () => {
@@ -94,14 +97,15 @@ describe('runFmTimeEval', () => {
     });
   });
 
-  it('captures a failed extraction case (wrong phrases)', async () => {
-    // The scanner cannot see the German phrase and the model returns none, so the
-    // extractor falls to default 'today', which does not contain 'letzte woche'.
-    const provider = new ScriptProvider({ ...ALL_CORRECT, 'q:was war letzte woche los': '{"phrases":[]}' });
+  it('captures a failed question case (no usable window)', async () => {
+    // The scanner cannot see the German phrase and the model emits no
+    // windows, so the stage falls to the today default, which fails the
+    // case's last-week predicate.
+    const provider = new ScriptProvider({ ...ALL_CORRECT, 'q:was war letzte woche los': '{"windows":[]}' });
     const report = await runFmTimeEval(provider, FM_EVAL_NOW, FM_EVAL_TZ, new AbortController().signal);
 
-    const extractFailure = report.failures.find((f) => f.stage === 'extract');
-    expect(extractFailure).toMatchObject({ input: 'was war letzte woche los', expected: 'letzte woche' });
+    const questionFailure = report.failures.find((f) => f.stage === 'question');
+    expect(questionFailure).toMatchObject({ input: 'was war letzte woche los' });
     expect(report.extract.pass).toBe(1);
   });
 

--- a/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
+++ b/app/src/lib/assistant/__tests__/timeframe-stage.test.ts
@@ -6,7 +6,7 @@
  * warm); interpretation quality is the interpreter's own concern.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { extractTimeframes, scanTimeExpressions, TIMEFRAME_SCHEMA, buildTimeframeSystemLine } from '../timeframe-stage';
+import { resolveTimeframesFromQuestion, scanTimeExpressions, buildTimeframeSystemLine } from '../timeframe-stage';
 import { interpretWhen, resetWindowInterpreterCacheForTests } from '../window-interpreter';
 import type { AssistantProvider } from '../types';
 
@@ -14,18 +14,6 @@ const NOW = new Date('2026-07-16T14:30:00Z');
 const TZ = 'America/New_York';
 const signal = () => new AbortController().signal;
 
-/** A provider whose `complete` routes by the system prompt: the extractor's
- *  prompt says "find the time expressions", the interpreter's says "convert a
- *  human time phrase". Each side returns whatever the test wired for it. */
-function makeProvider(
-  onExtract: (question: string) => string,
-  onInterpret: (phrase: string) => string,
-): AssistantProvider {
-  const complete = vi.fn(async (system: string, text: string) => ({
-    text: system.includes('find the time expressions') ? onExtract(text) : onInterpret(text),
-  }));
-  return { complete } as unknown as AssistantProvider;
-}
 
 describe('scanTimeExpressions', () => {
   it('finds simple day words', () => {
@@ -97,351 +85,84 @@ describe('scanTimeExpressions', () => {
   });
 });
 
-describe('extractTimeframes', () => {
+describe('buildTimeframeSystemLine', () => {
+  it('quotes every resolved label for the answering model to copy', () => {
+    const line = buildTimeframeSystemLine(['today', 'the same day one week back']);
+    expect(line).toContain('"today"');
+    expect(line).toContain('"the same day one week back"');
+  });
+});
+
+describe('resolveTimeframesFromQuestion', () => {
   beforeEach(() => resetWindowInterpreterCacheForTests());
 
-  it('passes the schema and the question, returns every resolved phrase', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["today","yesterday"],"none":false}',
-      (phrase) => (phrase === 'today' ? '{"daysAgo":0}' : '{"daysAgo":1}'),
+  /** Provider whose complete routes by prompt: the windows interrogation
+   *  says "every time period one QUESTION means"; anything else is the
+   *  per-phrase interpreter (the fallback). */
+  const providerWith = (onWindows: (q: string) => string, onInterpret: (p: string) => string = () => '{"daysAgo":0}') =>
+    ({
+      complete: vi.fn(async (system: string, text: string) => ({
+        text: system.includes('every time period one QUESTION means') ? onWindows(text) : onInterpret(text),
+      })),
+    }) as unknown as AssistantProvider;
+
+  it('resolves each window through the production parser and seeds the cache', async () => {
+    const p = providerWith(() =>
+      '{"windows":[{"meaning":"today","daysAgo":0},{"meaning":"the same day one week back","daysAgo":7}]}',
     );
-    const result = await extractTimeframes('today vs yesterday', p, NOW, TZ, signal());
+    const result = await resolveTimeframesFromQuestion('compare to same day, last week', p, NOW, TZ, signal(), {
+      user: 'hows today?',
+      assistant: '5 events.',
+    });
     expect(result).toEqual({
-      phrases: ['today', 'yesterday'],
+      phrases: ['today', 'the same day one week back'],
       resolved: [
         { phrase: 'today', fields: { daysAgo: 0 } },
-        { phrase: 'yesterday', fields: { daysAgo: 1 } },
+        { phrase: 'the same day one week back', fields: { daysAgo: 7 } },
       ],
       abstained: false,
     });
-
-    const [system, text, , schema] = vi.mocked(p.complete).mock.calls[0];
-    expect(system).toContain('Today is Thursday, 2026-07-16');
-    expect(text).toBe('today vs yesterday');
-    expect(schema).toBe(TIMEFRAME_SCHEMA);
+    // ONE model call: the windows interrogation. The cache was seeded, so a
+    // tool-time interpretWhen on the meaning label costs no model call.
+    expect(vi.mocked(p.complete)).toHaveBeenCalledTimes(1);
+    expect(await interpretWhen('the same day one week back', p, NOW, TZ, signal())).toEqual({ daysAgo: 7 });
+    expect(vi.mocked(p.complete)).toHaveBeenCalledTimes(1);
+    // The context rode the question.
+    const [, text] = vi.mocked(p.complete).mock.calls[0] as unknown as [string, string];
+    expect(text).toContain('hows today?');
   });
 
-  it('defaults to today when the question names no time', async () => {
-    const p = makeProvider(
-      () => '{"phrases":[],"none":true}',
-      () => '{"daysAgo":0}',
+  it('skips junk windows and windowless items, keeping the good ones', async () => {
+    const p = providerWith(() =>
+      '{"windows":[{"meaning":"nothing","none":true},{"meaning":"bad"},{"meaning":"yesterday","daysAgo":1}]}',
     );
-    expect(await extractTimeframes('give me a summary', p, NOW, TZ, signal())).toEqual({
-      phrases: ['today'],
-      resolved: [{ phrase: 'today', fields: { daysAgo: 0 } }],
-      abstained: false,
-    });
-  });
-
-  it('recovers phrases wrapped in prose from an unconstrained backend', async () => {
-    const p = makeProvider(
-      () => 'Sure: {"phrases":["last week"],"none":false} done',
-      () => '{"lastCount":1,"lastUnit":"week"}',
-    );
-    expect((await extractTimeframes('what about last week', p, NOW, TZ, signal())).phrases).toEqual(['last week']);
-  });
-
-  it('abstains when the question named a time but no interpretation resolves', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["blursday"],"none":false}',
-      () => 'no json here',
-    );
-    expect(await extractTimeframes('what happened blursday', p, NOW, TZ, signal())).toEqual({
-      phrases: [],
-      resolved: [],
-      abstained: true,
-    });
-  });
-
-  it('drops only the phrases that fail, keeping the rest', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["today","blursday"],"none":false}',
-      (phrase) => (phrase === 'today' ? '{"daysAgo":0}' : 'garbage'),
-    );
-    expect(await extractTimeframes('today and blursday', p, NOW, TZ, signal())).toEqual({
-      phrases: ['today'],
-      resolved: [{ phrase: 'today', fields: { daysAgo: 0 } }],
-      abstained: false,
-    });
-  });
-
-  it('drops phrases the model parroted from the prompt date line, keeping the real one', async () => {
-    // The model echoes the "Today is Friday, 2026-07-24 ..." line and returns
-    // those as phrases; only "yesterday" was actually in the question. The
-    // parroted ones must never reach the interpreter.
-    const interpret = vi.fn((phrase: string) => (phrase === 'yesterday' ? '{"daysAgo":1}' : '{"daysAgo":0}'));
-    const p = makeProvider(() => '{"phrases":["today","Friday","2026-07-24","yesterday"],"none":false}', interpret);
-    const result = await extractTimeframes('what happened yesterday', p, NOW, TZ, signal());
-    expect(result).toEqual({ phrases: ['yesterday'], resolved: [{ phrase: 'yesterday', fields: { daysAgo: 1 } }], abstained: false });
-    // Only the surviving phrase was interpreted; the three parroted ones were
-    // filtered in code before the loop.
-    expect(interpret).toHaveBeenCalledTimes(1);
-    expect(interpret).toHaveBeenCalledWith('yesterday');
-  });
-
-  it('defaults to today when every phrase was parroted, never abstaining', async () => {
-    // None of these appear in the question, so the filter empties the list;
-    // that is the same as naming no time, which defaults to today (not abstain).
-    const p = makeProvider(
-      () => '{"phrases":["today","Friday","2026-07-24","America/New_York"],"none":false}',
-      () => '{"daysAgo":0}',
-    );
-    expect(await extractTimeframes('any events at my place', p, NOW, TZ, signal())).toEqual({
-      phrases: ['today'],
-      resolved: [{ phrase: 'today', fields: { daysAgo: 0 } }],
-      abstained: false,
-    });
-  });
-
-  it('returns each resolved phrase with the structured window it resolved to', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["last hour"],"none":false}',
-      () => '{"lastCount":1,"lastUnit":"hour"}',
-    );
-    const { resolved } = await extractTimeframes('anything in the last hour', p, NOW, TZ, signal());
-    expect(resolved).toEqual([{ phrase: 'last hour', fields: { lastCount: 1, lastUnit: 'hour' } }]);
-  });
-
-  it('de-dupes phrases that differ only by case', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["today","Today"],"none":false}',
-      () => '{"daysAgo":0}',
-    );
-    const result = await extractTimeframes('today Today', p, NOW, TZ, signal());
-    expect(result.phrases).toEqual(['today']);
-  });
-
-  it('pre-warms interpretWhen so a later resolve of the same phrase is free', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["today"],"none":false}',
-      () => '{"daysAgo":0}',
-    );
-    await extractTimeframes('anything today', p, NOW, TZ, signal());
-    const callsAfterStage = vi.mocked(p.complete).mock.calls.length; // 1 extract + 1 interpret
-
-    const fields = await interpretWhen('today', p, NOW, TZ, signal());
-    expect(fields).toEqual({ daysAgo: 0 });
-    // No new model call: the stage already cached "today" for this day.
-    expect(vi.mocked(p.complete).mock.calls.length).toBe(callsAfterStage);
-  });
-
-  it('falls open to today when extraction itself fails', async () => {
-    const complete = vi.fn(async (system: string) => {
-      if (system.includes('find the time expressions')) throw new Error('offline');
-      return { text: '{"daysAgo":0}' };
-    });
-    const p = { complete } as unknown as AssistantProvider;
-    expect(await extractTimeframes('summary', p, NOW, TZ, signal())).toEqual({
-      phrases: ['today'],
-      resolved: [],
-      abstained: false,
-    });
-  });
-
-  it('keeps scan-found phrases even when the model returns an empty list', async () => {
-    // The decoder drops list members and compact forms nondeterministically; the
-    // scanner owns them, so a compact clock range plus both day words survive even
-    // when the model surfaces nothing. The clock range has no day to anchor it and
-    // does not resolve, yet stays in the allowed list for the model to compose.
-    const p = makeProvider(
-      () => '{"phrases":[],"none":true}',
-      (phrase) => {
-        if (phrase === 'today') return '{"daysAgo":0}';
-        if (phrase === 'yesterday') return '{"daysAgo":1}';
-        return 'no window here';
-      },
-    );
-    const result = await extractTimeframes('Compare 10am-6pm yesterday and today.', p, NOW, TZ, signal());
-    expect(result.abstained).toBe(false);
-    expect(result.phrases).toEqual(['10am-6pm', 'yesterday', 'today']);
-    expect(result.resolved).toEqual([
-      { phrase: 'yesterday', fields: { daysAgo: 1 } },
-      { phrase: 'today', fields: { daysAgo: 0 } },
-    ]);
-  });
-
-  it('keeps scan-found phrases when the model reply is unparseable junk', async () => {
-    const p = makeProvider(
-      () => 'total garbage, no json at all',
-      () => '{"fromDate":"2026-06-01","toDate":"2026-06-30"}',
-    );
-    const result = await extractTimeframes('give me a recap of last month', p, NOW, TZ, signal());
-    expect(result.phrases).toEqual(['last month']);
-    expect(result.abstained).toBe(false);
-  });
-
-  it('proceeds on scan phrases when the extraction model call fails', async () => {
-    const complete = vi.fn(async (system: string) => {
-      if (system.includes('find the time expressions')) throw new Error('offline');
-      return { text: '{"daysAgo":1}' };
-    });
-    const p = { complete } as unknown as AssistantProvider;
-    const result = await extractTimeframes('what happened yesterday', p, NOW, TZ, signal());
+    const result = await resolveTimeframesFromQuestion('yesterday and whenever', p, NOW, TZ, signal());
     expect(result.phrases).toEqual(['yesterday']);
-    expect(result.resolved).toEqual([{ phrase: 'yesterday', fields: { daysAgo: 1 } }]);
     expect(result.abstained).toBe(false);
   });
 
-  it('unions scan phrases with model phrases the scan could not see', async () => {
-    const p = makeProvider(
-      () => '{"phrases":["letzte woche"],"none":false}',
-      (phrase) => (phrase === 'today' ? '{"daysAgo":0}' : '{"lastCount":1,"lastUnit":"week"}'),
-    );
-    const result = await extractTimeframes('was los today letzte woche', p, NOW, TZ, signal());
-    expect(result.phrases).toEqual(['today', 'letzte woche']);
-  });
-
-  it('propagates an abort instead of swallowing it', async () => {
-    const complete = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
-    const p = { complete } as unknown as AssistantProvider;
-    await expect(extractTimeframes('today', p, NOW, TZ, signal())).rejects.toThrow('Aborted');
-  });
-});
-
-describe('buildTimeframeSystemLine', () => {
-  it('quotes each resolved phrase for the answering model to copy', () => {
-    expect(buildTimeframeSystemLine(['today', 'January 21'])).toBe(
-      'Timeframes for this question, already resolved (copy these exact phrases into when): "today", "January 21".',
-    );
-  });
-});
-
-/**
- * Refs #434, observed live: "How may folks came..." matched the bare
- * month-name class as the month of May, and the obedient planner then issued
- * a wasted whole-of-May query. The four month/season names that double as
- * everyday words match only behind a determiner; the unambiguous names stay
- * bare, and "<month> <day>" keeps the full list.
- */
-describe('scanTimeExpressions month-word guard', () => {
-  it('ignores may/march/fall/spring used as ordinary words', () => {
-    expect(scanTimeExpressions('How may folks came to the front of my house?')).toEqual([]);
-    expect(scanTimeExpressions('did the camera fall over')).toEqual([]);
-    expect(scanTimeExpressions('march the recording out')).toEqual([]);
-  });
-
-  it('still finds them behind a determiner, verbatim', () => {
-    expect(scanTimeExpressions('how busy was it in may')).toEqual(['in may']);
-    expect(scanTimeExpressions('summarize this march')).toEqual(['this march']);
-    expect(scanTimeExpressions('what happened last fall')).toEqual(['last fall']);
-  });
-
-  it('keeps unambiguous months bare and month+day with the full list', () => {
-    expect(scanTimeExpressions('how busy was april')).toEqual(['april']);
-    expect(scanTimeExpressions('what happened on may 15')).toEqual(['may 15']);
-  });
-});
-
-/** Refs #434: "between mon and tue" had no scan class and no interpreter
- *  branch, so the model computed the dates itself and started on Sunday. */
-describe('scanTimeExpressions weekday ranges', () => {
-  it('finds a between-weekdays span, abbreviations included', () => {
-    expect(scanTimeExpressions('who came by between mon and tue?')).toEqual(['between mon and tue']);
-    expect(scanTimeExpressions('what happened from friday to sunday')).toEqual(['from friday to sunday']);
-  });
-
-  it('does not fire a bare abbreviation outside the range shape', () => {
-    expect(scanTimeExpressions('the cat sat on the mat')).toEqual([]);
-  });
-});
-
-describe('scanTimeExpressions lunch band', () => {
-  // Two adjacent phrases, not one: the compound "at lunch 5 days ago" is the
-  // extraction model's to copy whole, and containment dedup then absorbs
-  // these halves into it (refs #434).
-  it('finds lunch as a part of the day', () => {
-    expect(scanTimeExpressions('who came at lunch 5 days ago')).toEqual(['lunch', '5 days ago']);
-    expect(scanTimeExpressions('anything around lunchtime')).toEqual(['lunchtime']);
-  });
-});
-
-/**
- * Refs #434: with a roster, the parse call already copied the time phrases,
- * so extractTimeframes takes them as `statedPhrases` and makes NO extraction
- * model call of its own; the interpreter calls (and the scan, provenance,
- * and abstain logic) are unchanged. `undefined` statedPhrases keeps the old
- * extraction call: roster-less installs and group mode still extract.
- */
-describe('extractTimeframes with parse-stated phrases', () => {
-  beforeEach(() => resetWindowInterpreterCacheForTests());
-
-  it('skips the extraction model call and unions stated phrases with the scan', async () => {
-    const p = makeProvider(
-      () => {
-        throw new Error('extraction must not be called');
-      },
-      () => '{"daysAgo":1}',
-    );
-    const result = await extractTimeframes('was war letzte Woche los, and yesterday', p, NOW, TZ, signal(), [
-      'letzte Woche',
-    ]);
-    // Scan found "yesterday"; the stated phrase adds what regex cannot see.
-    expect(result.phrases).toEqual(['yesterday', 'letzte Woche']);
+  it('falls back to the scan floor when the call fails', async () => {
+    const p = {
+      complete: vi.fn(async (system: string, text: string) => {
+        if (system.includes('every time period one QUESTION means')) throw new Error('offline');
+        return { text: text === 'today' ? '{"daysAgo":0}' : '{"daysAgo":1}' };
+      }),
+    } as unknown as AssistantProvider;
+    const result = await resolveTimeframesFromQuestion('compare today and yesterday', p, NOW, TZ, signal());
+    expect(result.phrases).toEqual(['today', 'yesterday']);
     expect(result.abstained).toBe(false);
-    // Only interpreter calls happened.
-    for (const [system] of vi.mocked(p.complete).mock.calls) {
-      expect(system).not.toContain('find the time expressions');
-    }
   });
 
-  it('drops a stated phrase that is not a substring of the question', async () => {
-    const p = makeProvider(() => '', () => '{"daysAgo":0}');
-    const result = await extractTimeframes('what happened today', p, NOW, TZ, signal(), ['2026-07-16', 'today']);
+  it('defaults to today when nothing names a time anywhere', async () => {
+    const p = providerWith(() => '{"windows":[]}');
+    const result = await resolveTimeframesFromQuestion('what cameras do I have', p, NOW, TZ, signal());
     expect(result.phrases).toEqual(['today']);
-  });
-
-  // Containment dedup (refs #434): the scan emits the halves ("lunch",
-  // "5 days ago"), the parse copies the compound; only the compound survives,
-  // so the planner never queries the whole day next to the lunch band.
-  it('absorbs scan phrases contained in a stated compound', async () => {
-    const p = makeProvider(() => '', () => '{"daysAgo":5,"fromTime":"11:00","toTime":"13:00"}');
-    const result = await extractTimeframes('who came at lunch 5 days ago', p, NOW, TZ, signal(), [
-      'at lunch 5 days ago',
-    ]);
-    expect(result.phrases).toEqual(['at lunch 5 days ago']);
-  });
-
-  it('still answers on the scan alone when stated phrases are empty', async () => {
-    const p = makeProvider(() => '', () => '{"daysAgo":0}');
-    const result = await extractTimeframes('what happened today', p, NOW, TZ, signal(), []);
-    expect(result.phrases).toEqual(['today']);
-  });
-});
-
-/** Refs #438: containment absorbs a contained phrase only when its container
- *  actually resolved. "all this week" once swallowed the scan-vouched "this
- *  week" and then failed to interpret, leaving the turn with nothing. */
-describe('resolution-aware containment', () => {
-  beforeEach(() => resetWindowInterpreterCacheForTests());
-
-  it('keeps the contained scan phrases when the compound fails to resolve', async () => {
-    const p = makeProvider(
-      () => '',
-      (phrase) => (phrase === 'at lunch 5 days ago' ? 'garbage' : '{"daysAgo":5}'),
-    );
-    const result = await extractTimeframes('who came at lunch 5 days ago', p, NOW, TZ, signal(), [
-      'at lunch 5 days ago',
-    ]);
-    expect(result.phrases).toEqual(['lunch', '5 days ago']);
     expect(result.abstained).toBe(false);
   });
-});
 
-/** Refs #442: a container that "resolved" to NO window (none / {}) must not
- *  absorb a scan-vouched contained phrase - that is how "all this week"
- *  killed "this week" and left the turn with an unresolvable phrase. */
-describe('windowless containers do not absorb', () => {
-  beforeEach(() => resetWindowInterpreterCacheForTests());
-
-  it('keeps the contained phrase when the compound resolves to no window', async () => {
-    const p = makeProvider(
-      () => '',
-      (phrase) => (phrase === 'all this week' ? '{"none":true}' : '{"meaning":"w","week":"this"}'),
-    );
-    const result = await extractTimeframes('hows the front looking all this week?', p, NOW, TZ, signal(), [
-      'all this week',
-    ]);
-    expect(result.phrases).toContain('this week');
-    expect(result.abstained).toBe(false);
+  it('abstains only when windows were emitted, none resolved, and the scan sees no time', async () => {
+    const p = providerWith(() => '{"windows":[{"meaning":"whenever","none":true}]}');
+    const result = await resolveTimeframesFromQuestion('what happened at blursday oclock', p, NOW, TZ, signal());
+    expect(result).toEqual({ phrases: [], resolved: [], abstained: true });
   });
 });

--- a/app/src/lib/assistant/__tests__/triage.test.ts
+++ b/app/src/lib/assistant/__tests__/triage.test.ts
@@ -189,30 +189,26 @@ describe('classifyRequest with a roster and vocabulary', () => {
   const ask = (provider: AssistantProvider, question: string) =>
     classifyRequest(provider, question, new AbortController().signal, undefined, undefined, [], roster, labels);
 
-  it('constrains subject and objects to the real values and copies when', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","subject":"events","objects":["person"],"when":["between mon and tue"]}',
-    );
+  it('constrains subject and objects to the real values', async () => {
+    const provider = providerSaying('{"kind":"ZONEMINDER","subject":"events","objects":["person"]}');
     const verdict = await ask(provider, 'How may folks came to the front of my house between mon and tue?');
 
     const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
     expect(system).toContain('car, person, truck');
     expect(system).not.toContain('"covered"');
+    // Time left this call entirely (refs #444): the windows interrogation
+    // owns it on every backend.
+    expect(system).not.toContain('"when"');
     expect(schema).toMatchObject({
       properties: {
         subject: { enum: ['events', 'monitors', 'server', 'groups', 'other'] },
         objects: { type: 'array', items: { enum: labels } },
-        when: { type: 'array', items: { type: 'string' } },
       },
-      required: ['kind', 'subject', 'objects', 'when'],
+      required: ['kind', 'subject', 'objects'],
     });
     expect((schema as { properties: object }).properties).not.toHaveProperty('monitors');
-    expect(verdict).toEqual({
-      kind: 'zoneminder',
-      subject: 'events',
-      objects: ['person'],
-      when: ['between mon and tue'],
-    });
+    expect((schema as { properties: object }).properties).not.toHaveProperty('when');
+    expect(verdict).toEqual({ kind: 'zoneminder', subject: 'events', objects: ['person'] });
   });
 
   it('sends the unchanged prompt and schema when no roster is given', async () => {
@@ -228,11 +224,9 @@ describe('classifyRequest with a roster and vocabulary', () => {
   // An unconstrained backend can reply anything; values outside the enums
   // are dropped, never trusted.
   it('drops subjects and objects outside the enums', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","subject":"weather","objects":["unicorn"],"when":[]}',
-    );
+    const provider = providerSaying('{"kind":"ZONEMINDER","subject":"weather","objects":["unicorn"]}');
     const verdict = await ask(provider, 'anything in the backyard');
-    expect(verdict).toEqual({ kind: 'zoneminder', objects: [], when: [] });
+    expect(verdict).toEqual({ kind: 'zoneminder', objects: [] });
   });
 
   // Refs #436: selecting the whole vocabulary is the creep signature.
@@ -250,54 +244,6 @@ describe('classifyRequest with a roster and vocabulary', () => {
     );
     const verdict = await ask(provider, 'any vehicles today');
     expect(verdict.objects).toEqual(['car', 'truck']);
-  });
-});
-
-/** Refs #434: the parse call copies the time phrases too, so the separate
- *  extraction model call is not needed on the roster lane. */
-describe('classifyRequest when-phrase slot', () => {
-  it('asks for and returns verbatim time phrases with the roster', async () => {
-    const provider = providerSaying(
-      '{"kind":"ZONEMINDER","subject":"events","objects":[],"when":["between mon and tue"]}',
-    );
-    const verdict = await classifyRequest(
-      provider,
-      'who came between mon and tue',
-      new AbortController().signal,
-      undefined,
-      undefined,
-      [],
-      ['FrontDoor'],
-      ['person'],
-    );
-    const [system, , , schema] = vi.mocked(provider.complete).mock.calls[0];
-    expect(system).toContain('"when"');
-    expect(schema).toMatchObject({
-      properties: { when: { type: 'array', items: { type: 'string' } } },
-      required: ['kind', 'subject', 'objects', 'when'],
-    });
-    expect(verdict.when).toEqual(['between mon and tue']);
-  });
-
-  it('drops junk when values and leaves the slot unset without a roster', async () => {
-    const junk = providerSaying(
-      '{"kind":"ZONEMINDER","subject":"events","objects":[],"when":["", 42]}',
-    );
-    const verdict = await classifyRequest(
-      junk,
-      'summarize',
-      new AbortController().signal,
-      undefined,
-      undefined,
-      [],
-      ['FrontDoor'],
-      ['person'],
-    );
-    expect(verdict.when).toEqual([]);
-
-    const bare = providerSaying('{"kind":"CHAT"}');
-    const none = await classifyRequest(bare, 'hello', new AbortController().signal);
-    expect(none.when).toBeUndefined();
   });
 });
 

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -6,7 +6,7 @@
  * (scripts/prompt-eval.mts interpret stage), not unit tests.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { interpretWhen, resetWindowInterpreterCacheForTests, selectBranches, WINDOW_SCHEMA, buildInterpreterPrompt } from '../window-interpreter';
+import { interpretWhen, resetWindowInterpreterCacheForTests, selectBranches, WINDOW_SCHEMA, buildInterpreterPrompt, buildQuestionWindowsSchema, questionOffersRolling } from '../window-interpreter';
 import type { AssistantProvider } from '../types';
 
 const NOW = new Date('2026-07-16T14:30:00Z');
@@ -336,5 +336,29 @@ describe('parseFields round-trips every schema field', () => {
       fromWeekday: 'monday',
       toWeekday: 'tuesday',
     });
+  });
+});
+
+/** Refs #444: the rolling branch is offered to the windows call only when
+ *  the question shows a rolling marker - it is the decoder's attractor and
+ *  swallowed "what happened today" (lastCount 1 day, 2/2) when always on. */
+describe('questionOffersRolling', () => {
+  it('detects counted rolling spans and sub-day units', () => {
+    expect(questionOffersRolling('summarize the past 2 weeks')).toBe(true);
+    expect(questionOffersRolling('anything an hour ago')).toBe(true);
+    expect(questionOffersRolling('what happened 3 hours ago')).toBe(true);
+  });
+
+  it('stays off for calendar phrasings', () => {
+    expect(questionOffersRolling('what happened today')).toBe(false);
+    expect(questionOffersRolling('compare to same day, last week')).toBe(false);
+    expect(questionOffersRolling('how was the rear of my house all this week?')).toBe(false);
+  });
+
+  it('drops the rolling branch from the windows schema when off', () => {
+    const on = JSON.stringify(buildQuestionWindowsSchema(true));
+    const off = JSON.stringify(buildQuestionWindowsSchema(false));
+    expect(on).toContain('lastCount');
+    expect(off).not.toContain('lastCount');
   });
 });

--- a/app/src/lib/assistant/fm-eval.ts
+++ b/app/src/lib/assistant/fm-eval.ts
@@ -15,11 +15,10 @@
  * in the pullable device log file.
  */
 import { interpretWhen, resetWindowInterpreterCacheForTests } from './window-interpreter';
-import { extractTimeframes } from './timeframe-stage';
+import { resolveTimeframesFromQuestion } from './timeframe-stage';
 import { resolveWindow } from './event-range';
-import { normalizeWhenPhrase } from './tool-helpers';
 import type { AssistantProvider } from './types';
-import { TIME_INTERPRET_CASES, TIME_EXTRACT_CASES } from './time-eval-cases';
+import { TIME_INTERPRET_CASES, TIME_QUESTION_CASES, type ResolvedQuestionWindow } from './time-eval-cases';
 
 /** The fixed clock every case predicate is written against: Sunday
  *  2026-07-19 14:00 America/New_York (same instant prompt-eval.mts pins). A
@@ -33,7 +32,7 @@ export const FM_EVAL_TZ = 'America/New_York';
 
 /** How many cases this eval scores. Exported so a caller running it alongside the
  *  contract eval can size one progress bar over both (see `system-model-eval.ts`). */
-export const TIME_EVAL_CASE_COUNT = TIME_INTERPRET_CASES.length + TIME_EXTRACT_CASES.length;
+export const TIME_EVAL_CASE_COUNT = TIME_INTERPRET_CASES.length + TIME_QUESTION_CASES.length;
 
 /** One class's running tally. */
 export interface FmEvalTally {
@@ -43,8 +42,8 @@ export interface FmEvalTally {
 
 /** A case that did not meet its predicate, kept compact for the log line. */
 export interface FmEvalFailure {
-  /** 'interpret' | 'extract', so a reader can tell which stage failed. */
-  stage: 'interpret' | 'extract';
+  /** 'interpret' | 'question', so a reader can tell which stage failed. */
+  stage: 'interpret' | 'question';
   /** The case's class label ('relative-day', 'rolling', 'extract'...). */
   cls: string;
   /** The phrase or question fed in. */
@@ -58,7 +57,7 @@ export interface FmEvalFailure {
 export interface FmEvalReport {
   /** Interpretation cases scored, per class and overall. */
   interpret: FmEvalTally & { byClass: Record<string, FmEvalTally> };
-  /** Extraction cases scored. */
+  /** Whole-question window cases scored (refs #444). */
   extract: FmEvalTally;
   /** Combined pass/total across both stages. */
   total: FmEvalTally;
@@ -96,7 +95,7 @@ export async function runFmTimeEval(
   resetWindowInterpreterCacheForTests();
 
   const startedAt = Date.now();
-  const total = TIME_INTERPRET_CASES.length + TIME_EXTRACT_CASES.length;
+  const total = TIME_INTERPRET_CASES.length + TIME_QUESTION_CASES.length;
   let done = 0;
   const failures: FmEvalFailure[] = [];
   const byClass: Record<string, FmEvalTally> = {};
@@ -117,32 +116,31 @@ export async function runFmTimeEval(
     onProgress?.(++done, total);
   }
 
-  for (const c of TIME_EXTRACT_CASES) {
+  for (const c of TIME_QUESTION_CASES) {
     if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-    const cls = c.cls ?? 'extract';
-    const result = await extractTimeframes(c.question, provider, now, timezone, signal);
-    const phrases = result.phrases.map((p) => normalizeWhenPhrase(p));
-    // A none-case is correct when the extractor found no stated timeframe and
-    // fell to the default 'today' (extractTimeframes never returns an empty
-    // phrase list except when it abstains). The `expect` cases require each
-    // expected phrase to appear as a normalized substring of some returned
-    // phrase, exactly as prompt-eval scores them.
-    const ok = c.none
-      ? phrases.length === 1 && phrases[0] === 'today'
-      : !result.abstained && (c.expect ?? []).every((e) => phrases.some((p) => p.includes(normalizeWhenPhrase(e))));
+    const cls = c.cls ?? 'question';
+    // The production path end to end (refs #442's lesson): the same function
+    // the app calls, windows resolved through parseFields + resolveWindow.
+    const result = await resolveTimeframesFromQuestion(c.question, provider, now, timezone, signal, c.context);
+    const windows: ResolvedQuestionWindow[] = result.resolved.map((tf) => ({
+      fields: tf.fields as Record<string, unknown>,
+      range: resolveWindow(tf.fields, now, timezone),
+    }));
+    const ok = !result.abstained && c.ok(windows);
     extract.total += 1;
     if (ok) extract.pass += 1;
     else {
       failures.push({
-        stage: 'extract',
+        stage: 'question',
         cls,
         input: c.question,
-        expected: c.none ? 'no timeframe (default today)' : (c.expect ?? []).join(', '),
-        got: result.abstained ? 'abstained' : JSON.stringify(result.phrases),
+        expected: cls,
+        got: JSON.stringify(result.resolved.map((tf) => tf.fields)),
       });
     }
     onProgress?.(++done, total);
   }
+
 
   const interpretTotals = Object.values(byClass).reduce(
     (acc, e) => ({ pass: acc.pass + e.pass, total: acc.total + e.total }),

--- a/app/src/lib/assistant/parse-context.ts
+++ b/app/src/lib/assistant/parse-context.ts
@@ -1,0 +1,45 @@
+/**
+ * The previous-exchange context that rides the parse, coverage, and time
+ * calls (refs #440, #444), and the helpers that build it. A module of its
+ * own because triage imports the timeframe stage, and the stage needs these
+ * too: the graph must stay acyclic.
+ */
+import { ASSISTANT } from '../zmninja-ng-constants';
+
+/** The previous completed exchange, for classifying a follow-up (refs #440):
+ *  "yes" or "what about the garage?" is unreadable without it. */
+export interface ParseContext {
+  user: string;
+  assistant: string;
+}
+
+/** The latest completed user+assistant exchange BEFORE the message currently
+ *  being classified, or undefined on a fresh thread. */
+export function latestExchange(history: ReadonlyArray<{ role: string; text?: string }>): ParseContext | undefined {
+  for (let i = history.length - 1; i >= 1; i--) {
+    const assistant = history[i];
+    if (assistant.role !== 'assistant' || !assistant.text) continue;
+    for (let j = i - 1; j >= 0; j--) {
+      const user = history[j];
+      if (user.role === 'user' && user.text) return { user: user.text, assistant: assistant.text };
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/** The question as the parse and coverage calls receive it: bare, or wrapped
+ *  with the previous exchange so a short follow-up carries its topic. Both
+ *  turns are trimmed hard - the context is a hint, not a transcript. */
+export function buildContextualQuestion(question: string, context?: ParseContext): string {
+  if (!context) return question;
+  const trim = (text: string) =>
+    text.length > ASSISTANT.parseContextCharacters ? `${text.slice(0, ASSISTANT.parseContextCharacters)}...` : text;
+  return [
+    'Earlier exchange, for context only:',
+    `user: ${trim(context.user)}`,
+    `assistant: ${trim(context.assistant)}`,
+    '',
+    `The LATEST message, the one to classify: ${question}`,
+  ].join('\n');
+}

--- a/app/src/lib/assistant/time-eval-cases.ts
+++ b/app/src/lib/assistant/time-eval-cases.ts
@@ -59,17 +59,6 @@ export interface TimeInterpretCase {
   ok: (fields: Record<string, unknown>, range: ResolvedRange) => boolean;
 }
 
-export interface TimeExtractCase {
-  /** The question fed to `extractTimeframes`. */
-  question: string;
-  /** Class label; defaults to 'extract' when omitted. */
-  cls?: string;
-  /** Each must appear as a normalized substring of some returned phrase. */
-  expect?: string[];
-  /** The question names no time: the extractor must fall to the default
-   *  'today' (it never returns an empty phrase list unless it abstains). */
-  none?: boolean;
-}
 
 /** 36 interpretation cases across 10 CLASSES, not variants of one phrase.
  *  Predicates check the RESOLVED range through resolveWindow whenever a window is
@@ -144,44 +133,54 @@ export const TIME_INTERPRET_CASES: TimeInterpretCase[] = [
   { phrase: 'vorgestern', cls: 'non-english', ok: (_f, r) => startsOn(r, '2026-07-17') },
 ];
 
-/** 16 extraction cases: multiple time expressions in one question, time words
- *  embedded mid-sentence, zero-time questions, one non-English.
- *
- *  A compact clock range on its own ("10am-6pm", "9-5") resolves to an error by
- *  design: a bare time-of-day has no day to anchor it. Extraction must still
- *  surface it verbatim, because the token-level provenance layer (the answering
- *  model copies allowed phrases into `when`) lets the model legally compose it
- *  with a day word drawn from the same question ("10am-6pm" + "yesterday"). */
-export const TIME_EXTRACT_CASES: TimeExtractCase[] = [
-  { question: 'what happened today', expect: ['today'] },
-  { question: 'compare today and yesterday', expect: ['today', 'yesterday'] },
-  { question: 'summarize the past 2 weeks', expect: ['past 2 weeks'] },
-  // The "<n> <unit> ago" family: the interpret cases below have carried
-  // "3 days ago" all along, but nothing checked that the scan FINDS it in a
-  // question, so the whole family fell through to the today default (refs #310).
-  { question: 'what was the busiest hour 2 days ago?', expect: ['2 days ago'] },
-  { question: 'anything two days ago', expect: ['two days ago'] },
-  { question: 'what happened 3 hours ago', expect: ['3 hours ago'] },
-  { question: 'how many people came this morning and this evening', expect: ['this morning', 'this evening'] },
-  { question: 'show me events from july 15 and july 21', expect: ['july 15', 'july 21'] },
-  { question: 'anything between june 1 and june 15', expect: ['june 1', 'june 15'] },
-  { question: 'who came by yesterday from 4pm to 10pm', expect: ['yesterday', '4pm', '10pm'] },
-  // Compact clock ranges: a dash form and a bare "between X and Y", each with a
-  // day word the range attaches to.
-  { question: 'Compare 10am-6pm yesterday and today.', expect: ['10am-6pm', 'yesterday', 'today'] },
-  { question: 'anything between 9-5 today', expect: ['9-5', 'today'] },
-  { question: 'were there cars in the driveway yesterday afternoon', expect: ['yesterday', 'afternoon'] },
-  { question: 'give me a recap of last month', expect: ['last month'] },
-  { question: 'how busy was it in april', expect: ['april'] },
-  // Weekday ranges and the month-word guard (refs #434): the range phrase
-  // must surface whole, and the "may" typo must not scan as a month (the
-  // guard is unit-tested; here the range keeps the case answerable).
-  { question: 'who came by between mon and tue?', expect: ['between mon and tue'] },
-  { question: 'How may folks came to the front of my house between mon and tue?', expect: ['between mon and tue'] },
-  { question: 'who came at lunch 5 days ago', expect: ['lunch', '5 days ago'] },
-  { question: 'how was the rear of my house all this week?', expect: ['all this week'] },
-  { question: 'was war letzte Woche bei mir los', expect: ['letzte woche'] },
-  { question: 'what cameras do I have', none: true },
-  { question: 'is the server ok', none: true },
-  { question: 'list all my monitors', none: true },
+/** One resolved window as the question stage produces it: the parsed fields
+ *  plus their resolveWindow range. */
+export interface ResolvedQuestionWindow {
+  fields: Record<string, unknown>;
+  range: ResolvedRange;
+}
+
+export interface TimeQuestionCase {
+  /** The question fed to `resolveTimeframesFromQuestion`. */
+  question: string;
+  /** Previous exchange, for follow-up and comparison cases (refs #444). */
+  context?: { user: string; assistant: string };
+  /** Class label; defaults to 'question'. */
+  cls?: string;
+  /** Predicate over the RESOLVED windows. A question naming no time arrives
+   *  as one default-today window. */
+  ok: (windows: ResolvedQuestionWindow[]) => boolean;
+}
+
+const oneOn = (ws: ResolvedQuestionWindow[], day: string) => ws.length === 1 && startsOn(ws[0].range, day);
+const someOn = (ws: ResolvedQuestionWindow[], day: string) => ws.some((w) => startsOn(w.range, day));
+const bandedW = (w: ResolvedQuestionWindow) => String(w.fields.fromTime ?? '').length > 0;
+
+/** Whole-question window cases (refs #444), anchored to FM_EVAL_NOW: Sunday
+ *  2026-07-19, America/New_York. Every live failure of the copy pipeline is
+ *  a case here; both eval harnesses run them through the production
+ *  `resolveTimeframesFromQuestion`. */
+export const TIME_QUESTION_CASES: TimeQuestionCase[] = [
+  { question: 'what happened today', ok: (ws) => oneOn(ws, '2026-07-19') },
+  { question: 'compare today and yesterday', ok: (ws) => ws.length === 2 && someOn(ws, '2026-07-19') && someOn(ws, '2026-07-18') },
+  { question: 'summarize the past 2 weeks', ok: (ws) => ws.length === 1 && ((ws[0].fields.lastUnit === 'week' && Number(ws[0].fields.lastCount) === 2) || (ws[0].fields.lastUnit === 'day' && Number(ws[0].fields.lastCount) === 14)) },
+  { question: 'what was the busiest hour 2 days ago?', ok: (ws) => oneOn(ws, '2026-07-17') },
+  { question: 'how many people came this morning and this evening', ok: (ws) => ws.length === 2 && ws.every((w) => startsOn(w.range, '2026-07-19') && bandedW(w)) },
+  { question: 'show me events from july 15 and july 12', ok: (ws) => ws.length === 2 && someOn(ws, '2026-07-15') && someOn(ws, '2026-07-12') },
+  { question: 'who came by yesterday from 4pm to 10pm', ok: (ws) => oneOn(ws, '2026-07-18') && bandedW(ws[0]) },
+  { question: 'Compare 10am-6pm yesterday and today.', ok: (ws) => ws.length === 2 && someOn(ws, '2026-07-18') && someOn(ws, '2026-07-19') && ws.every(bandedW) },
+  { question: 'anything between 9-5 today', ok: (ws) => oneOn(ws, '2026-07-19') && String(ws[0].fields.fromTime ?? '').startsWith('09') },
+  { question: 'were there cars in the driveway yesterday afternoon', ok: (ws) => oneOn(ws, '2026-07-18') && bandedW(ws[0]) },
+  { question: 'give me a recap of last month', ok: (ws) => oneOn(ws, '2026-06-01') },
+  { question: 'how busy was it in april', ok: (ws) => oneOn(ws, '2026-04-01') },
+  { question: 'was war letzte Woche bei mir los', ok: (ws) => ws.length === 1 && (ws[0].fields.week === 'last' || (ws[0].fields.lastUnit === 'week' && Number(ws[0].fields.lastCount) === 1) || (ws[0].fields.lastUnit === 'day' && Number(ws[0].fields.lastCount) === 7) || startsOn(ws[0].range, '2026-07-06')) },
+  { question: 'who came by between mon and tue?', ok: (ws) => oneOn(ws, '2026-07-13') },
+  { question: 'How may folks came to the front of my house between mon and tue?', ok: (ws) => oneOn(ws, '2026-07-13') },
+  { question: 'how was the rear of my house all this week?', ok: (ws) => oneOn(ws, '2026-07-13') },
+  { question: 'who came at lunch 5 days ago', ok: (ws) => oneOn(ws, '2026-07-14') && bandedW(ws[0]) },
+  // The copy pipeline's structural blind spot: a context comparison.
+  { question: 'compare to same day, last week', context: { user: 'hows today?', assistant: 'Today there were 5 events.' }, ok: (ws) => ws.length === 2 && someOn(ws, '2026-07-19') && someOn(ws, '2026-07-12') },
+  // No time named: the default today window.
+  { question: 'what cameras do I have', cls: 'no-time-default', ok: (ws) => oneOn(ws, '2026-07-19') },
+  { question: 'is the server ok', cls: 'no-time-default', ok: (ws) => oneOn(ws, '2026-07-19') },
 ];

--- a/app/src/lib/assistant/timeframe-stage.ts
+++ b/app/src/lib/assistant/timeframe-stage.ts
@@ -1,84 +1,29 @@
 /**
- * Extracts and resolves EVERY timeframe a ZoneMinder question names, before
- * the tool round runs (refs #270).
+ * Resolves every time period a question means, before the tool round runs
+ * (refs #444; the copy-based pipeline this replaced was refs #265/#270).
  *
- * The tool loop asks the model to copy the user's time words into `when` and
- * then interprets each phrase on demand (window-interpreter.ts). On a backend
- * whose runtime owns the tool loop (apple, native) that interpretation would
- * have to nest a second model call INSIDE a tool call, which the native loops
- * cannot do. So this stage front-runs it: one constrained call lists every
- * time expression in the question, each is resolved through the SAME
- * `interpretWhen` (pre-warming its per-day cache, so the later tool call hits
- * the cache and never nests a model call), and the turn learns up front
- * whether the period is knowable at all.
- *
- * Division of labor mirrors the interpreter's (refs #265): the model finds the
- * time words in any language, code decides what to do with them.
- * - No timeframe stated -> "today" (the app's default period).
- * - A stated timeframe that no interpretation can resolve -> abstain: the
- *   caller tells the user it could not work out the period and stops, rather
- *   than answering the wrong window with real data.
- * - Several timeframes -> all of them, so "today vs yesterday" resolves both.
+ * One constrained call takes the WHOLE question (plus the previous exchange
+ * for follow-ups) and expresses each period as a structured window in the
+ * interpreter's own branch shapes, meaning-first. Nothing is copied, so the
+ * copy-truncation class ("same day, last week" -> "last week") cannot occur;
+ * a comparison emits one window per period. Code resolves each window and
+ * seeds the interpreter cache under its meaning label, so the later tool
+ * call resolves with no model at all. The deterministic scan survives as
+ * the fallback and recall floor, not a splicer.
  */
-import { format } from 'date-fns';
-import { toZonedTime } from 'date-fns-tz';
-import { interpretWhen, PART_OF_DAY_WORDS, WEEKDAY_WORDS, WEEKDAY_ABBREVS, MONTH_SEASON_NAMES, AMBIGUOUS_MONTH_WORDS } from './window-interpreter';
+import { interpretWhen, parseFields, seedInterpreterCache, buildQuestionWindowsPrompt, buildQuestionWindowsSchema, questionOffersRolling, PART_OF_DAY_WORDS, WEEKDAY_WORDS, WEEKDAY_ABBREVS, MONTH_SEASON_NAMES, AMBIGUOUS_MONTH_WORDS } from './window-interpreter';
+import { buildContextualQuestion, type ParseContext } from './parse-context';
 import { normalizeWhenPhrase } from './tool-helpers';
 import { log, LogLevel } from '../logger';
 import { WINDOW_UNITS, resolveWindow, type WindowFields } from './event-range';
 import type { AssistantProvider, ResolvedTimeframe } from './types';
 import { isAbortError } from '../is-abort-error';
 
-/** The extractor's output contract, constrained on backends that support it
- *  (Ollama json_schema, WebLLM XGrammar) and parsed defensively everywhere.
- *  `none: true` means the question named no time at all. */
-export const TIMEFRAME_SCHEMA: Record<string, unknown> = {
-  type: 'object',
-  properties: {
-    phrases: { type: 'array', items: { type: 'string' } },
-    none: { type: 'boolean' },
-  },
-  additionalProperties: false,
-};
-
-/** Model-facing (rule 5 exempt): never rendered, only sent to the model. The
- *  `today` line is computed in code so the model never has to know the date. */
-export function buildTimeframePrompt(now: Date, timezone: string): string {
-  const today = format(toZonedTime(now, timezone), 'EEEE, yyyy-MM-dd');
-  return [
-    'You find the time expressions in one question about security-camera events. Reply with ONLY one JSON object.',
-    `Today is ${today} (timezone ${timezone}).`,
-    'A time expression is ANY phrase naming when events happened: a day ("today", "yesterday"), a rolling span',
-    '("the past 2 weeks", "last month"), a part of the day ("this morning", "this evening"), a month or season',
-    '("april", "this summer"), a weekday, a date ("July 21"), or a clock range, whether written out',
-    '("from 4pm to 10pm", "between 9am and 5pm") or compact ("10am-6pm", "9-5"). They are',
-    'often embedded mid-sentence: "how busy was it in april" contains "april".',
-    'List every one in "phrases", each copied VERBATIM in the user\'s own language ("today", "letzte Woche", "in april").',
-    'Do not translate, normalize, invent, or add a time the question does not state.',
-    'A question may hold several time expressions, or none.',
-    'Set "none" true and "phrases" [] when the question names no time at all.',
-  ].join('\n');
-}
-
 /** The one system line handed to the answering model, naming the exact phrases
  *  it may copy into `when`. Model-facing (rule 5 exempt). */
 export function buildTimeframeSystemLine(phrases: string[]): string {
   const quoted = phrases.map((phrase) => `"${phrase}"`).join(', ');
   return `Timeframes for this question, already resolved (copy these exact phrases into when): ${quoted}.`;
-}
-
-/** The phrases array from the extractor's reply, or [] when unparseable.
- *  Defensive: an unconstrained backend may wrap the object in prose. */
-function parsePhrases(text: string): string[] {
-  const match = /\{[\s\S]*\}/.exec(text);
-  if (!match) return [];
-  try {
-    const raw = JSON.parse(match[0]) as Record<string, unknown>;
-    if (!Array.isArray(raw.phrases)) return [];
-    return raw.phrases.map((entry) => String(entry).trim()).filter((entry) => entry.length > 0);
-  } catch {
-    return [];
-  }
 }
 
 /** A clock token: "4pm", "9 am", "16:30", "9:00pm". Requires a meridian or a
@@ -197,138 +142,83 @@ export interface ExtractedTimeframes {
 }
 
 /**
- * Every timeframe the question resolves to, or an abstention.
- *
- * ONE constrained model call finds the time words; each is then resolved
- * through `interpretWhen`, which caches the result for this calendar day so
- * the later tool call reuses it. A phrase no interpretation can turn into a
- * window is dropped. Never throws except on abort (which propagates from the
- * model calls, matching the rest of the assistant path).
+ * The primary time path on EVERY backend (refs #444): the whole-question
+ * windows interrogation, probed 13/13 on the live-failure matrix. Falls back
+ * to the scan floor on any failure; abstains only when the model saw a
+ * period nothing could resolve and the scan sees no time words either.
  */
-export async function extractTimeframes(
+export async function resolveTimeframesFromQuestion(
   question: string,
   provider: AssistantProvider,
   now: Date,
   timezone: string,
   signal: AbortSignal,
-  /** Time phrases the parse call already copied (refs #434). Given (even
-   *  []), the extraction model call is SKIPPED and these stand in for its
-   *  output: the scan union, provenance filter, containment dedup, and
-   *  interpreter calls below are identical either way. `undefined` keeps the
-   *  old extraction call, so a roster-less install and group mode still
-   *  extract. */
-  statedPhrases?: string[],
+  context?: ParseContext,
 ): Promise<ExtractedTimeframes> {
-  // Code-first extraction (refs #270): a deterministic scan OWNS every time class
-  // it can recognize, so the shapes that flaked on-device (compact clock ranges
-  // never surfacing, multi-value lists dropping members, even "last month"
-  // vanishing once: measured 11-12/16 across FM runs) are decided in code, not
-  // left to a nondeterministic decoder whose worst shape is exactly a free-string
-  // array. The model call still runs and only ADDS phrasings code cannot see
-  // (unlisted languages, odd wording), so extraction flakiness is bounded to
-  // phrasings no scanner could detect.
-  const scanPhrases = scanTimeExpressions(question);
-
-  let extracted: string[] = [];
-  if (statedPhrases !== undefined) {
-    extracted = statedPhrases;
-  } else {
-    try {
-      const reply = await provider.complete(buildTimeframePrompt(now, timezone), question, signal, TIMEFRAME_SCHEMA);
-      extracted = parsePhrases(reply.text);
-    } catch (error) {
-      if (isAbortError(error)) throw error;
-      log.assistant('Timeframe extraction failed', LogLevel.WARN, {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      // With the scan in hand the turn is not blind when the model call fails: only
-      // fall straight to the default period when the scan also found nothing (the
-      // pre-scan fail-open path). Otherwise proceed on the scan phrases alone.
-      if (scanPhrases.length === 0) return { phrases: ['today'], resolved: [], abstained: false };
-    }
+  let windows: unknown[] = [];
+  try {
+    const reply = await provider.complete(
+      buildQuestionWindowsPrompt(now, timezone),
+      buildContextualQuestion(question, context),
+      signal,
+      buildQuestionWindowsSchema(questionOffersRolling(question)),
+    );
+    const raw = JSON.parse(/\{[\s\S]*\}/.exec(reply.text)?.[0] ?? '{}') as { windows?: unknown[] };
+    windows = Array.isArray(raw.windows) ? raw.windows : [];
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    log.assistant('Question-window interrogation failed; falling back to the scan', LogLevel.WARN, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return scanFallbackTimeframes(question, provider, now, timezone, signal);
   }
 
-  // The model parrots the prompt's own date line (buildTimeframePrompt names
-  // today, the weekday, the ISO date and the timezone), so the extractor returns
-  // time words the user never typed. Provenance is decidable in code, exactly as
-  // whenNotFromQuestion decides it: a phrase that truly came from the question is
-  // a substring of it. Filter the MODEL's phrases to those; scan phrases are
-  // verbatim substrings by construction and never need this filter.
-  const normalizedQuestion = normalizeWhenPhrase(question);
-  const modelStated = extracted.filter((phrase) => {
-    if (normalizedQuestion.includes(normalizeWhenPhrase(phrase))) return true;
-    log.assistant('Dropped parroted timeframe phrase', LogLevel.DEBUG, { phrase });
-    return false;
-  });
-
-  // Union scan + model, de-duped on the normalized form: the scan owns its
-  // classes and wins ties (listed first, in question order), the model only adds
-  // a phrase whose normalized form the scan did not already cover.
-  const scanKeys = new Set(scanPhrases.map(normalizeWhenPhrase));
+  const resolved: ResolvedTimeframe[] = [];
   const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const phrase of [...scanPhrases, ...modelStated]) {
+  for (const [index, item] of windows.entries()) {
+    if (item === null || typeof item !== 'object') continue;
+    // Production parse, never a raw field read (refs #442): parseFields is
+    // the one place every schema field round-trips.
+    const fields = parseFields(JSON.stringify(item));
+    if (!fields) continue;
+    const window = resolveWindow(fields, now, timezone);
+    if (window === undefined || 'error' in window) continue;
+    const meaning = typeof (item as { meaning?: unknown }).meaning === 'string' ? (item as { meaning: string }).meaning.trim() : '';
+    const phrase = meaning.length > 0 ? meaning : `window ${index + 1}`;
     const key = normalizeWhenPhrase(phrase);
     if (seen.has(key)) continue;
     seen.add(key);
-    deduped.push(phrase);
+    resolved.push({ phrase, fields });
+    seedInterpreterCache(phrase, fields, now, timezone);
   }
-  const namedTime = deduped.length > 0;
 
-  const resolvedByKey = new Map<string, WindowFields>();
-  const windowfulKeys = new Set<string>();
-  for (const phrase of namedTime ? deduped : ['today']) {
+  if (resolved.length > 0) {
+    return { phrases: resolved.map((tf) => tf.phrase), resolved, abstained: false };
+  }
+  if (windows.length > 0 && scanTimeExpressions(question).length === 0) {
+    return { phrases: [], resolved: [], abstained: true };
+  }
+  return scanFallbackTimeframes(question, provider, now, timezone, signal);
+}
+
+/** The deterministic floor: the scan's phrases through the per-phrase
+ *  interpreter, the today default when it finds nothing. Never abstains -
+ *  every phrase here is scan-vouched, and an unresolved one retries at tool
+ *  time exactly as before. */
+async function scanFallbackTimeframes(
+  question: string,
+  provider: AssistantProvider,
+  now: Date,
+  timezone: string,
+  signal: AbortSignal,
+): Promise<ExtractedTimeframes> {
+  const scanPhrases = scanTimeExpressions(question);
+  const phrases = scanPhrases.length > 0 ? scanPhrases : ['today'];
+  const resolved: ResolvedTimeframe[] = [];
+  for (const phrase of phrases) {
     const fields = await interpretWhen(phrase, provider, now, timezone, signal);
     if ('error' in fields && fields.error) continue;
-    const key = normalizeWhenPhrase(phrase);
-    resolvedByKey.set(key, fields as WindowFields);
-    // "Resolved" and "resolved to a WINDOW" differ: none/{} interprets
-    // cleanly but names no period, and such a container must not absorb a
-    // scan-vouched contained phrase (refs #442: "all this week" once
-    // interpreted to nothing and killed "this week" with it).
-    const window = resolveWindow(fields as WindowFields, now, timezone);
-    if (window !== undefined && !('error' in window)) windowfulKeys.add(key);
+    resolved.push({ phrase, fields: fields as WindowFields });
   }
-
-  // Containment dedup, resolution-aware (refs #434, #438): the scan emits
-  // the halves of a compound ("lunch", "5 days ago") while the model copies
-  // it whole; querying both the whole day and the band would double the
-  // fan-out, so a contained phrase is absorbed - but ONLY by a container
-  // that actually resolved. "all this week" once swallowed the scan-vouched
-  // "this week" and then failed to interpret, leaving the turn nothing.
-  const union = deduped.filter((phrase) => {
-    const key = normalizeWhenPhrase(phrase);
-    return !deduped.some((other) => {
-      const otherKey = normalizeWhenPhrase(other);
-      return otherKey !== key && otherKey.includes(key) && windowfulKeys.has(otherKey);
-    });
-  });
-
-  const resolved: ResolvedTimeframe[] = [];
-  for (const phrase of namedTime ? union : ['today']) {
-    const fields = resolvedByKey.get(normalizeWhenPhrase(phrase));
-    if (fields !== undefined) resolved.push({ phrase, fields });
-  }
-
-  // Neither path named a time: the default period, kept even if it failed to
-  // resolve so the turn still proceeds on today.
-  if (!namedTime) return { phrases: ['today'], resolved, abstained: false };
-
-  // A phrase survives into the allowed list if it resolved OR the scan detected
-  // it. An unresolvable compact clock range ("10am-6pm", "9-5", "from 4pm to
-  // 10pm") carries no day to anchor it, yet the token-level provenance layer lets
-  // the answering model legally compose it with a day word from the same
-  // question, so it must still be offered. An unresolved MODEL-only phrase
-  // ("blursday") is a hallucinated period and is dropped.
-  const resolvedKeys = new Set(resolved.map((tf) => normalizeWhenPhrase(tf.phrase)));
-  const phrases = union.filter((phrase) => {
-    const key = normalizeWhenPhrase(phrase);
-    return resolvedKeys.has(key) || scanKeys.has(key);
-  });
-
-  // Everything stated failed to resolve and the scan vouched for nothing: the
-  // question named a period no interpretation could work out, so abstain rather
-  // than answer a wrong window with real data.
-  if (phrases.length === 0) return { phrases: [], resolved: [], abstained: true };
   return { phrases, resolved, abstained: false };
 }

--- a/app/src/lib/assistant/triage.ts
+++ b/app/src/lib/assistant/triage.ts
@@ -20,47 +20,11 @@ import type { AssistantMessage, AssistantProvider, AssistantStatus, TraceEntry }
 import { sanitizeModelText } from './sanitize';
 import { log, LogLevel } from '../logger';
 import { isAbortError } from '../is-abort-error';
-import { ASSISTANT } from '../zmninja-ng-constants';
+import { buildContextualQuestion, type ParseContext } from './parse-context';
+
+export { buildContextualQuestion, latestExchange, type ParseContext } from './parse-context';
 
 export type RequestKind = 'zoneminder' | 'chat' | 'action';
-
-/** The previous completed exchange, for classifying a follow-up (refs #440):
- *  "yes" or "what about the garage?" is unreadable without it. */
-export interface ParseContext {
-  user: string;
-  assistant: string;
-}
-
-/** The latest completed user+assistant exchange BEFORE the message currently
- *  being classified, or undefined on a fresh thread. */
-export function latestExchange(history: ReadonlyArray<{ role: string; text?: string }>): ParseContext | undefined {
-  for (let i = history.length - 1; i >= 1; i--) {
-    const assistant = history[i];
-    if (assistant.role !== 'assistant' || !assistant.text) continue;
-    for (let j = i - 1; j >= 0; j--) {
-      const user = history[j];
-      if (user.role === 'user' && user.text) return { user: user.text, assistant: assistant.text };
-    }
-    return undefined;
-  }
-  return undefined;
-}
-
-/** The question as the parse and coverage calls receive it: bare, or wrapped
- *  with the previous exchange so a short follow-up carries its topic. Both
- *  turns are trimmed hard - the context is a hint, not a transcript. */
-export function buildContextualQuestion(question: string, context?: ParseContext): string {
-  if (!context) return question;
-  const trim = (text: string) =>
-    text.length > ASSISTANT.parseContextCharacters ? `${text.slice(0, ASSISTANT.parseContextCharacters)}...` : text;
-  return [
-    'Earlier exchange, for context only:',
-    `user: ${trim(context.user)}`,
-    `assistant: ${trim(context.assistant)}`,
-    '',
-    `The LATEST message, the one to classify: ${question}`,
-  ].join('\n');
-}
 
 /** What the events/monitors/server question is about; `other` falls back to
  *  the free tool loop (refs #432). */
@@ -84,6 +48,7 @@ export interface TriageVerdict {
    *  interpretation stay there. Absent without a roster. */
   when?: string[];
 }
+
 
 /** Model-facing (rule 5 exempt): never rendered, only matched below.
  *
@@ -170,9 +135,6 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
         '"subject": what the message asks about. events - what happened, who or what came by, was seen,',
         "detected, or counted. monitors - the camera list or a camera's state. server - health or whether",
         'the system is up. groups - monitor groups. other - anything else.',
-        '"when": every time expression the message names, each copied VERBATIM in its own language',
-        '("today", "letzte Woche", "between mon and tue", "at lunch 5 days ago"); [] when it names none.',
-        'Copy whole compound phrases; never invent, translate, or normalize a time.',
         ...(labels.length > 0
           ? [
               '"objects": every listed label the message asks about, judged by meaning ("folks" or "Leute" mean',
@@ -181,7 +143,7 @@ const triagePromptLines = (servers: readonly string[], monitors: readonly string
             ]
           : []),
         '',
-        `Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "subject", "when"${labels.length > 0 ? ', and "objects"' : ''}.`,
+        `Reply with "kind" (ZONEMINDER, ACTION, or CHAT), "subject"${labels.length > 0 ? ', and "objects"' : ''}.`,
       ]
     : ['Reply with one word: ZONEMINDER, ACTION, or CHAT.']),
 ];
@@ -217,11 +179,8 @@ export function buildTriageSchema(monitors: readonly string[], labels: readonly 
       kind: { type: 'string', enum: ['ZONEMINDER', 'ACTION', 'CHAT'] },
       subject: { type: 'string', enum: [...QUERY_SUBJECTS] },
       ...(labels.length > 0 ? { objects: { type: 'array', items: { type: 'string', enum: [...labels] } } } : {}),
-      // Free strings by necessity (no enum can list every time phrase); the
-      // timeframe stage's provenance filter distrusts them (refs #434).
-      when: { type: 'array', items: { type: 'string' } },
     },
-    required: ['kind', 'subject', ...(labels.length > 0 ? ['objects'] : []), 'when'],
+    required: ['kind', 'subject', ...(labels.length > 0 ? ['objects'] : [])],
     additionalProperties: false,
   };
 }
@@ -267,7 +226,7 @@ export function parseTriageSlots(
   labels: readonly string[] = [],
 ): Omit<TriageVerdict, 'kind'> {
   if (monitors.length === 0) return {};
-  let raw: { subject?: unknown; objects?: unknown; when?: unknown };
+  let raw: { subject?: unknown; objects?: unknown };
   try {
     raw = JSON.parse(reply) as typeof raw;
   } catch {
@@ -283,12 +242,6 @@ export function parseTriageSlots(
     // (observed live on "how busy...", refs #436), and as a filter it
     // silently EXCLUDES events with no detection at all: derive no filter.
     slots.objects = labels.length > 1 && objects.length === labels.length ? [] : objects;
-  }
-  if (Array.isArray(raw.when)) {
-    slots.when = raw.when
-      .filter((w): w is string => typeof w === 'string')
-      .map((w) => w.trim())
-      .filter((w) => w.length > 0);
   }
   return slots;
 }

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -232,10 +232,12 @@ function wrap(picked: Array<Record<string, unknown>>): Record<string, unknown> {
  *  app executes. Exported so the eval harness scores EXACTLY what production
  *  sends: a hand-copied prompt in the harness drifted the moment this one
  *  changed, and measured a bug the app did not have. */
-export function buildInterpreterPrompt(now: Date, timezone: string): string {
+/** The field-teaching lines both time prompts share: the per-phrase
+ *  interpreter and the whole-question windows interrogation (refs #444)
+ *  must teach identical vocabulary or their answers drift apart. */
+function fieldTeachingLines(now: Date, timezone: string): string[] {
   const today = format(toZonedTime(now, timezone), 'EEEE, yyyy-MM-dd');
   return [
-    'You convert a human time phrase into a JSON time window. Reply with ONLY one JSON object.',
     `Today is ${today} (timezone ${timezone}).`,
     'Fields (use the fewest that express the phrase):',
     '- lastCount + lastUnit: a rolling span ending now. "past 2 weeks" -> {"lastCount":2,"lastUnit":"week"}; "last 6 hours" -> {"lastCount":6,"lastUnit":"hour"}.',
@@ -258,12 +260,82 @@ export function buildInterpreterPrompt(now: Date, timezone: string): string {
     // it and a real window with it; restating the meaning puts the phrase's
     // actual coverage in front of the decoder before any field is chosen.
     'ALWAYS fill "meaning" first: one short sentence saying exactly which days (and hours) the phrase covers. Then the fields that express it.',
+  ];
+}
+
+/** Model-facing (rule 5 exempt): the per-phrase interpreter prompt, used by
+ *  the scan fallback and any tool-time cache miss. */
+export function buildInterpreterPrompt(now: Date, timezone: string): string {
+  return [
+    'You convert a human time phrase into a JSON time window. Reply with ONLY one JSON object.',
+    ...fieldTeachingLines(now, timezone),
   ].join('\n');
+}
+
+/** Model-facing (rule 5 exempt): the whole-question interrogation (refs
+ *  #444), the primary time path on every backend. Nothing is copied - the
+ *  model expresses each period the question means as one window object -
+ *  so the copy-truncation failure class ("same day, last week" -> "last
+ *  week") cannot occur. Probed 13/13 on the live-failure matrix. */
+export function buildQuestionWindowsPrompt(now: Date, timezone: string): string {
+  return [
+    'You express every time period one QUESTION means, as a list of JSON time windows. Reply with ONLY one JSON object: {"windows":[...]}, one window object per period the question asks about.',
+    ...fieldTeachingLines(now, timezone),
+    // The probe's measured tail, in its winning order (refs #444): the
+    // anti-attractor rules live HERE and not in the shared lines, because
+    // sharing them regressed the per-phrase interpreter (ayer, last tuesday
+    // night) while the windows call needs them against rolling collapse.
+    '"same day last week" or "a week ago today" -> {"daysAgo":7}: ONE single day, never a rolling span.',
+    '"this/last <week, month, year>" means that CALENDAR unit, never a rolling span: "all this week" -> {"week":"this"}; "last month" -> the previous month as fromDate/toDate. Only a counted "past/last N <units>" is rolling. Your fields must express exactly what your own "meaning" sentence says.',
+    'A comparison means one window PER compared period: "compare to same day, last week" asked after a question about today is TWO windows - {"daysAgo":0} and {"daysAgo":7} - never one span covering both.',
+    'The question may include an earlier exchange for context: a comparison or follow-up can mean a period from that exchange plus a new one - emit BOTH as windows.',
+    '"windows" is [] when the question names no time at all.',
+    'Every window object starts with its own "meaning" sentence, then the fields. Each "meaning" names exactly ONE period ("today", "the same day one week back") - never the comparison or the question.',
+  ].join('\n');
+}
+
+/** Whether the question carries any counted-rolling marker ("past 2 weeks",
+ *  "last 6 hours", "an hour ago") or a sub-day unit word. The rolling branch
+ *  is the decoder's attractor - "what happened today" decoded lastCount 1
+ *  day 2/2 with it offered - so, exactly like selectBranches per phrase, the
+ *  windows schema offers it only when the question can actually mean one.
+ *  English unit words: an unlisted language loses counted-rolling and falls
+ *  to a calendar span, never worse than a wrong window. */
+const QUESTION_ROLLING_RE =
+  /\b(?:past|last|previous)\s+(?:\d+|an?|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:minute|hour|day|week|month|year)s?\b|\b(?:minute|hour)s?\b/i;
+
+export function questionOffersRolling(question: string): boolean {
+  return QUESTION_ROLLING_RE.test(question);
+}
+
+/** The windows-array schema: each item is one of WINDOW_SCHEMA's own
+ *  branches, so a window that no branch can express is undecodable. The
+ *  rolling branch rides only when the question shows a rolling marker. */
+export function buildQuestionWindowsSchema(offerRolling = true): Record<string, unknown> {
+  const branches = (WINDOW_SCHEMA as { anyOf: Array<{ required: string[] }> }).anyOf;
+  const offered = offerRolling ? branches : branches.filter((b) => !b.required.includes('lastCount'));
+  return {
+    type: 'object',
+    properties: { windows: { type: 'array', items: { anyOf: offered } } },
+    required: ['windows'],
+    additionalProperties: false,
+  };
 }
 
 /** Session cache: the same phrase on the same calendar day means the same
  *  window, and "yesterday"/"today" repeat constantly. */
 const CACHE = new Map<string, WindowFields | { error: string }>();
+
+function windowCacheKey(phrase: string, now: Date, timezone: string): string {
+  return `${format(toZonedTime(now, timezone), 'yyyy-MM-dd')}::${timezone}::${phrase.trim().toLowerCase()}`;
+}
+
+/** Seeds the per-day cache with fields the windows interrogation already
+ *  produced (refs #444), keyed by the window's meaning label, so a tool-time
+ *  interpretWhen on that label resolves without any model call. */
+export function seedInterpreterCache(phrase: string, fields: WindowFields, now: Date, timezone: string): void {
+  CACHE.set(windowCacheKey(phrase, now, timezone), fields);
+}
 
 /** Test-only. */
 export function resetWindowInterpreterCacheForTests(): void {
@@ -279,7 +351,7 @@ export async function interpretWhen(
   timezone: string,
   signal: AbortSignal,
 ): Promise<WindowFields | { error: string }> {
-  const cacheKey = `${format(toZonedTime(now, timezone), 'yyyy-MM-dd')}::${timezone}::${phrase.trim().toLowerCase()}`;
+  const cacheKey = windowCacheKey(phrase, now, timezone);
   const cached = CACHE.get(cacheKey);
   if (cached) return cached;
 


### PR DESCRIPTION
Fixes #444.

## Acceptance
- "resolveTimeframesFromQuestion: one model call, windows parsed through production parseFields, resolved via resolveWindow, meanings become the `when` labels with their fields seeded into the interpreter cache so tools never re-interpret." — done, unit-tested (single-call assertion, cache-seed assertion, junk-window skipping).
- "'compare to same day, last week' after a today question plans TWO windows: today and exactly one day (daysAgo 7)." — done; eval case passes through the production function.
- "Zero resolvable windows falls back" — to the deterministic scan floor. Per the maintainer's mid-review direction the old extraction model call is DELETED, not kept as a second pipeline, and the Ollama-only gating in the original acceptance was overridden: the same path runs on every backend.
- "A whole-question time eval stage runs the production function over the shared case list and is recorded in llm-models.md; existing scores hold." — both harnesses (prompt-eval via a provider shim, fm-eval) run `resolveTimeframesFromQuestion` end to end; recorded.

## Deleted with the copy step
Extraction call + prompt + schema, phrase provenance filter, scan/model union, containment dedup, the parse's `when` slot. New structural narrowing: the rolling branch is offered only when the question shows a rolling marker (selectBranches lifted to question level).

## Scores (qwen3:8b, temp 0, reasoning none)
| stage | score |
|---|---|
| time — all classes incl. 36/36 question windows | 124/124 |
| routing | 36/36 |
| coverage | 20/20 |
| triage (roster-less) | 38/38 |

On-device (Apple FM, Gemini Nano) runs the identical path but is unmeasured there — array-of-anyOf schemas are untested on those runtimes; the settings time eval now scores the real path when run on a device. Recorded in `llm-models.md`.

Gates: `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5