### PR TITLE
fix(assistant): calendar month field - 'this month' ran as a rolling 30 days on Gemini Nano

### DIFF
--- a/agents/project/llm-models.md
+++ b/agents/project/llm-models.md
@@ -136,7 +136,15 @@ after any prompt or provider change and put both scores in the PR.
   parse scores 36/36 and the separate extraction call is gone on the roster
   lane; the eval's extract stage still measures the roster-less fallback's
   model-only recall, where multi-phrase misses are pre-existing and the
-  scan union covers them. After the #438 split, routing scores 24/24 and
+  scan union covers them. First on-device datapoint (refs #449, Pixel 10
+  logcat): Gemini Nano ran "this month" as a ROLLING 30 days - schema
+  gating is decorative on a backend that cannot constrain decoding, so
+  every calendar concept needs a first-class field with code arithmetic
+  (`month: this|last` added, mirroring `week`); a parse-time veto of
+  un-offered branches was considered and rejected (it would turn an English
+  regex into an output gate and break non-English rolling phrases). qwen3:8b
+  adopted the new field unprompted and holds time 124/124; Nano's own score
+  comes from the settings system-model eval, run on the device. After the #438 split, routing scores 24/24 and
   coverage 18/18, with every interpret class at 100% including the new
   calendar-week field and the meaning-first branches. With the #440
   context and app-default additions, routing scores 36/36 (standalone

--- a/app/src/lib/assistant/__tests__/event-range.test.ts
+++ b/app/src/lib/assistant/__tests__/event-range.test.ts
@@ -307,3 +307,27 @@ describe('calendar weeks', () => {
     expect(at({ week: 'this', daysAgo: 1 })).toHaveProperty('error');
   });
 });
+
+/** Refs #449: "this month" on Gemini Nano ran as a rolling 30 days because
+ *  the vocabulary had no calendar-month word. Code does the arithmetic;
+ *  NOW is Thursday 2026-07-16. */
+describe('calendar months', () => {
+  it('resolves this month from the 1st through now', () => {
+    expect(at({ month: 'this' })).toEqual({
+      startDateTime: '2026-07-01 00:00:00',
+      endDateTime: '2026-07-16 10:30:00',
+    });
+  });
+
+  it('resolves last month as the whole previous month', () => {
+    expect(at({ month: 'last' })).toEqual({
+      startDateTime: '2026-06-01 00:00:00',
+      endDateTime: '2026-07-01 00:00:00',
+    });
+  });
+
+  it('rejects unknown values and mixing with other shapes', () => {
+    expect(at({ month: 'next' })).toHaveProperty('error');
+    expect(at({ month: 'this', week: 'this' })).toHaveProperty('error');
+  });
+});

--- a/app/src/lib/assistant/__tests__/window-interpreter.test.ts
+++ b/app/src/lib/assistant/__tests__/window-interpreter.test.ts
@@ -362,3 +362,16 @@ describe('questionOffersRolling', () => {
     expect(off).not.toContain('lastCount');
   });
 });
+
+/** Refs #449: the calendar-month field, same shape as week. */
+describe('calendar-month field', () => {
+  beforeEach(() => resetWindowInterpreterCacheForTests());
+
+  it('has a branch, is taught in both prompts, and round-trips the parser', async () => {
+    const branches = WINDOW_SCHEMA.anyOf as Array<{ required: string[] }>;
+    expect(branches.some((b) => b.required.includes('month'))).toBe(true);
+    expect(buildInterpreterPrompt(new Date('2026-07-16T14:30:00Z'), 'UTC')).toContain('"month"');
+    const p = providerSaying('{"meaning":"this calendar month","month":"this"}');
+    expect(await interpretWhen('this month', p, NOW, 'UTC', new AbortController().signal)).toEqual({ month: 'this' });
+  });
+});

