### PR TITLE
fix(auth): fetch the server version for profiles without credentials

### DIFF
--- a/agents/project/domain-context.md
+++ b/agents/project/domain-context.md
@@ -169,6 +169,11 @@ matching reality, fixing it is a protocol change like any rule edit.
 - A ZoneMinder server with auth disabled returns login success with no
   tokens: track `requiresAuth` explicitly instead of deriving freshness
   from token presence, or no-auth servers refresh-loop forever (cf0d3b8f).
+- A profile with no stored credentials never logs in, and login is where
+  the server version arrives. `bootstrapAuth` fetches
+  `/host/getVersion.json` for that path; without it every version-gated
+  branch (the `frames=1` snapshot shape, run-state detection, the Server
+  page) silently took its legacy arm on public servers (#461).
 
 ## Platform quirks
 

--- a/app/src/hooks/__tests__/useMonitorStream.test.ts
+++ b/app/src/hooks/__tests__/useMonitorStream.test.ts
@@ -225,6 +225,31 @@ describe('useMonitorStream', () => {
     expect(result.current.streamUrl).toContain('rand='); // cacheBuster in snapshot
   });
 
+  it('drops a caller-supplied maxfps in snapshot mode (refs #461)', async () => {
+    useSettingsStore.setState({
+      profileSettings: {
+        'profile-1': {
+          ...DEFAULT_SETTINGS,
+          viewMode: 'snapshot',
+        },
+      },
+    });
+    useMonitorStore.setState({ regenerateConnKey: vi.fn(() => 12345) });
+
+    // LiveMonitorPlayer always passes maxfps through streamOptions; the
+    // spread used to put it back on a request that has no frame rate.
+    const { result } = renderHook(() =>
+      useMonitorStream({ monitorId: '1', streamOptions: { maxfps: 10, scale: 50 } })
+    );
+
+    await waitFor(() => {
+      expect(result.current.streamUrl).toBeTruthy();
+    });
+
+    expect(result.current.streamUrl).toContain('scale=50');
+    expect(result.current.streamUrl).not.toContain('maxfps');
+  });
+
   describe('snapshot request shape by monitor decoding', () => {
     // mode=single reads shared memory without marking the monitor as viewed, so
     // a monitor that decodes on demand stops decoding and the snapshot freezes

--- a/app/src/hooks/useMonitorStream.ts
+++ b/app/src/hooks/useMonitorStream.ts
@@ -242,6 +242,9 @@ export function useMonitorStream({
       // Only use multi-port in streaming mode, not snapshot (and not force-disabled)
       minStreamingPort: effectiveMinStreamingPort,
       ...streamOptions,
+      // A snapshot has no frame rate; the caller's maxfps (LiveMonitorPlayer
+      // always passes one) must not put it back after the spread (refs #461).
+      ...(effectiveViewMode === 'snapshot' ? { maxfps: undefined } : {}),
     })
     : '';
 

--- a/app/src/services/profile-bootstrap.ts
+++ b/app/src/services/profile-bootstrap.ts
@@ -7,7 +7,7 @@
 
 import type { Profile } from '../api/types';
 import { getServerTimeZone } from '../api/time';
-import { fetchGo2RTCPath, fetchZmsPath } from '../api/auth';
+import { fetchGo2RTCPath, fetchZmsPath, getVersion } from '../api/auth';
 import { getSession } from './sessions';
 import { log, LogLevel } from '../lib/logger';
 
@@ -29,6 +29,20 @@ export async function bootstrapAuth(
     // Mark as authenticated so API client doesn't try to re-login
     const { useAuthStore } = await import('../stores/auth');
     useAuthStore.getState().setTokens(profile.id, {});
+    // Login is where the server version normally arrives, and this path never
+    // logs in. Without it every version-gated branch (the frames=1 snapshot
+    // shape for on-demand monitors, run-state detection, the Server page)
+    // took its legacy arm on public servers (refs #461). setTokens with no
+    // tokens keeps the no-auth state and merges the version in.
+    try {
+      const { version, apiversion } = await getVersion(getSession(profile.id).client);
+      useAuthStore.getState().setTokens(profile.id, { version, apiversion });
+      log.profileService('Server version fetched for public server', LogLevel.INFO, { version });
+    } catch (versionError) {
+      log.profileService('Failed to fetch server version for public server', LogLevel.WARN, {
+        error: versionError,
+      });
+    }
     return;
   }
 

--- a/app/src/stores/__tests__/profile-bootstrap.test.ts
+++ b/app/src/stores/__tests__/profile-bootstrap.test.ts
@@ -15,6 +15,7 @@ import {
 import type { Profile } from '../../api/types';
 import { asProfileId } from '../../api/types';
 import { useAuthStore } from '../auth';
+import { getVersion } from '../../api/auth';
 import { useSettingsStore } from '../settings';
 import { seedProfiles, resetProfileFixture } from '../../tests/profile-fixture';
 import { resetFakeStoreGates } from '../../tests/fake-store-gates';
@@ -46,6 +47,7 @@ vi.mock('../../api/time', () => ({
 vi.mock('../../api/auth', () => ({
   fetchZmsPath: vi.fn(),
   fetchGo2RTCPath: vi.fn(),
+  getVersion: vi.fn(),
 }));
 
 vi.mock('../../api/server', () => ({
@@ -107,6 +109,33 @@ describe('Profile Bootstrap', () => {
       expect(setTokensSpy).toHaveBeenCalledWith(mockProfile.id, {});
       expect(useAuthStore.getState().slices[mockProfile.id]?.isAuthenticated).toBe(true);
       expect(useAuthStore.getState().slices[mockProfile.id]?.requiresAuth).toBe(false);
+    });
+
+    // A no-auth server never goes through login, which is where the version
+    // normally arrives, so the snapshot request shape and every other
+    // version-gated branch saw null and took the legacy path (refs #461).
+    it('fetches and stores the server version when no credentials are stored', async () => {
+      vi.mocked(getVersion).mockResolvedValue({ version: '1.39.3', apiversion: '2.0' });
+      const profileWithoutCreds = { ...mockProfile, username: undefined, password: undefined };
+
+      await bootstrapAuth(profileWithoutCreds, mockContext);
+
+      const slice = useAuthStore.getState().slices[mockProfile.id];
+      expect(slice?.version).toBe('1.39.3');
+      expect(slice?.apiVersion).toBe('2.0');
+      expect(slice?.isAuthenticated).toBe(true);
+      expect(slice?.requiresAuth).toBe(false);
+    });
+
+    it('stays authenticated with no version when the version fetch fails on a public server', async () => {
+      vi.mocked(getVersion).mockRejectedValue(new Error('network'));
+      const profileWithoutCreds = { ...mockProfile, username: undefined, password: undefined };
+
+      await bootstrapAuth(profileWithoutCreds, mockContext);
+
+      const slice = useAuthStore.getState().slices[mockProfile.id];
+      expect(slice?.version).toBeNull();
+      expect(slice?.isAuthenticated).toBe(true);
     });
 
     it('authenticates with stored credentials', async () => {


### PR DESCRIPTION
Refs #461.

The reporter's trace is right. A profile with no stored credentials takes the early-return branch of `bootstrapAuth`, which calls `setTokens(profile.id, {})` and never fetches anything, and login is the only place the server version normally arrives. The auth slice therefore kept `version: null` on public servers, and `isZmVersionAtLeast(null, '1.37.61')` is false, so the #387 fix never engaged: on-demand monitors polled with `mode=single`, `zmc` saw no viewer, and the Montage froze exactly as in #383.

The same null reached every other version consumer through `useAuthSlice(...).version`: `getMonitorRunState` on the monitor cards, montage tiles and detail page, the Monitors page settings dialog, and the Server page.

`bootstrapAuth` now fetches `/host/getVersion.json` on that path and feeds the result through the existing no-token branch of `setTokens`, which already merges version and keeps `requiresAuth: false`. A failed fetch logs a warning and leaves the profile authenticated as before.

The issue's second observation is also fixed: `useMonitorStream` cleared `maxfps` for snapshot requests, but the `...streamOptions` spread ran afterwards and `LiveMonitorPlayer` always passes one, so snapshot URLs carried `maxfps=10`. Harmless to `zms`, now gone.

## Acceptance

- A profile without stored credentials against a ZoneMinder server with auth disabled ends bootstrap with `version` and `apiVersion` populated in its auth slice, `isAuthenticated: true`, `requiresAuth: false`.
- On that profile, a monitor with `Decoding` other than `Always` on ZM >= 1.37.61 polls snapshots with `mode=jpeg&frames=1`, so the Montage picture keeps updating.
- If the version fetch fails, the profile is still authenticated and the app behaves as before this change.
- Snapshot requests carry no `maxfps`, even when the caller passes one through `streamOptions`.

## Tests

- `profile-bootstrap.test.ts`: no-credentials profile stores the fetched version and API version; a failed fetch leaves it authenticated with no version. Both red on `main`.
- `useMonitorStream.test.ts`: snapshot mode with `streamOptions: { maxfps: 10 }` yields no `maxfps`. Red on `main`.
- `npm run gates`: 4411 tests, build, a11y, correctness, ratchet.

## Not verified on a live server

No public ZoneMinder is reachable from here. The reporter's own DevTools check (`zmng-auth` in localStorage showing `version: null`) is the thing to repeat after this lands: it should show `1.39.3`.

## Docs

`agents/project/domain-context.md` records the no-credentials version gap under Auth and tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsAyBwMenLNgG2Qz3oxZzB