### PR TITLE
feat: remember mute and fullscreen for live monitors and event playback, auto-fullscreen on rotation

### DIFF
--- a/app/src/components/monitors/MonitorCard.tsx
+++ b/app/src/components/monitors/MonitorCard.tsx
@@ -27,6 +27,7 @@ import { getMonitorAspectRatio } from '../../lib/monitor/monitor-rotation';
 import { getMonitorRunState, monitorDotColor } from '../../lib/monitor/monitor-status';
 import { useAuthSlice } from '../../stores/auth';
 import { useOpenMonitorEvents } from '../../hooks/useOpenMonitorEvents';
+import { useMonitorMuted } from '../../hooks/useMonitorMuted';
 
 interface MonitorCardComponentProps extends MonitorCardProps {
   /** Callback to open the settings dialog for this monitor. `profileId` is
@@ -67,7 +68,7 @@ function MonitorCardComponent({
   const openMonitorEvents = useOpenMonitorEvents();
   const resolvedFit = (objectFit === 'flex' ? 'cover' : (objectFit ?? 'cover')) as 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
   const [protocol, setProtocol] = useState('MJPEG');
-  const [isMuted, setIsMuted] = useState(true);
+  const [isMuted, toggleMuted] = useMonitorMuted(ownerProfile?.id, monitor.Id);
   const runState = getMonitorRunState(monitor, status, zmVersion);
   const isRTC = monitor.Go2RTCEnabled === true && !!ownerProfile?.go2rtcUrl;
   const aspectRatio = getMonitorAspectRatio(monitor.Width, monitor.Height, monitor.Orientation);
@@ -169,7 +170,7 @@ function MonitorCardComponent({
               <HintButton
                 type="button"
                 className="h-4 w-4 shrink-0 text-muted-foreground hover:text-foreground"
-                onClick={(e) => { e.stopPropagation(); setIsMuted((m) => !m); }}
+                onClick={(e) => { e.stopPropagation(); toggleMuted(); }}
                 title={isMuted ? t('monitor_detail.unmute') : t('monitor_detail.mute')}
                 aria-label={isMuted ? t('monitor_detail.unmute') : t('monitor_detail.mute')}
                 data-testid="monitor-volume-btn"
@@ -327,7 +328,7 @@ function MonitorCardComponent({
                 <HintButton
                   type="button"
                   className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
-                  onClick={(e) => { e.stopPropagation(); setIsMuted((m) => !m); }}
+                  onClick={(e) => { e.stopPropagation(); toggleMuted(); }}
                   title={isMuted ? t('monitor_detail.unmute') : t('monitor_detail.mute')}
                   aria-label={isMuted ? t('monitor_detail.unmute') : t('monitor_detail.mute')}
                   data-testid="monitor-volume-btn"

--- a/app/src/components/monitors/MontageMonitor.tsx
+++ b/app/src/components/monitors/MontageMonitor.tsx
@@ -41,6 +41,7 @@ import { useNotificationStore } from '../../stores/notifications';
 import type { NotificationEvent } from '../../stores/notifications';
 import { formatEventCount } from '../../lib/utils';
 import { useOpenMonitorEvents } from '../../hooks/useOpenMonitorEvents';
+import { useMonitorMuted } from '../../hooks/useMonitorMuted';
 
 // Stable empty-array reference so the selector doesn't force a re-render
 // every time it returns "no events" for this monitor.
@@ -171,7 +172,7 @@ function MontageMonitorComponent({
     useShallow((state) => state.getProfileSettings(currentProfile?.id || ''))
   );
   const [protocol, setProtocol] = useState('MJPEG');
-  const [isMuted, setIsMuted] = useState(true);
+  const [isMuted, toggleMuted] = useMonitorMuted(currentProfile?.id, monitor.Id);
   const mediaRef = useRef<HTMLImageElement | HTMLVideoElement>(null);
   const resolvedFit = objectFit ?? 'cover';
   const isRTC = monitor.Go2RTCEnabled === true && !!currentProfile?.go2rtcUrl;
@@ -339,7 +340,7 @@ function MontageMonitorComponent({
               )}
               onClick={(e) => {
                 e.stopPropagation();
-                setIsMuted((m) => !m);
+                toggleMuted();
               }}
               title={isMuted ? t('monitor_detail.unmute') : t('monitor_detail.mute')}
               aria-label={isMuted ? t('monitor_detail.unmute') : t('monitor_detail.mute')}

--- a/app/src/components/monitors/__tests__/MonitorCard.test.tsx
+++ b/app/src/components/monitors/__tests__/MonitorCard.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../../lib/security/secureStorage', () => import('../../../tests/fake
 import { MonitorCard } from '../MonitorCard';
 import { useMonitorSeenStore } from '../../../stores/monitorSeen';
 import { useProfileStore } from '../../../stores/profile';
+import { useSettingsStore } from '../../../stores/settings';
 import { asProfileId } from '../../../api/types';
 import type { Monitor, MonitorStatus } from '../../../api/types';
 import { seedProfiles, resetProfileFixture, makeProfile } from '../../../tests/profile-fixture';
@@ -17,8 +18,8 @@ import { resetFakeStoreGates } from '../../../tests/fake-store-gates';
 const OTHER_PROFILE_ID = asProfileId('other-profile');
 
 vi.mock('../LiveMonitorPlayer', () => ({
-  LiveMonitorPlayer: ({ monitor }: { monitor: { Name: string } }) => (
-    <div data-testid="video-player">{monitor.Name}</div>
+  LiveMonitorPlayer: ({ monitor, muted }: { monitor: { Name: string }; muted?: boolean }) => (
+    <div data-testid="video-player" data-muted={String(muted ?? true)}>{monitor.Name}</div>
   ),
 }));
 
@@ -256,5 +257,26 @@ describe('MonitorCard', () => {
       `/events?monitorId=1&profileId=${OTHER_PROFILE_ID}`,
       { state: { from: '/monitors' } }
     );
+  });
+
+  it('remembers an unmuted Go2RTC monitor across remounts (refs #463)', async () => {
+    const user = userEvent.setup();
+    seedProfiles([makeProfile('test', { go2rtcUrl: 'https://go2rtc.test' })], {
+      current: 'test',
+      settings: { test: { viewMode: 'streaming' } },
+    });
+    const rtcMonitor = { ...monitor, Go2RTCEnabled: true } as Monitor;
+    const card = <MonitorCard monitor={rtcMonitor} status={status} onShowSettings={vi.fn()} />;
+
+    const { unmount } = render(card);
+    expect(screen.getByTestId('video-player')).toHaveAttribute('data-muted', 'true');
+    await user.click(screen.getByTestId('monitor-volume-btn'));
+    expect(screen.getByTestId('video-player')).toHaveAttribute('data-muted', 'false');
+    expect(useSettingsStore.getState().getProfileSettings(asProfileId('test')).unmutedMonitorIds).toEqual(['1']);
+    unmount();
+
+    render(card);
+    expect(screen.getByTestId('video-player')).toHaveAttribute('data-muted', 'false');
+    expect(screen.getByTestId('monitor-volume-btn')).toHaveAttribute('aria-label', 'monitor_detail.mute');
   });
 });

--- a/app/src/components/monitors/__tests__/MontageMonitor.test.tsx
+++ b/app/src/components/monitors/__tests__/MontageMonitor.test.tsx
@@ -15,6 +15,7 @@ import { MontageMonitor } from '../MontageMonitor';
 import type { Monitor, MonitorStatus, Profile } from '../../../api/types';
 import { asProfileId } from '../../../api/types';
 import { useMonitorStore } from '../../../stores/monitors';
+import { useSettingsStore } from '../../../stores/settings';
 import { useMonitorSeenStore } from '../../../stores/monitorSeen';
 import { useNotificationStore } from '../../../stores/notifications';
 import { seedProfiles, resetProfileFixture, makeProfile } from '../../../tests/profile-fixture';
@@ -66,16 +67,19 @@ vi.mock('../LiveMonitorPlayer', () => ({
     reduceStream,
     paused,
     forceViewMode,
+    muted,
   }: {
     reduceStream?: boolean;
     paused?: boolean;
     forceViewMode?: string;
+    muted?: boolean;
   }) => (
     <div
       data-testid="video-player"
       data-reduce-stream={String(reduceStream ?? false)}
       data-paused={String(paused ?? false)}
       data-force-view-mode={forceViewMode ?? 'none'}
+      data-muted={String(muted ?? true)}
     >
       Mock LiveMonitorPlayer
     </div>
@@ -514,6 +518,33 @@ describe('MontageMonitor', () => {
     // resolved from it would produce no startDateTime at all.
     expect(params.get('startDateTime')).toBe('2026-07-10T08:49:38');
   });
+
+  it('remembers an unmuted Go2RTC monitor across remounts (refs #463)', async () => {
+    const user = userEvent.setup();
+    const rtcMonitor = { ...mockMonitor, Go2RTCEnabled: true } as Monitor;
+    const rtcProfile = { ...mockProfile, go2rtcUrl: 'https://go2rtc.test' };
+    const tile = (
+      <MontageMonitor
+        monitor={rtcMonitor}
+        status={mockStatus}
+        currentProfile={rtcProfile}
+        accessToken="test-token"
+        navigate={mockNavigate}
+      />
+    );
+
+    const { unmount } = render(tile);
+    expect(screen.getByTestId('video-player')).toHaveAttribute('data-muted', 'true');
+    await user.click(screen.getByTestId('montage-volume-btn'));
+    expect(screen.getByTestId('video-player')).toHaveAttribute('data-muted', 'false');
+    expect(useSettingsStore.getState().getProfileSettings(rtcProfile.id).unmutedMonitorIds).toEqual(['1']);
+    unmount();
+
+    render(tile);
+    expect(screen.getByTestId('video-player')).toHaveAttribute('data-muted', 'false');
+    expect(screen.getByTestId('montage-volume-btn')).toHaveAttribute('aria-label', 'monitor_detail.mute');
+  });
+
 });
 
 /**
@@ -597,4 +628,5 @@ describe('MontageMonitor alarm state is conveyed without animation', () => {
       expect(screen.getByRole('status')).toHaveTextContent('montage.alarm_status');
     });
   });
+
 });

--- a/app/src/hooks/__tests__/useMonitorMuted.test.tsx
+++ b/app/src/hooks/__tests__/useMonitorMuted.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * useMonitorMuted: the per-monitor mute choice lives in profile settings so
+ * a tile that remounts (route change, group switch, app relaunch) starts in
+ * the state the user last chose (refs #463).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../../api/store-gates', () => import('../../tests/fake-store-gates'));
+vi.mock('../../lib/security/secureStorage', () => import('../../tests/fake-secure-storage'));
+
+import { asProfileId } from '../../api/types';
+import { useSettingsStore } from '../../stores/settings';
+import { seedProfiles, resetProfileFixture } from '../../tests/profile-fixture';
+import { useMonitorMuted } from '../useMonitorMuted';
+
+const HOME = asProfileId('home');
+const SHED = asProfileId('shed');
+
+describe('useMonitorMuted', () => {
+  beforeEach(() => {
+    seedProfiles(['home', 'shed'], { current: 'home' });
+  });
+  afterEach(resetProfileFixture);
+
+  it('starts muted and persists an unmute across remounts', () => {
+    const first = renderHook(() => useMonitorMuted(HOME, '1'));
+    expect(first.result.current[0]).toBe(true);
+
+    act(() => first.result.current[1]());
+    expect(first.result.current[0]).toBe(false);
+    expect(useSettingsStore.getState().getProfileSettings(HOME).unmutedMonitorIds).toEqual(['1']);
+    first.unmount();
+
+    const second = renderHook(() => useMonitorMuted(HOME, '1'));
+    expect(second.result.current[0]).toBe(false);
+  });
+
+  it('muting again forgets the monitor', () => {
+    const { result } = renderHook(() => useMonitorMuted(HOME, '1'));
+    act(() => result.current[1]());
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(true);
+    expect(useSettingsStore.getState().getProfileSettings(HOME).unmutedMonitorIds).toEqual([]);
+  });
+
+  it('is scoped to the monitor and the profile', () => {
+    const { result } = renderHook(() => useMonitorMuted(HOME, '1'));
+    act(() => result.current[1]());
+
+    expect(renderHook(() => useMonitorMuted(HOME, '2')).result.current[0]).toBe(true);
+    expect(renderHook(() => useMonitorMuted(SHED, '1')).result.current[0]).toBe(true);
+  });
+
+  it('stays muted with no profile and ignores toggles', () => {
+    const { result } = renderHook(() => useMonitorMuted(undefined, '1'));
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(true);
+    expect(useSettingsStore.getState().profileSettings).toEqual(
+      expect.not.objectContaining({ '': expect.anything() }),
+    );
+  });
+});

--- a/app/src/hooks/useMonitorMuted.ts
+++ b/app/src/hooks/useMonitorMuted.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { useSettingsStore } from '../stores/settings';
+import type { ProfileId } from '../api/types';
+
+/**
+ * Per-monitor mute state for live Go2RTC tiles, persisted in the owning
+ * profile's settings (`unmutedMonitorIds`) so a tile that remounts starts in
+ * the state the user last chose (refs #463). Without a profile the tile is
+ * always muted and toggling is a no-op.
+ */
+export function useMonitorMuted(
+  profileId: ProfileId | null | undefined,
+  monitorId: string,
+): [isMuted: boolean, toggleMuted: () => void] {
+  const isMuted = useSettingsStore((state) =>
+    profileId ? !state.getProfileSettings(profileId).unmutedMonitorIds.includes(monitorId) : true,
+  );
+  const toggleMuted = useCallback(() => {
+    if (!profileId) return;
+    const { getProfileSettings, updateProfileSettings } = useSettingsStore.getState();
+    const others = getProfileSettings(profileId).unmutedMonitorIds.filter((id) => id !== monitorId);
+    updateProfileSettings(profileId, {
+      unmutedMonitorIds: isMuted ? [...others, monitorId] : others,
+    });
+  }, [profileId, monitorId, isMuted]);
+  return [isMuted, toggleMuted];
+}

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -313,6 +313,10 @@ export interface ProfileSettings {
    *  request and an error toast on every visit. Listing the monitor here skips
    *  the MP4 attempt entirely. App-local, not a ZoneMinder monitor field. */
   forceZmsMonitorIds: string[];
+  /** Go2RTC monitors the user unmuted on a live tile. Tiles start muted so
+   *  a grid does not open as a cacophony; listing a monitor here restores
+   *  its last choice across remounts (refs #463). */
+  unmutedMonitorIds: string[];
   // Force-disable multi-port streaming. When true, the app ignores the server's
   // ZM_MIN_STREAMING_PORT and uses the portal's default port for all streams.
   // Default false = auto (use the server config when present).
@@ -504,6 +508,7 @@ export const DEFAULT_SETTINGS: ProfileSettings = {
   showAnalysisFrames: false,
   monitorStreamingOverrides: {},
   forceZmsMonitorIds: [],
+  unmutedMonitorIds: [],
   // Auto by default: honor the server's ZM_MIN_STREAMING_PORT when present
   forceDisableMultiPort: false,
   apiTimeoutSeconds: API_REQUEST.defaultTimeoutSeconds,

--- a/docs/developer-guide/05-component-architecture.rst
+++ b/docs/developer-guide/05-component-architecture.rst
@@ -131,6 +131,18 @@ counted rather than what "seen" becomes after the click. It drops the date param
 entirely for a quiet monitor (``newEventCount`` is 0 or undefined) or a
 never-seeded one (the watermark is ``null``, so the whole history is the new set).
 
+``useMonitorMuted`` (``hooks/useMonitorMuted.ts``) is the other hook both tiles
+share. A Go2RTC tile starts muted so a grid does not open as a cacophony, but
+the choice used to live in component state and reset on every remount: a group
+switch, a route change, or a relaunch put every unmuted monitor back to muted.
+The hook reads ``unmutedMonitorIds`` from the owning profile's settings through
+``getProfileSettings`` and returns ``[isMuted, toggleMuted]``; ``toggleMuted``
+writes the list back with ``updateProfileSettings``, so the state survives
+remounts and syncs with the rest of the profile. The key is the monitor id
+within one profile, which is why the same id on a second server does not
+collide. Without a profile id the tile is always muted and the toggle is a
+no-op.
+
 The whole component is wrapped in ``memo``:
 
 .. code:: tsx

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -42,6 +42,8 @@ If Go2RTC connects but no video frames appear within 8 seconds, the app automati
 
 How a feed fills its tile — **Fit whole image** or **Crop to fill** — and **Analysis frames** live in the ⋮ menu at the end of the toolbar, on both the Monitors and Monitor Detail screens. The protocol label (enabled in {doc}`settings`) shows which streaming protocol is active on each feed. The Monitor Detail page also shows native video controls (play, pause, volume) for Go2RTC streams.
 
+Go2RTC feeds in the Monitors list start muted. The speaker icon next to a monitor's name unmutes it, and the app remembers that choice per monitor until you mute it again. The volume control on the Monitor Detail page is the browser's own and is not remembered.
+
 For tile views (Monitors list, Montage, Dashboard widgets), the *Streaming Mode* setting does apply, see {doc}`settings` for details.
 
 #### Scroll Pad

--- a/docs/user-guide/montage.md
+++ b/docs/user-guide/montage.md
@@ -80,7 +80,7 @@ Each tile honors the same streaming rules as elsewhere in the app:
 - Monitors with Go2RTC enabled stream live video (WebRTC, MSE, or HLS).
 - Monitors on MJPEG follow the global *Streaming Mode* setting, *Streaming* shows continuous MJPEG, *Snapshot* shows a periodic JPEG that refreshes on the configured interval. While aggregating, each tile follows its own server's setting unless you set the group's Streaming Mode in {doc}`settings`.
 
-Go2RTC streams in the montage are muted by default. The protocol label (MJPEG/MSE/WebRTC) visibility is controlled by the toolbar eye toggle. Monitors that cannot be reached display a VideoOff placeholder instead of a broken feed.
+Go2RTC streams in the montage are muted by default. Tap the speaker icon on a tile to unmute it; the app remembers the choice per monitor, so that monitor starts unmuted next time until you mute it again. The protocol label (MJPEG/MSE/WebRTC) visibility is controlled by the toolbar eye toggle. Monitors that cannot be reached display a VideoOff placeholder instead of a broken feed.
 
 ## Performance
 


### PR DESCRIPTION
Refs #463, #462.

**Mute.** Live Go2RTC tiles on the Monitors page and the Montage started muted and forgot the user's unmute on every remount. The choice now lives in the owning profile's settings as `unmutedMonitorIds`, through one shared `useMonitorMuted` hook. The Monitor Detail page shows the browser's native controls on Go2RTC streams, so `useGo2RTCStream` now listens for `volumechange` and reports user changes through `onMutedChange`, wired to the same hook. The MP4 event player persists its mute as `eventPlaybackMuted` the same way.

**Fullscreen.** Remembering exit cannot work: exit is the only way off a fullscreen page, so every visit would end by forgetting. Entering is remembered instead and exit is session-only. Maximizing Monitor Detail writes the monitor into `fullscreenMonitorIds` (which also gives #462 its "tap a Montage tile, land in fullscreen"); entering fullscreen on the event player sets `eventPlaybackFullscreen`. The off switches are explicit settings: **Open in fullscreen** per monitor in the monitor's Settings dialog, **Open live view in fullscreen** for every monitor under Settings > Live Streaming (`monitorDetailFullscreen`, whose description points at the per-monitor switch), and **Open events in fullscreen** under Settings > Playback. `Mp4EventPlayer` gains `fullscreen` / `onFullscreenChange` in the same shape as `playbackRate` / `onRateChange`; when the real Fullscreen API refuses a request made without a user gesture it falls back to video.js full-window mode.

**Rotation.** `useAutoFullscreen` layers a temporary landscape term (`(orientation: landscape) and (pointer: coarse)`) on top of the setting for both pages, so a phone turned sideways fills the screen and never writes anything. `useMonitorFlag` generalizes the monitor-id-list setting so mute and fullscreen share one reader and writer.

**Rotation during event playback did nothing** on the first device pass. `useZoomPan` set `will-change: transform` and an identity transform on the player's ancestor, which makes it the containing block for `position: fixed` descendants; video.js's full-window player (the path every rotation takes) filled the card instead of the viewport. At identity the element now carries neither.

## Acceptance

Mute, live view:
- Unmuting a monitor on the Monitors page, the Montage, or the Monitor Detail page persists per monitor per profile; the next render of that monitor on any of the three starts unmuted.
- Muting it again clears the memory; the monitor starts muted next time.
- Other monitors on the same profile are unaffected; the same monitor id on another profile is unaffected.
- The preference is a profile-scoped setting (`unmutedMonitorIds`) read through `getProfileSettings`, defaulting to empty.

Mute, event playback:
- Muting or unmuting the MP4 event player persists for the profile; every event opened afterwards starts in that state, regardless of monitor.
- The preference is a profile-scoped setting read through `getProfileSettings`, defaulting to muted.
- ZMS (MJPEG) event playback has no audio and is unaffected.

Fullscreen, live view:
- Maximizing the Monitor Detail page remembers that monitor: it opens maximized every time afterwards, including when tapped from the Montage (`fullscreenMonitorIds`, per profile, default empty).
- Exiting fullscreen changes the current visit only. "Open in fullscreen" in the monitor's Settings dialog (Video tab) shows the same state and is the off switch; it applies as soon as it is flipped.
- "Open live view in fullscreen" under Settings > Live Streaming opens every monitor maximized (`monitorDetailFullscreen`, default off); its description points at the per-monitor switch for a single monitor.

Fullscreen, event playback:
- Entering fullscreen on the MP4 event player turns "Open events in fullscreen" on (`eventPlaybackFullscreen`, per profile, default off); every event opened afterwards starts fullscreen.
- Leaving fullscreen changes the current event only. The switch under Settings > Playback is the off switch.
- Where the platform refuses fullscreen without a user gesture, the player fills the window instead.

Rotation:
- On a touch device, turning to landscape during live view (Monitor Detail) or MP4 event playback goes fullscreen; turning back to portrait leaves it. Neither writes a setting.
- Leaving fullscreen while landscape stays in the normal view until the next rotation to landscape.
- Desktop windows are unaffected.

## Tests

- `useMonitorMuted.test.tsx`, `useMonitorFlag.test.tsx`: default, persist across remount, clear, monitor and profile scoping, no-profile no-op, the two lists kept apart. Real settings store.
- `useAutoFullscreen.test.tsx`: setting seeds; session toggle; rotation in and out; mounted in landscape; user exit while landscape then rotate again; setting survives rotating back; override dropped when the monitor changes.
- `useZoomPan.test.tsx`: no transform or will-change at identity, both present when zoomed, both gone after reset.
- `MonitorCard.test.tsx`, `MontageMonitor.test.tsx`: click the speaker, unmount, remount, player receives `muted={false}`.
- `useGo2RTCStream.test.ts`: a native-control unmute reaches `onMutedChange`; the hook's own muted write does not.
- `MonitorDetail.test.tsx`: remembered mute; native-control mute change persists; a monitor set to open fullscreen opens maximized and exit does not clear it; maximizing writes the monitor; the live view setting opens every monitor maximized.
- `EventDetail.test.tsx`: mute persists and remounts; the fullscreen setting seeds the player, exit does not clear it, entering writes it and the next event opens fullscreen.
- `MonitorSettingsDialog.test.tsx`: the Open in fullscreen switch reads and writes the monitor list. `PlaybackSection` and `LiveStreamingSection` tests: the two fullscreen switches write their settings. `settings.test.ts`: defaults.
- All new tests fail against `main`. `npm run gates` passed: 4408 tests, build, a11y, correctness, ratchet.

## Not verified on device

- The Monitor Detail mute write-back depends on the browser firing `volumechange` for its native control bar; jsdom dispatches it by hand.
- Rotation and the fullscreen fallback are matchMedia and video.js behaviour that jsdom does not have. The Android full-window fallback (status bar stays visible) and iOS `preferFullWindow` path need one manual rotation each on a phone. The zoom-container fix is the diagnosis for "rotation did nothing" on the first device pass; a second pass confirms it.
- `Mp4EventPlayer` itself has no unit test; the video.js wiring is covered only through the `EventDetail` mock.
- No e2e scenario: the settings switches follow the existing force-ZMS toggle, which has none either.

## Docs

User guide (monitors, montage, events, settings) and developer guide (component architecture, api and data fetching) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsAyBwMenLNgG2Qz3oxZzB