--- a/app/src/lib/assistant/event-range.ts
+++ b/app/src/lib/assistant/event-range.ts
@@ -56,6 +56,11 @@ export interface WindowFields {
    *  is Monday 00:00 through now, "last" the previous Monday through
    *  Sunday. Distinct from a rolling lastUnit:"week", which ends now. */
   week?: string;
+  /** A calendar month, resolved in code (refs #449): "this" is the 1st
+   *  through now, "last" the whole previous month. Exists because a
+   *  schema-less backend (Gemini Nano) expressed "this month" as a rolling
+   *  30 days - the vocabulary simply had no calendar-month word. */
+  month?: string;
   /** Most recent past day with this day-of-month number (1-31): "the 21st".
    *  Code finds the date, exactly as `weekday` finds the most recent weekday,
    *  because a small model resolves a bare ordinal to the wrong ISO date. */
@@ -146,16 +151,30 @@ export function resolveWindow(
   now: Date,
   timezone: string,
 ): ResolvedEventRange | { error: string } | undefined {
-  const { lastCount, lastUnit, daysAgo, weekday, fromWeekday, toWeekday, week, dayOfMonth, weekend, date, fromDate, toDate, fromTime, toTime } = fields;
+  const { lastCount, lastUnit, daysAgo, weekday, fromWeekday, toWeekday, week, month, dayOfMonth, weekend, date, fromDate, toDate, fromTime, toTime } = fields;
   const dayPickers = [daysAgo !== undefined, weekday !== undefined, dayOfMonth !== undefined, date !== undefined].filter(Boolean).length;
   const rolling = lastCount !== undefined || lastUnit !== undefined;
   const ranged = fromDate !== undefined || toDate !== undefined;
   const weekendShape = weekend !== undefined;
   const weekdayRange = fromWeekday !== undefined || toWeekday !== undefined;
   const weekShape = week !== undefined;
+  const monthShape = month !== undefined;
 
-  if ([rolling, dayPickers > 0, ranged, weekendShape, weekdayRange, weekShape].filter(Boolean).length > 1) {
-    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, dayOfMonth, or date), a weekday span (fromWeekday+toWeekday), a calendar week, a weekend, or a span (fromDate/toDate).' };
+  if ([rolling, dayPickers > 0, ranged, weekendShape, weekdayRange, weekShape, monthShape].filter(Boolean).length > 1) {
+    return { error: 'Send ONE window shape: a rolling window (lastCount+lastUnit), a day (daysAgo, weekday, dayOfMonth, or date), a weekday span (fromWeekday+toWeekday), a calendar week, a calendar month, a weekend, or a span (fromDate/toDate).' };
+  }
+
+  if (monthShape) {
+    if (month !== 'this' && month !== 'last') {
+      return { error: `month must be "this" or "last". Received "${String(month)}".` };
+    }
+    const zonedNow = toZonedTime(now, timezone);
+    const first = new Date(zonedNow.getFullYear(), zonedNow.getMonth() - (month === 'last' ? 1 : 0), 1);
+    const nextFirst = new Date(first.getFullYear(), first.getMonth() + 1, 1);
+    const start = fromZonedTime(first, timezone);
+    const endRaw = fromZonedTime(nextFirst, timezone);
+    const end = endRaw.getTime() > now.getTime() ? now : endRaw;
+    return { startDateTime: formatForZm(start, timezone), endDateTime: formatForZm(end, timezone) };
   }
 
   if (weekShape) {

--- a/app/src/lib/assistant/time-eval-cases.ts
+++ b/app/src/lib/assistant/time-eval-cases.ts
@@ -113,8 +113,8 @@ export const TIME_INTERPRET_CASES: TimeInterpretCase[] = [
   // which resolveWindow clamps to the real last day)
   { phrase: 'april', cls: 'month-year', ok: (_f, r) => startsOn(r, '2026-04-01') && endsOnDate(r, '2026-05-01') },
   { phrase: 'february', cls: 'month-year', ok: (_f, r) => startsOn(r, '2026-02-01') && endsOnDate(r, '2026-03-01') },
-  { phrase: 'this month', cls: 'month-year', ok: (f, r) => f.fromDate === '2026-07-01' && endsBy(r, '2026-07-19') },
-  { phrase: 'last month', cls: 'month-year', ok: (f) => (f.fromDate === '2026-06-01' && f.toDate === '2026-06-30') || (f.lastUnit === 'month' && f.lastCount === 1) },
+  { phrase: 'this month', cls: 'month-year', ok: (f, r) => f.month === 'this' || (f.fromDate === '2026-07-01' && endsBy(r, '2026-07-19')) },
+  { phrase: 'last month', cls: 'month-year', ok: (f) => f.month === 'last' || (f.fromDate === '2026-06-01' && f.toDate === '2026-06-30') || (f.lastUnit === 'month' && f.lastCount === 1) },
   { phrase: 'this year', cls: 'month-year', ok: (f, r) => f.fromDate === '2026-01-01' && endsBy(r, '2026-07-19') },
   { phrase: 'since july 1', cls: 'month-year', ok: (f) => f.fromDate === '2026-07-01' && (f.toDate === undefined || String(f.toDate) >= '2026-07-19') },
   // clock ranges (resolved endpoints: a date branch that lands on the same day is

--- a/app/src/lib/assistant/window-interpreter.ts
+++ b/app/src/lib/assistant/window-interpreter.ts
@@ -67,6 +67,8 @@ export const WINDOW_SCHEMA: Record<string, unknown> = {
     { type: 'object', properties: { meaning: { type: 'string' }, weekday: { type: 'string', enum: [...WEEKDAYS] }, fromTime: { type: 'string' }, toTime: { type: 'string' } }, required: ['meaning', 'weekday'], additionalProperties: false },
     // a calendar week, Monday-anchored; code works out the dates (refs #438).
     { type: 'object', properties: { meaning: { type: 'string' }, week: { type: 'string', enum: ['this', 'last'] } }, required: ['meaning', 'week'], additionalProperties: false },
+    // a calendar month; code works out the dates (refs #449).
+    { type: 'object', properties: { meaning: { type: 'string' }, month: { type: 'string', enum: ['this', 'last'] } }, required: ['meaning', 'month'], additionalProperties: false },
     // a span between two weekdays ("between mon and tue"); code works out the
     // dates, so the model never anchors the wrong calendar day (refs #434).
     { type: 'object', properties: { meaning: { type: 'string' }, fromWeekday: { type: 'string', enum: [...WEEKDAYS] }, toWeekday: { type: 'string', enum: [...WEEKDAYS] } }, required: ['meaning', 'fromWeekday', 'toWeekday'], additionalProperties: false },
@@ -245,10 +247,11 @@ function fieldTeachingLines(now: Date, timezone: string): string[] {
     '- weekday: the most recent such day. "on sunday" -> {"weekday":"sunday"}; "last tuesday" -> {"weekday":"tuesday"}.',
     '- fromWeekday + toWeekday: a span between two weekdays, full names. "between mon and tue" -> {"fromWeekday":"monday","toWeekday":"tuesday"}; "from friday to sunday" -> {"fromWeekday":"friday","toWeekday":"sunday"}. Code works out the dates, so do NOT send fromDate/toDate for these.',
     '- "week": a calendar week, Monday-anchored. "this week" or "all this week" -> {"week":"this"}; "last week" -> {"week":"last"}. Code works out the dates; never send fromDate/toDate for these.',
+    '- "month": ONLY the words "this month" or "last month". "this month" -> {"month":"this"}; "last month" -> {"month":"last"}. Code works out the dates. A NAMED month ("april", "june") is NEVER this field: name it with fromDate+toDate.',
     '- dayOfMonth: a bare ordinal, just the number. "the 21st" -> {"dayOfMonth":21}; "on the 3rd" -> {"dayOfMonth":3}. Code picks the most recent past such day, so do NOT work out the date yourself.',
     '- weekend: which past weekend, ONLY when the phrase literally says "weekend". "this weekend" -> {"weekend":"this"}; "last weekend" -> {"weekend":"last"}; "two weekends ago" -> {"weekend":"two-ago"}. Code works out the two dates.',
     '- date: one explicit calendar date. "July 15" -> {"date":"2026-07-15"} (use the year that makes it most recent, never future).',
-    '- fromDate + toDate: a calendar span, both inclusive. "april" -> {"fromDate":"2026-04-01","toDate":"2026-04-30"}. "this month" -> the 1st of the current month through today. "this year" -> {"fromDate":"2026-01-01","toDate":"2026-12-31"}. "june 1 to 15" -> both dates. Either side may stand alone: "since july 1" -> {"fromDate":"2026-07-01"}.',
+    '- fromDate + toDate: a calendar span, both inclusive. "april" -> {"fromDate":"2026-04-01","toDate":"2026-04-30"}. a NAMED month like "june 1 to 15". "this year" -> {"fromDate":"2026-01-01","toDate":"2026-12-31"}. "june 1 to 15" -> both dates. Either side may stand alone: "since july 1" -> {"fromDate":"2026-07-01"}.',
     '- fromTime/toTime: 24h "HH:MM" from 00:00 to 23:59, narrowing ONE day named by daysAgo/weekday/date. "yesterday from 4pm to 10pm" -> {"daysAgo":1,"fromTime":"16:00","toTime":"22:00"}.',
     '- A part of the day is a day plus a clock band: morning 06:00-12:00, noon or lunch 11:00-13:00, afternoon 12:00-18:00, evening 18:00-23:59, night 20:00-23:59. ALWAYS include the day, defaulting to today (daysAgo 0) when none is named: "this morning" -> {"daysAgo":0,"fromTime":"06:00","toTime":"12:00"}; "around noon" -> {"daysAgo":0,"fromTime":"11:00","toTime":"13:00"}; "last night" -> {"daysAgo":1,"fromTime":"20:00","toTime":"23:59"}; "last tuesday night" -> {"weekday":"tuesday","fromTime":"20:00","toTime":"23:59"}.',
     '- none: true when the phrase asks for no time limit. "all time" -> {"none":true}.',
@@ -401,6 +404,7 @@ export function parseFields(text: string): WindowFields | undefined {
     // raw-parsed replies instead of running this function - scored 100%
     // (refs #442).
     if (raw.week !== undefined) fields.week = String(raw.week);
+    if (raw.month !== undefined) fields.month = String(raw.month);
     if (raw.fromWeekday !== undefined) fields.fromWeekday = String(raw.fromWeekday);
     if (raw.toWeekday !== undefined) fields.toWeekday = String(raw.toWeekday);
     if (raw.dayOfMonth !== undefined) fields.dayOfMonth = Number(raw.dayOfMonth);


### PR DESCRIPTION
Fixes #449.

## Acceptance
- "WindowFields gains month: this|last; resolveWindow anchors it to the calendar month in code; conflicts rejected." — done, unit-tested (this/last arithmetic, unknown value, shape conflicts).
- "The shared field teaching covers it; month/year fromDate guidance updated." — done; after "in april" grabbed the field once, the teaching scopes it to the literal this/last-month words and named months stay calendar spans (re-measured clean).
- "parseFields round-trips it; interpretWhen unit tests cover it; eval predicates accept the calendar field; qwen3:8b holds time 124/124." — all done; qwen adopted the field unprompted on first contact.
- "On-device verification is the settings system-model eval, run manually on the Pixel." — documented; the playbook records the first on-device datapoint and why a parse-time branch veto was rejected (an English regex must not gate model output).

One shared vocabulary for every backend — no Nano-specific fork.

Gates: `npm run gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPKKq6oiQvno9u1zwvVBU5