### PR TITLE
fix(android): stop R8 optimizing away Capacitor's plugin annotation (closes #452)

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -37,13 +37,18 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
-            // The -optimize variant, because the plain proguard-android.txt sets
-            // -dontoptimize: R8 then only shrinks and obfuscates, leaving the
-            // inlining, dead-branch removal, and class merging off. Play Console
-            // flags that as a missed optimization ("Improve your app's memory and
-            // performance with R8 optimization"). R8 full mode is already on by
-            // default under AGP 8.
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            // proguard-android.txt, NOT the -optimize variant. The -optimize
+            // file drops -dontoptimize, and R8's field optimization then deletes
+            // com.getcapacitor.PluginHandle.pluginAnnotation: the release
+            // mapping.txt kept only bridge/pluginClass/pluginMethods/pluginId/
+            // instance, so the inlined getPluginAnnotation() returned null and
+            // every Capacitor permission check NPE'd in Bridge.getPermissionStates.
+            // FirebaseMessaging.requestPermissions() runs during push init at
+            // startup, so 2.2.1 crashed on open for Android users.
+            // Play Console's "Improve your app's memory and performance with R8
+            // optimization" hint is not worth this; re-landing it needs keep
+            // rules for Capacitor's reflective metadata plus a device pass.
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             ndk {
                 debugSymbolLevel 'FULL'
             }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zmNinjaNG",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zmNinjaNG",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "@aparajita/capacitor-biometric-auth": "^10.0.0",
         "@aparajita/capacitor-secure-storage": "^8.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zmNinjaNG",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "type": "module",
   "main": "electron/main.cjs",
   "scripts": {

--- a/app/src/tests/agents-contracts.test.ts
+++ b/app/src/tests/agents-contracts.test.ts
@@ -528,6 +528,26 @@ describe('Native contract: Android local network permission', () => {
   });
 });
 
+describe('Native contract: R8 keeps Capacitor plugin metadata', () => {
+  it('does not optimize the release build without keeping PluginHandle', () => {
+    const androidDir = path.join(repoRoot, 'app/android');
+    const gradle = read(path.join(androidDir, 'app/build.gradle'));
+    const optimizing = /getDefaultProguardFile\('proguard-android-optimize\.txt'\)/.test(gradle);
+    if (!optimizing) return;
+
+    // -optimize drops -dontoptimize, and R8's field optimization then deletes
+    // PluginHandle.pluginAnnotation, so getPluginAnnotation() returns null and
+    // every Capacitor permission check NPEs in Bridge.getPermissionStates.
+    // That shipped in 2.2.1 and crashed the app on open. Optimizing
+    // again is fine, but only with the reflective metadata kept.
+    const rules = read(path.join(androidDir, 'app/proguard-rules.pro'));
+    expect(
+      /-keepclassmembers class com\.getcapacitor\.PluginHandle/.test(rules),
+      'proguard-android-optimize.txt needs a keep rule for com.getcapacitor.PluginHandle members',
+    ).toBe(true);
+  });
+});
+
 describe('developer docs reference valid rule IDs', () => {
   it('every "rule <id>" reference resolves', () => {
     // Derived from AGENTS.md so adding or removing a rule cannot desync


### PR DESCRIPTION
Closes #452.

2.2.1 crashed on open for Android users with a configured profile and notifications enabled. `com.getcapacitor.PluginHandle.pluginAnnotation` was optimized out of the release build, so `Bridge.getPermissionStates` dereferenced null and killed the process on Capacitor's HandlerThread, out of reach of the JS `.catch()`.

Reverts the release build to `proguard-android.txt`. Shrinking and obfuscation stay on; only the optimization passes go. This is the configuration every release before 2.2.1 used.

Also bumps the version to 2.2.2, so support can tell a crashing install from a fixed one.

## Evidence

Comparing the `mapping.txt` published with the 2.2.1 release against the fix build:

| | shipped 2.2.1 | this branch |
|---|---|---|
| `PluginHandle.pluginAnnotation` | absent | `-> f` |
| `PluginHandle.legacyPluginAnnotation` | absent | `-> e` |
| `CapacitorPlugin` annotation class | kept (`k6.b`) | kept (`v5.b`) |

Build artifacts: run 33683066501, `versionName=2.2.2`, `versionCode=102876`.

## Acceptance

- The release build no longer optimizes away `PluginHandle.pluginAnnotation`; the release `mapping.txt` lists the field. Verified against the artifact from run 33683066501.
- Android launches normally with a configured profile and notifications enabled. **Not yet verified on a device** — see below.
- A gate fails if `proguard-android-optimize.txt` is used again without a keep rule for `com.getcapacitor.PluginHandle` members. New test in `app/src/tests/agents-contracts.test.ts`, proven red against the pre-change gradle.

## Not verified

Neither build has been launched on a device. The reproduction needs a configured server with notifications enabled, and the crash cannot occur in a debug build at all, since debug does not run R8. The mapping diff is the evidence; a device pass is still worth doing before the Play rollout.

## Re-landing R8 optimization

Not blocked, but it needs keep rules for Capacitor's reflective metadata and a device smoke test. The new gate enforces that pairing rather than banning the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9kxwyQvyscxA43cXs4xq6