### PR TITLE
fix(events): page fullscreen actually fills the screen for MP4 and ZMS

### DIFF
--- a/app/src/components/events/Mp4EventPlayer.tsx
+++ b/app/src/components/events/Mp4EventPlayer.tsx
@@ -262,7 +262,9 @@ export function Mp4EventPlayer({
       playsinline: true,
       preferFullWindow: isIOS,
       muted,
-      aspectRatio,
+      // video.js's aspectRatio setter forces fluid mode, after fill has been
+      // applied, so a filled player must not carry one (refs #462).
+      aspectRatio: fill ? undefined : aspectRatio,
       poster,
       disablePictureInPicture: isAndroid,
       playbackRates: [...EVENT_PLAYBACK_RATES],
@@ -364,9 +366,11 @@ export function Mp4EventPlayer({
 
     // Fill follows the page's fullscreen: the box is the screen there, and
     // fluid's aspect-ratio padding would size the player off the width alone.
-    if (fill !== player.fill()) {
-      player.fluid(!fill);
-      player.fill(fill);
+    // Compared on fluid(), since fill() can read true while aspectRatio has
+    // already flipped the player back to fluid.
+    if (player.fluid() === fill) {
+      if (fill) player.fill(true);
+      else player.fluid(true);
     }
 
     // Reapply the desired rate when it changes externally (e.g. a rate set on a
@@ -559,7 +563,8 @@ export function Mp4EventPlayer({
 
   return (
     <div data-vjs-player className={cn(className)}>
-      <div ref={videoRef} />
+      {/* h-full: in fill mode the player is 100% of this box. */}
+      <div ref={videoRef} className="h-full" />
     </div>
   );
 }

--- a/app/src/components/events/ZmsEventPlayer.tsx
+++ b/app/src/components/events/ZmsEventPlayer.tsx
@@ -603,6 +603,89 @@ export function ZmsEventPlayer({
     value: rate * 100,
   }));
 
+  // Transport and progress live in the controls card normally and as an
+  // overlay on the picture in fullscreen, where the full card would leave a
+  // landscape phone almost no room for the picture (refs #462).
+  const transport = (
+    <>
+      {/* Transport Controls */}
+      <div className="flex items-center justify-center gap-2">
+        {/* Jump to start */}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={goToStart}
+          disabled={currentFrame <= 1}
+          title={t('event_detail.go_to_start')}
+          data-testid="zms-go-to-start"
+        >
+          <SkipBack className="h-4 w-4" />
+        </Button>
+        {/* Seek back 5s */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={seekBack}
+          disabled={currentFrame <= 1}
+          title={t('event_detail.rewind')}
+          className="gap-1"
+          data-testid="zms-seek-back"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span className="text-xs">{t('event_detail.seek_back')}</span>
+        </Button>
+        {/* Play/Pause */}
+        <Button
+          variant="default"
+          size="icon"
+          onClick={togglePlayPause}
+          title={isPlaying ? t('event_detail.pause') : t('event_detail.play')}
+          data-testid="zms-play-pause"
+        >
+          {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+        </Button>
+        {/* Seek forward 5s */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={seekForward}
+          disabled={currentFrame >= totalFrames}
+          title={t('event_detail.fast_forward')}
+          className="gap-1"
+          data-testid="zms-seek-forward"
+        >
+          <span className="text-xs">{t('event_detail.seek_forward')}</span>
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+        {/* Jump to end */}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={goToEnd}
+          disabled={currentFrame >= totalFrames}
+          title={t('event_detail.go_to_end')}
+          data-testid="zms-go-to-end"
+        >
+          <SkipForward className="h-4 w-4" />
+        </Button>
+      </div>
+    </>
+  );
+  const progress = (
+    <>
+      {/* Progress Bar with Alarm Frames */}
+      <EventProgressBar
+        currentFrame={currentFrame}
+        totalFrames={totalFrames}
+        alarmFrames={alarmFramePositions}
+        onSeek={goToFrame}
+        duration={effectiveDuration}
+        onScrubStart={handleScrubStart}
+        onScrubEnd={handleScrubEnd}
+      />
+    </>
+  );
+
   return (
     <div className={cn(className, fullscreen && 'flex flex-col h-full min-h-0 gap-3')}>
       {/* Video Display */}
@@ -663,84 +746,23 @@ export function ZmsEventPlayer({
             </div>
           )}
         </div>
-        <ZoomControls zoomPan={zoomPan} className="bottom-2 left-2" />
+        <ZoomControls zoomPan={zoomPan} className={fullscreen ? 'bottom-28 left-2' : 'bottom-2 left-2'} />
+        {fullscreen && (
+          <div
+            className="absolute inset-x-0 bottom-0 z-20 space-y-2 bg-black/60 p-2 pb-[max(0.5rem,var(--sai-bottom,env(safe-area-inset-bottom)))] backdrop-blur-sm"
+            data-testid="zms-fullscreen-controls"
+          >
+            {transport}
+            {progress}
+          </div>
+        )}
       </Card>
 
       {/* Playback Controls */}
+      {!fullscreen && (
       <Card className="p-4 space-y-4 bg-card/95 backdrop-blur">
-        {/* Transport Controls */}
-        <div className="flex items-center justify-center gap-2">
-          {/* Jump to start */}
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={goToStart}
-            disabled={currentFrame <= 1}
-            title={t('event_detail.go_to_start')}
-            data-testid="zms-go-to-start"
-          >
-            <SkipBack className="h-4 w-4" />
-          </Button>
-          {/* Seek back 5s */}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={seekBack}
-            disabled={currentFrame <= 1}
-            title={t('event_detail.rewind')}
-            className="gap-1"
-            data-testid="zms-seek-back"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            <span className="text-xs">{t('event_detail.seek_back')}</span>
-          </Button>
-          {/* Play/Pause */}
-          <Button
-            variant="default"
-            size="icon"
-            onClick={togglePlayPause}
-            title={isPlaying ? t('event_detail.pause') : t('event_detail.play')}
-            data-testid="zms-play-pause"
-          >
-            {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
-          </Button>
-          {/* Seek forward 5s */}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={seekForward}
-            disabled={currentFrame >= totalFrames}
-            title={t('event_detail.fast_forward')}
-            className="gap-1"
-            data-testid="zms-seek-forward"
-          >
-            <span className="text-xs">{t('event_detail.seek_forward')}</span>
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-          {/* Jump to end */}
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={goToEnd}
-            disabled={currentFrame >= totalFrames}
-            title={t('event_detail.go_to_end')}
-            data-testid="zms-go-to-end"
-          >
-            <SkipForward className="h-4 w-4" />
-          </Button>
-        </div>
-
-        {/* Progress Bar with Alarm Frames */}
-        <EventProgressBar
-          currentFrame={currentFrame}
-          totalFrames={totalFrames}
-          alarmFrames={alarmFramePositions}
-          onSeek={goToFrame}
-          duration={effectiveDuration}
-          onScrubStart={handleScrubStart}
-          onScrubEnd={handleScrubEnd}
-        />
-
+        {transport}
+        {progress}
         {/* Speed Controls */}
         <div className="space-y-2">
           <label className="text-sm text-muted-foreground">
@@ -799,11 +821,12 @@ export function ZmsEventPlayer({
           </div>
         )}
       </Card>
+      )}
 
       {/* Max score frame. The first alarm frame is no longer shown here: the
           event frame carousel above the player already leads with it (refs
           #272), and the quick-jump button above still seeks to it. */}
-      {maxScoreFrameId && maxScoreFrameId !== alarmFrameId && (
+      {!fullscreen && maxScoreFrameId && maxScoreFrameId !== alarmFrameId && (
         <Card className="p-4 mt-4">
           <h3 className="text-sm font-semibold mb-3">{t('event_detail.max_score_frame')}</h3>
           <button

--- a/app/src/components/events/__tests__/ZmsEventPlayer.test.tsx
+++ b/app/src/components/events/__tests__/ZmsEventPlayer.test.tsx
@@ -145,12 +145,19 @@ describe('ZmsEventPlayer', () => {
   it('gives the picture the full height in fullscreen instead of a 16:9 box (refs #462)', () => {
     renderPlayer();
     expect(screen.getByTestId('zms-video-area').className).toContain('aspect-video');
+    expect(screen.queryByTestId('zms-fullscreen-controls')).toBeNull();
+    expect(screen.getByTestId('zms-speed-100')).toBeTruthy();
 
     cleanup();
     renderPlayer({ fullscreen: true });
     const area = screen.getByTestId('zms-video-area');
     expect(area.className).not.toContain('aspect-video');
     expect(area.className).toContain('h-full');
+    // Only transport and progress ride on the picture; the full card with
+    // speed presets would leave a landscape phone no room for it.
+    const overlay = screen.getByTestId('zms-fullscreen-controls');
+    expect(overlay.contains(screen.getByTestId('zms-play-pause'))).toBe(true);
+    expect(screen.queryByTestId('zms-speed-100')).toBeNull();
   });
 
   it('shows the ZMS notice only when playback fell back from video', () => {

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -669,10 +669,10 @@ export default function EventDetail() {
         ref={scrollerRef}
         data-testid="event-detail-scroller"
         className={cn(
-          'flex-1 flex flex-col items-center overflow-y-auto',
+          'flex-1 flex flex-col items-center',
           pageFullscreen
             ? 'min-h-0 overflow-hidden pt-[calc(var(--fullscreen-toolbar-h)+var(--sai-top,env(safe-area-inset-top)))] pb-[var(--sai-bottom,env(safe-area-inset-bottom))] pl-[var(--sai-left,env(safe-area-inset-left))] pr-[var(--sai-right,env(safe-area-inset-right))]'
-            : 'p-2 sm:p-3 md:p-4 bg-muted/10',
+            : 'overflow-y-auto p-2 sm:p-3 md:p-4 bg-muted/10',
           incomingSlide === 'left' && 'event-slide-left',
           incomingSlide === 'right' && 'event-slide-right',
         )}
@@ -786,6 +786,10 @@ export default function EventDetail() {
             </Card>
           )}
 
+          {/* Fullscreen is the player alone: the frames strip and the
+              metadata cards would put content below the fold behind the
+              overflow-hidden scroller (refs #462). */}
+          {!pageFullscreen && (<>
           {/* Significant frames for this event (#272). Sits between the player
               and the metadata so the frames read as a detail of what is on
               screen above, rather than pushing the player itself below the
@@ -904,6 +908,7 @@ export default function EventDetail() {
               </div>
             </Card>
           )}
+          </>)}
         </div>
       </div>
 


### PR DESCRIPTION
Refs #462. Follows #473, whose auto-merge landed before this commit was pushed.

Device pass on #473 showed MP4 blank after rotation and ZMS showing the bottom of the page. The app log has no fullscreen entries, so this came from code and a Chromium reproduction at 852x393.

**MP4 blank.** video.js's `aspectRatio` setter forces fluid mode, and the constructor applies it after `fill`, so the filled player never took effect on open. The player's mount div also had no height, so fill mode collapsed it. A filled player now carries no `aspectRatio`, the mode switch compares on `fluid()` rather than `fill()`, and the mount div is `h-full`.

**ZMS showing the bottom.** The whole controls card (transport, progress, speed presets, quick jumps, alarm count) sat under the picture in fullscreen; on a landscape phone it is taller than what is left, so the picture got the scraps. Fullscreen now overlays only transport and progress on the picture and hides the rest, along with the frames strip and metadata cards below the player. The scroller carried both `overflow-y-auto` and `overflow-hidden`; one rule per mode now.

## Acceptance

- With "Open events in fullscreen" on, or on rotating to landscape, an MP4 event fills the screen under the exit bar; a ZMS event shows the picture with a translucent transport-and-progress strip at the bottom and nothing else.
- Nothing below the player is mounted in fullscreen.

## Verification

- Chromium at 852x393 with the setting on: MP4 `.video-js` element carries `vjs-fill` and measures 852x365 under the 28px bar; ZMS picture 852x365 with a 98px overlay. Screenshots reviewed.
- `ZmsEventPlayer.test.tsx`: fullscreen shows the overlay with transport inside and no speed presets.
- `npm run gates`: 4422 tests, build, a11y, correctness, ratchet.

## Not verified on device

One rotation on the iPhone for an MP4 event and a ZMS event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsAyBwMenLNgG2Qz3oxZzB