### PR TITLE
fix(monitors): fullscreen feed fits a landscape phone; Exit button clears the corner

### DIFF
--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -413,7 +413,9 @@ export default function MonitorDetail() {
       {/* Fullscreen exit bar */}
       {isFullscreen && (
         <div
-          className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))] pt-[var(--sai-top,env(safe-area-inset-top))]"
+          // Landscape corners: Android reports no side inset, and the rounded
+          // corner then swallowed the Exit button. Never less than 1.25rem.
+          className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm pl-[max(1.25rem,var(--sai-left,env(safe-area-inset-left)))] pr-[max(1.25rem,var(--sai-right,env(safe-area-inset-right)))] pt-[var(--sai-top,env(safe-area-inset-top))]"
           data-testid="monitor-detail-fullscreen-toolbar"
         >
           <div className="h-[var(--fullscreen-toolbar-h)] flex items-center justify-between px-3">
@@ -437,9 +439,14 @@ export default function MonitorDetail() {
 
       {/* Main Content */}
       <div className={cn(
+        // min-h-0: a flex item's default min-height is its content, and the
+        // feed's percentage height resolves to the image's natural aspect at
+        // full width while that is measured. In landscape that is taller than
+        // the screen, so the item grew past it and the frame lost its bottom.
+        // With the floor removed the card is the screen and contain applies.
         'flex-1 flex flex-col items-center justify-center',
         isFullscreen
-          ? 'pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
+          ? 'min-h-0 overflow-hidden pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
           : 'p-2 sm:p-3 md:p-4 bg-muted/10'
       )}>
         <Card

--- a/app/tests/features/monitor-detail.feature
+++ b/app/tests/features/monitor-detail.feature
@@ -13,6 +13,12 @@ Feature: Monitor Detail Page
     Then I should see the monitor player
     And I should see a video player element
 
+  @web
+  Scenario: Fullscreen feed fits a landscape phone screen
+    Given the viewport is landscape phone size
+    When I maximize the monitor feed
+    Then the fullscreen feed should fit within the viewport
+
   @all
   Scenario: Snapshot button downloads an image
     Then I should see the monitor player

--- a/app/tests/steps/common.steps.ts
+++ b/app/tests/steps/common.steps.ts
@@ -135,6 +135,10 @@ Then('I should be on the {string} page', async ({ page }, pageName: string) => {
 });
 
 // Generic viewport steps used across multiple features
+Given('the viewport is landscape phone size', async ({ page }) => {
+  await page.setViewportSize({ width: 852, height: 393 });
+});
+
 Given('the viewport is mobile size', async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
   await page.waitForTimeout(300);

--- a/app/tests/steps/monitor-detail.steps.ts
+++ b/app/tests/steps/monitor-detail.steps.ts
@@ -151,3 +151,27 @@ Then('the currently open monitor should show a live MJPEG frame', async ({ page 
   await assertMjpegFrameLoaded(page);
   log.info('E2E: Final monitor MJPEG frame verified', { component: 'e2e' });
 });
+
+When('I maximize the monitor feed', async ({ page }) => {
+  // A touch device in landscape is already fullscreen from the rotation
+  // term (useAutoFullscreen), and then there is no header button to press.
+  const toolbar = page.getByTestId('monitor-detail-fullscreen-toolbar');
+  if (!(await toolbar.isVisible().catch(() => false))) {
+    await page.getByTestId('monitor-detail-maximize').click();
+  }
+  await expect(toolbar).toBeVisible({ timeout: testConfig.timeouts.transition });
+});
+
+// The feed card sat in a flex item whose min-height defaulted to its content,
+// so in landscape it grew past the screen and the frame lost its bottom. The
+// card has to be the screen for object-fit contain to mean anything.
+Then('the fullscreen feed should fit within the viewport', async ({ page }) => {
+  const viewport = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+  await expect(page.getByTestId('monitor-player')).toBeVisible();
+  // Polled: the card slides in on navigation, so the first box can be mid-flight.
+  const box = () => page.getByTestId('monitor-player').boundingBox();
+  await expect.poll(async () => { const c = await box(); return c ? c.y + c.height : Infinity; }, { message: 'card bottom' }).toBeLessThanOrEqual(viewport.height + 1);
+  await expect.poll(async () => { const c = await box(); return c ? c.x + c.width : Infinity; }, { message: 'card right' }).toBeLessThanOrEqual(viewport.width + 1);
+  await expect.poll(async () => (await box())?.height ?? 0, { message: 'card height' }).toBeGreaterThan(viewport.height * 0.6);
+});
+


### PR DESCRIPTION
Refs #462. Follows #465.

Rotating a phone in Monitor Detail showed the feed magnified and cut off at the bottom, and on Android the Exit button sat under the rounded corner.

**The crop.** In fullscreen the feed card takes `h-full` from a `flex-1` column item whose `min-height` defaults to its content. While the percentage chain is being measured the image falls back to its natural aspect at full width; in landscape that is taller than the screen, so the item grew past the screen, the card followed, and the frame rendered whole with its bottom clipped. It looked like a zoom or a crop but was neither. Portrait never overflowed, which is why it looked fine there. `min-h-0` (and `overflow-hidden`) on that item in fullscreen lets it shrink to the screen, and the existing `object-fit: contain` then fits the frame. Pinch zoom was working all along, on a box larger than the screen.

**The corner.** The fullscreen bar padded its ends with the safe-area inset alone; Android reports none in landscape. The ends are now at least 1.25rem.

## Acceptance

- In fullscreen on a landscape phone, the feed card is no taller or wider than the screen and the whole frame is visible, letterboxed as needed.
- The Exit button is not under a rounded corner on Android in landscape.
- The normal (non-fullscreen) page still scrolls; the change is scoped to fullscreen.

## Tests

- e2e `monitor-detail.feature`, "Fullscreen feed fits a landscape phone screen" (`@web`): 852x393 viewport, maximize, the card's bottom and right edges stay inside the viewport and its height is most of the screen. Proven red against the pre-change page (card bottom at 883px on a 393px viewport), then green. The maximize step tolerates a page that is already fullscreen from the rotation term, so the same scenario runs on touch emulation.
- `npm run gates` passed.

## Not verified

WebKit. The suite's shared Background step cannot navigate the phone-width Monitors list on iPhone emulation (a pre-existing limitation of that step, not this change), so the scenario ran on Chromium only. The `min-height: auto` flex rule is identical in WebKit; one rotation on the iPhone confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsAyBwMenLNgG2Qz3oxZzB