### PR TITLE
fix(ci): proven-red measures from the fork point, not the base branch tip (closes #455)

### DIFF
--- a/scripts/__tests__/proven-red.test.mjs
+++ b/scripts/__tests__/proven-red.test.mjs
@@ -76,6 +76,40 @@ test('proveRed fails when the changed test passes on the base code, and passes w
   }
 });
 
+test('proveRed measures from the fork point, not the base branch tip', () => {
+  const { dir, base, head, git } = repo();
+
+  // The base branch moves on after this branch was cut, which is what CI's
+  // github.event.pull_request.base.sha points at by the time the PR runs.
+  git('checkout', '-q', base);
+  mkdirSync(join(dir, 'app/src/lib/__tests__'), { recursive: true });
+  writeFileSync(join(dir, 'app/src/lib/other.ts'), 'export const other = () => 1;\n');
+  writeFileSync(join(dir, 'app/src/lib/__tests__/other.test.ts'), 'expect(other()).toBe(1)\n');
+  git('add', '.');
+  git('commit', '-qm', 'feat(other): land on the base branch');
+  const movedTip = git('rev-parse', 'HEAD');
+
+  const seen = [];
+  const runTests = (appDir, files) => {
+    seen.push(files);
+    return 1;
+  };
+  const code = proveRed({
+    base: movedTip,
+    head,
+    repo: dir,
+    title: 'fix(sum): add, not subtract',
+    runTests,
+    log: () => {},
+  });
+
+  // Only this branch's own test is proved. Diffing straight from the moved
+  // tip would drag in other.test.ts, which passes on the fork point and would
+  // fail the gate for a branch that changed nothing about it.
+  assert.equal(code, 0);
+  assert.deepEqual(seen, [['src/lib/__tests__/sum.test.ts']]);
+});
+
 test('proveRed fails a behavior change that brings no unit test', () => {
   const { dir, base, git } = repo();
   try {

--- a/scripts/proven-red.mjs
+++ b/scripts/proven-red.mjs
@@ -8,11 +8,11 @@
  * Mode default, refs #385), and each was found only because someone stashed
  * the fix and re-ran by hand. This script does that by machine.
  *
- * For a range base..head it takes the test files the range changed, runs
- * them in a throwaway worktree that holds the base code plus the head
- * tests, and fails when they pass there. A test that is green on the code
- * it claims to guard proves nothing. The normal unit-test job proves the
- * same tests are green on head.
+ * For a range base..head it takes the test files changed since the two
+ * forked, runs them in a throwaway worktree that holds the fork-point code
+ * plus the head tests, and fails when they pass there. A test that is green
+ * on the code it claims to guard proves nothing. The normal unit-test job
+ * proves the same tests are green on head.
  *
  *   node scripts/proven-red.mjs <base> <head> [--title "<pr title>"]
  *
@@ -78,7 +78,16 @@ function git(args, cwd) {
  * `runTests(appDir, files)` returns the vitest exit code; injectable for tests.
  */
 export function proveRed({ base, head, repo, title, runTests = runVitest, log = console.log }) {
-  const files = git(['diff', '--name-only', `${base}..${head}`], repo).split('\n').filter(Boolean);
+  // The fork point, not `base` itself. CI passes
+  // github.event.pull_request.base.sha, which is the base branch's tip at
+  // event time, so on a branch whose base has moved since it was cut, a
+  // two-dot diff reports the base branch's own newer commits as this range's
+  // changes. Those tests then rightly pass on `base` and the gate fails a PR
+  // that did nothing wrong. The same tip is also the wrong worktree to prove
+  // against: the pre-change code is the fork point, not whatever landed on
+  // the base branch afterwards.
+  const forkPoint = git(['merge-base', base, head], repo);
+  const files = git(['diff', '--name-only', `${forkPoint}..${head}`], repo).split('\n').filter(Boolean);
   const split = classify(files);
   const skip = skipReason(title, split);
   if (skip) {
@@ -92,7 +101,7 @@ export function proveRed({ base, head, repo, title, runTests = runVitest, log = 
 
   const worktree = mkdtempSync(path.join(tmpdir(), 'proven-red-'));
   try {
-    git(['worktree', 'add', '--detach', '-q', worktree, base], repo);
+    git(['worktree', 'add', '--detach', '-q', worktree, forkPoint], repo);
     for (const f of [...split.unitTests, ...split.testSupport]) {
       const from = path.join(repo, f);
       if (!existsSync(from)) continue; // deleted at head


### PR DESCRIPTION
Closes #455.

`scripts/proven-red.mjs` diffed `base..head` two-dot, where `base` is `github.event.pull_request.base.sha` — the base branch's tip at event time, not the branch's fork point. Once main moves ahead of a branch, that diff reports main's own newer commits as the range's changes, their tests pass on `base` exactly as they should, and the gate fails a PR that never touched them.

#453 hit it: branch cut at `1e8ebf9a`, main at `a1c9ede0`, and the gate proved `event-range.test.ts` and `window-interpreter.test.ts` — neither among the PR's four changed files.

The worktree had the same bug. It was checked out at `base`, but the pre-change code for a branch is its fork point, not whatever landed on main afterwards, so even a correct file list was proved against the wrong baseline.

Both now resolve through one `git merge-base base head`.

## Acceptance

- `proveRed` diffs from the merge-base of `base` and `head`, and checks the worktree out at that same commit. Both call sites now use `forkPoint`.
- A branch whose base has moved is proved against only its own changed tests. New case in `scripts/__tests__/proven-red.test.mjs` moves the base branch on after the fork and asserts `runTests` sees only the branch's own test file.
- The new case fails on the pre-change script. Verified: with `scripts/proven-red.mjs` stashed, `npm run test:scripts` reports `fail 1`, and the failure is that case. With the fix, 46/46 pass.

## Note

`.github/workflows/ci.yml` is unchanged. The script now resolves the fork point itself, so every caller is fixed, including the push-event path that passes `github.event.before`.

This is an M2 failure: the gate's exit code was checked, its input never was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9kxwyQvyscxA43cXs4xq6