### PR TITLE
feat(zoom): remove the 400% ceiling and fetch full-size frames while zoomed (refs #478)

### DIFF
--- a/app/src/components/events/EventFrameCarousel.tsx
+++ b/app/src/components/events/EventFrameCarousel.tsx
@@ -157,7 +157,7 @@ function EventFrameViewer({
 }) {
   // Destructured rather than kept whole: handing an object that still carries
   // the two refs to ZoomControls trips react-hooks/refs (rule 31).
-  const { ref, innerRef, ...controls } = useZoomPan({ maxScale: 4 });
+  const { ref, innerRef, ...controls } = useZoomPan();
 
   return (
     <Dialog open onOpenChange={onOpenChange}>

--- a/app/src/components/events/ZmsEventPlayer.tsx
+++ b/app/src/components/events/ZmsEventPlayer.tsx
@@ -594,7 +594,7 @@ export function ZmsEventPlayer({
 
   // Speed presets
   // Pinch-to-zoom and pan for ZMS image
-  const zoomPan = useZoomPan({ maxScale: 4 });
+  const zoomPan = useZoomPan();
 
   // Shared with the MP4 speed menu (EVENT_PLAYBACK_RATES). ZMS uses percentages,
   // so each multiplier maps to rate * 100.

--- a/app/src/components/monitors/LiveMonitorPlayer.tsx
+++ b/app/src/components/monitors/LiveMonitorPlayer.tsx
@@ -32,6 +32,7 @@ import {
   GO2RTC_FREEZE_RESET_S,
   GO2RTC_RETRY_INTERVAL_MIN,
 } from '../../lib/zmninja-ng-constants';
+import { ZMS_FULL_SCALE } from '../../lib/zm/zm-constants';
 import { Button } from '../ui/button';
 import { VideoOff, ShieldOff } from 'lucide-react';
 import { usePermissions } from '../../hooks/usePermissions';
@@ -151,6 +152,15 @@ export interface LiveMonitorPlayerProps {
    */
   bypassGo2rtcFailureCache?: boolean;
   /**
+   * Ask ZM for the monitor's own frame size instead of the profile's Stream
+   * scale, because the user has zoomed into this picture and magnifying a
+   * downscaled frame only magnifies the downscaling. Set while the view is
+   * zoomed and cleared on reset, which re-opens the stream each way. A no-op
+   * on the go2rtc/WebRTC path, which is already served at the camera's own
+   * resolution (refs #478).
+   */
+  fullResolution?: boolean;
+  /**
    * Ask ZM for a cheaper MJPEG stream than the owning profile normally wants
    * (All-mode "reduced" stream tuning, refs #337). The caller decides: the
    * montage page sets it while aggregating, the monitor detail view and Live
@@ -183,6 +193,7 @@ export function LiveMonitorPlayer({
   forceViewMode,
   bypassGo2rtcFailureCache = false,
   reduceStream = false,
+  fullResolution = false,
   paused = false,
 }: LiveMonitorPlayerProps) {
   const { t } = useTranslation();
@@ -525,8 +536,13 @@ export function LiveMonitorPlayer({
     monitorId: monitor.Id,
     serverId: monitor.ServerId,
     streamOptions: tunedStreamOptions(
-      { maxfps: rawSettings?.streamMaxFps, scale: rawSettings?.streamScale },
-      reduceStream,
+      {
+        maxfps: rawSettings?.streamMaxFps,
+        scale: fullResolution ? ZMS_FULL_SCALE : rawSettings?.streamScale,
+      },
+      // A zoomed picture is one the user is reading detail off, so the economy
+      // ceiling stands down for as long as they are in it.
+      reduceStream && !fullResolution,
     ),
     enabled: (effectiveStreamingMethod === 'mjpeg' || showMjpegPlaceholder) && !paused && !streamDenied,
     viewModeOverride: forceViewMode,

--- a/app/src/components/monitors/__tests__/LiveMonitorPlayer.test.tsx
+++ b/app/src/components/monitors/__tests__/LiveMonitorPlayer.test.tsx
@@ -339,6 +339,25 @@ describe('LiveMonitorPlayer reduced stream tuning', () => {
     });
   });
 
+  // Zoom magnifies the frame that arrived, so a 50% stream is 50% of the
+  // detail however far the user zooms in. The page asks for the full frame for
+  // as long as they stay zoomed (refs #478).
+  it('asks for the full-size frame while the view is zoomed', () => {
+    render(withQuery(<LiveMonitorPlayer monitor={monitor} profile={profile} fullResolution />));
+
+    expect(latestOptions()).toEqual({ maxfps: 10, scale: 100 });
+  });
+
+  it('gives the full-size frame back when the view zooms out', () => {
+    const { rerender } = render(
+      withQuery(<LiveMonitorPlayer monitor={monitor} profile={profile} fullResolution />),
+    );
+
+    rerender(withQuery(<LiveMonitorPlayer monitor={monitor} profile={profile} />));
+
+    expect(latestOptions()).toEqual({ maxfps: 10, scale: 50 });
+  });
+
   it('keeps a profile already streaming below the ceiling where it is', () => {
     seedProfiles([makeProfile('profile-1')], { settings: { 'profile-1': { streamMaxFps: 2, streamScale: 10 } } });
 

--- a/app/src/hooks/__tests__/useMonitorStream.frame.test.tsx
+++ b/app/src/hooks/__tests__/useMonitorStream.frame.test.tsx
@@ -23,6 +23,8 @@ import { useAuthStore } from '../../stores/auth';
 import { useSettingsStore, DEFAULT_SETTINGS } from '../../stores/settings';
 import type { Profile } from '../../api/types';
 import { asProfileId } from '../../api/types';
+import { ZM_INTEGRATION } from '../../lib/zmninja-ng-constants';
+import { log, LogLevel } from '../../lib/logger';
 
 vi.mock('../../lib/http', () => ({
   httpGet: vi.fn().mockResolvedValue({}),
@@ -175,6 +177,57 @@ describe('useMonitorStream: has-a-frame gate', () => {
     act(() => resumeCallback!());
 
     expect(result.current.hasFrame).toBe(false);
+  });
+
+  // Zooming in re-requests the stream at full size. The frame on screen is
+  // still a good one and the browser holds it until the new stream decodes, so
+  // withdrawing it here would blink the feed on every zoom (refs #478).
+  it('keeps the frame across a scale change until the new stream loads', async () => {
+    const view = renderHook(
+      ({ scale }: { scale: number }) =>
+        useMonitorStream({ monitorId: '1', streamOptions: { scale } }),
+      { initialProps: { scale: 50 } },
+    );
+    await waitFor(() => expect(view.result.current.imageSrc).not.toBe(''));
+    act(() => view.result.current.reportStreamLoad());
+    const halfSizeSrc = view.result.current.imageSrc;
+
+    view.rerender({ scale: 100 });
+    await waitFor(() => expect(view.result.current.imageSrc).not.toBe(halfSizeSrc));
+
+    expect(view.result.current.hasFrame).toBe(true);
+    // The restart is invisible on screen, so the log is where it is visible.
+    expect(log.monitor).toHaveBeenCalledWith(
+      expect.stringContaining('Stream scale changed from 50 to 100'),
+      LogLevel.INFO,
+      expect.objectContaining({ monitorId: '1', previousScale: 50, scale: 100 }),
+    );
+  });
+
+  // A held frame is a picture of the past. It stands in for a stream that is
+  // about to arrive, never for one that never does.
+  it('gives up the held frame when the re-requested stream never loads', async () => {
+    vi.useFakeTimers();
+    try {
+      const view = renderHook(
+        ({ scale }: { scale: number }) =>
+          useMonitorStream({ monitorId: '1', streamOptions: { scale } }),
+        { initialProps: { scale: 50 } },
+      );
+      await vi.waitFor(() => expect(view.result.current.imageSrc).not.toBe(''));
+      act(() => view.result.current.reportStreamLoad());
+
+      view.rerender({ scale: 100 });
+      await vi.waitFor(() => expect(view.result.current.hasFrame).toBe(true));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ZM_INTEGRATION.plannedRestartHoldMs + 100);
+      });
+
+      expect(view.result.current.hasFrame).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // Snapshot mode swaps the src on every refresh tick (a new cacheBuster), and

--- a/app/src/hooks/__tests__/useStreamLifecycle.test.ts
+++ b/app/src/hooks/__tests__/useStreamLifecycle.test.ts
@@ -912,6 +912,32 @@ describe('useStreamLifecycle', () => {
       expect(mockHttpGet).toHaveBeenCalledTimes(1);
     });
 
+    // A running nph-zms keeps sending the size it was started at, so a scale
+    // change is a different stream, not a different frame. Zooming in asks for
+    // the full-size one; without a fresh key the old process stays open on the
+    // server and the <img> reconnects to the small picture (refs #478).
+    it('quits and re-opens the stream when the requested scale changes', async () => {
+      const mediaRef = makeMediaRef();
+      const { result, rerender } = renderHook(
+        ({ scale }: { scale: number }) =>
+          useStreamLifecycle({ ...baseOptions, mediaRef, scale }),
+        { initialProps: { scale: 50 } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.connKey).not.toBe(0);
+      });
+      const halfSizeKey = result.current.connKey;
+      mockHttpGet.mockClear();
+
+      rerender({ scale: 100 });
+
+      await waitFor(() => {
+        expect(quitCountFor(halfSizeKey)).toBe(1);
+      });
+      expect(result.current.connKey).not.toBe(halfSizeKey);
+    });
+
     it('quits a multi-port stream on the port it was opened on', async () => {
       // useMonitorStream computes minStreamingPort from the view mode, so a
       // flip to snapshot drops it to undefined in the same commit as the flip.

--- a/app/src/hooks/__tests__/useStreamLifecycle.test.ts
+++ b/app/src/hooks/__tests__/useStreamLifecycle.test.ts
@@ -936,6 +936,12 @@ describe('useStreamLifecycle', () => {
         expect(quitCountFor(halfSizeKey)).toBe(1);
       });
       expect(result.current.connKey).not.toBe(halfSizeKey);
+      // The quit says why, so a log from a zoomed session is readable.
+      expect(mockLogFn).toHaveBeenCalledWith(
+        expect.stringContaining('CMD_QUIT on scale'),
+        expect.anything(),
+        expect.objectContaining({ connkey: halfSizeKey }),
+      );
     });
 
     it('quits a multi-port stream on the port it was opened on', async () => {

--- a/app/src/hooks/__tests__/useZoomPan.pinch.test.tsx
+++ b/app/src/hooks/__tests__/useZoomPan.pinch.test.tsx
@@ -19,7 +19,7 @@ describe('useZoomPan pinch limits', () => {
   it('never pinches below fit, and ignores a touch too small to be a pinch', () => {
     // No DOM needed: the config is built on the first render.
     function Harness() {
-      useZoomPan({ maxScale: 4 });
+      useZoomPan();
       return null;
     }
     render(<Harness />);

--- a/app/src/hooks/__tests__/useZoomPan.test.tsx
+++ b/app/src/hooks/__tests__/useZoomPan.test.tsx
@@ -7,7 +7,7 @@ import { useZoomPan } from '../useZoomPan';
 // handler can run end to end.
 let api: ReturnType<typeof useZoomPan>;
 function Harness() {
-  api = useZoomPan({ maxScale: 4 });
+  api = useZoomPan();
   return (
     <div ref={api.ref} data-testid="container">
       <div ref={api.innerRef} data-testid="inner" />
@@ -60,6 +60,16 @@ describe('useZoomPan keyboard pan', () => {
     // ArrowLeft pans left: content shifts right, so translateX increases.
     expect(translateX(inner.style.transform)).toBeGreaterThan(before);
     expect(ev.defaultPrevented).toBe(true);
+  });
+
+  // Old zmNinja zoomed as far as the user wanted; a 400% ceiling stopped this
+  // one well short of reading a plate or a face (refs #478).
+  it('keeps zooming in past the old 400% ceiling', () => {
+    mountZoomable();
+
+    for (let i = 0; i < 20; i++) act(() => api.zoomIn());
+
+    expect(api.scale).toBeGreaterThan(4);
   });
 
   it('does not intercept arrow keys when not zoomed', () => {

--- a/app/src/hooks/useMonitorStream.ts
+++ b/app/src/hooks/useMonitorStream.ts
@@ -158,7 +158,8 @@ export function useMonitorStream({
   // than kept as a boolean flag, so a src swap withdraws the frame during the
   // same render that introduces it. A flag reset from an effect would not: an
   // effect runs after paint, which is one painted frame of the old picture
-  // under the new connection. refs #352
+  // under the new connection. refs #352. The two deliberate exceptions, where
+  // the old picture is worth keeping, are read off the gate below.
   const [loadedSrc, setLoadedSrc] = useState<string>('');
 
   // Stream lifecycle: connKey generation, CMD_QUIT on regen/unmount, media abort
@@ -167,6 +168,33 @@ export function useMonitorStream({
   // is computed here because the lifecycle needs it too: a scale change has to
   // re-open the stream, not just re-point the <img> (refs #478).
   const effectiveScale = streamOptions.scale ?? bandwidth.imageScale;
+
+  // Set when a scale change re-opens the stream, so the frame gate below keeps
+  // the picture on screen until the replacement decodes (refs #478).
+  const [holdFrameForRestart, setHoldFrameForRestart] = useState(false);
+  const prevScaleRef = useRef(effectiveScale);
+  useEffect(() => {
+    const previous = prevScaleRef.current;
+    if (previous === effectiveScale) return;
+    prevScaleRef.current = effectiveScale;
+    setHoldFrameForRestart(true);
+    log.monitor(
+      `Stream scale changed from ${previous} to ${effectiveScale}, re-opening stream for monitor ${monitorId}`,
+      LogLevel.INFO,
+      { monitorId, previousScale: previous, scale: effectiveScale },
+    );
+  }, [effectiveScale, monitorId]);
+
+  // The hold is a courtesy, not a promise. A restart that never produces a
+  // frame must stop borrowing the old one, or a dead feed reads as a live one.
+  useEffect(() => {
+    if (!holdFrameForRestart) return;
+    const timer = setTimeout(
+      () => setHoldFrameForRestart(false),
+      ZM_INTEGRATION.plannedRestartHoldMs,
+    );
+    return () => clearTimeout(timer);
+  }, [holdFrameForRestart]);
 
   const { connKey, forceRegenerate, releaseConnection } = useStreamLifecycle({
     monitorId,
@@ -276,6 +304,7 @@ export function useMonitorStream({
     // Whatever the element is holding, it is not a frame off a working
     // connection any more.
     setLoadedSrc('');
+    setHoldFrameForRestart(false);
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);
       reconnectTimerRef.current = null;
@@ -306,6 +335,7 @@ export function useMonitorStream({
   const reportStreamLoad = () => {
     analysisFrames.applyOnStreamLoad();
     setLoadedSrc(imageSrc);
+    setHoldFrameForRestart(false);
     reconnectAttemptRef.current = 0;
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);
@@ -376,10 +406,16 @@ export function useMonitorStream({
   // matching the src there would blink the tile once per interval. A snapshot
   // that starts failing does fire `error`, which clears loadedSrc, so it still
   // falls back to the placeholder.
+  //
+  // A planned restart is the same case for the same reason: the scale changed,
+  // so the src changed, but the frame on screen came off a healthy stream and
+  // the browser holds it until the new one decodes. An error reconnect never
+  // holds - scheduleReconnect clears loadedSrc precisely because what the
+  // element is showing is no longer a frame off a working connection.
   const hasFrame =
     imageSrc !== '' &&
     loadedSrc !== '' &&
-    (effectiveViewMode === 'snapshot' || loadedSrc === imageSrc);
+    (effectiveViewMode === 'snapshot' || holdFrameForRestart || loadedSrc === imageSrc);
 
   return {
     streamUrl,

--- a/app/src/hooks/useMonitorStream.ts
+++ b/app/src/hooks/useMonitorStream.ts
@@ -162,6 +162,12 @@ export function useMonitorStream({
   const [loadedSrc, setLoadedSrc] = useState<string>('');
 
   // Stream lifecycle: connKey generation, CMD_QUIT on regen/unmount, media abort
+  // What this stream asks zms to resize to. The caller's own value wins over
+  // the bandwidth mode's, the same precedence the URL below spreads in, and it
+  // is computed here because the lifecycle needs it too: a scale change has to
+  // re-open the stream, not just re-point the <img> (refs #478).
+  const effectiveScale = streamOptions.scale ?? bandwidth.imageScale;
+
   const { connKey, forceRegenerate, releaseConnection } = useStreamLifecycle({
     monitorId,
     portalUrl: resolvedPortalUrl,
@@ -172,6 +178,7 @@ export function useMonitorStream({
     enabled,
     minStreamingPort: effectiveMinStreamingPort,
     profileId: currentProfile?.id,
+    scale: effectiveScale,
   });
 
   // Analysis frames: applied to the live connection by command, and re-applied
@@ -228,7 +235,7 @@ export function useMonitorStream({
     ? getStreamUrl(recordingUrl || currentProfile.cgiUrl, monitorId, {
       mode: effectiveViewMode === 'snapshot' && !snapshotSendsOneJpeg ? 'single' : 'jpeg',
       frames: snapshotSendsOneJpeg ? 1 : undefined,
-      scale: bandwidth.imageScale,
+      scale: effectiveScale,
       maxfps:
         effectiveViewMode === 'streaming'
           ? settings.streamMaxFps

--- a/app/src/hooks/useStreamLifecycle.ts
+++ b/app/src/hooks/useStreamLifecycle.ts
@@ -52,7 +52,7 @@ interface StreamCleanupParams {
 async function quitStreamForParams(
   params: StreamCleanupParams,
   logFn: ComponentLogger,
-  reason: 'unmount' | 'profile-switch' | 'disable' | 'view-mode',
+  reason: 'unmount' | 'profile-switch' | 'disable' | 'view-mode' | 'scale',
 ): Promise<void> {
   if (
     params.viewMode !== 'streaming' ||
@@ -367,7 +367,7 @@ export function useStreamLifecycle({
           minStreamingPort: prev.minStreamingPort,
         },
         logFn,
-        'view-mode',
+        prev.viewMode === viewMode ? 'scale' : 'view-mode',
       );
     }
 

--- a/app/src/hooks/useStreamLifecycle.ts
+++ b/app/src/hooks/useStreamLifecycle.ts
@@ -125,6 +125,14 @@ export interface UseStreamLifecycleOptions {
    * Omitted callers keep the pre-existing monitorId-only key.
    */
   profileId?: ProfileId | null;
+  /**
+   * The `scale=` this stream is currently asking zms for. A running nph-zms
+   * keeps sending the size it was started at, so a change here is a different
+   * stream and not a different frame: the old process is quit and a fresh key
+   * minted, exactly as a view-mode flip does. Zooming in raises it and the
+   * Stream scale setting changes it (refs #478).
+   */
+  scale?: number;
 }
 
 export interface UseStreamLifecycleReturn {
@@ -167,6 +175,7 @@ export function useStreamLifecycle({
   enabled = true,
   minStreamingPort,
   profileId,
+  scale,
 }: UseStreamLifecycleOptions): UseStreamLifecycleReturn {
   const regenerateConnKey = useMonitorStore((state) => state.regenerateConnKey);
 
@@ -316,11 +325,11 @@ export function useStreamLifecycle({
   // Both directions then mint a fresh key. The new mode needs one (a snapshot
   // URL carries a connkey too), and reusing the quit key risks colliding with
   // whatever server-side state it left behind.
-  const prevStreamIdentityRef = useRef({ viewMode, monitorId, enabled, minStreamingPort });
+  const prevStreamIdentityRef = useRef({ viewMode, monitorId, enabled, minStreamingPort, scale });
   useEffect(() => {
     const prev = prevStreamIdentityRef.current;
-    prevStreamIdentityRef.current = { viewMode, monitorId, enabled, minStreamingPort };
-    if (prev.viewMode === viewMode) return;
+    prevStreamIdentityRef.current = { viewMode, monitorId, enabled, minStreamingPort, scale };
+    if (prev.viewMode === viewMode && prev.scale === scale) return;
     // Only a mode flip on an otherwise unchanged stream is this effect's to
     // handle. When the enabled flag moved in the same commit, the disable
     // teardown or the regeneration effect already owns that key. When the
@@ -370,7 +379,7 @@ export function useStreamLifecycle({
     // current stream was opened on, even when it changes without a flip (the
     // force-disable-multi-port setting does that).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewMode, monitorId, enabled, minStreamingPort]);
+  }, [viewMode, monitorId, enabled, minStreamingPort, scale]);
 
   // Capture the live media element on every render. The unmount cleanup runs as
   // a passive effect, by which point React has already nulled mediaRef, so we

--- a/app/src/hooks/useZoomPan.ts
+++ b/app/src/hooks/useZoomPan.ts
@@ -9,7 +9,6 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { useGesture } from '@use-gesture/react';
 
 interface UseZoomPanOptions {
-  maxScale?: number;
   onSwipeLeft?: () => void;
   onSwipeRight?: () => void;
   swipeEnabled?: boolean;
@@ -28,7 +27,6 @@ const PAN_STEP = 80;
 const WHEEL_STEP = 0.15;
 
 export function useZoomPan({
-  maxScale = 4,
   onSwipeLeft,
   onSwipeRight,
   swipeEnabled = false,
@@ -74,7 +72,10 @@ export function useZoomPan({
     (s: number, x: number, y: number, animate: boolean) => {
       // Fit is the floor. Smaller than the frame is never a state a user
       // asked for, and it used to be one they could only leave by pinching out.
-      const scale = Math.max(1, Math.min(maxScale, s));
+      // There is no ceiling: a 400% one stopped short of the detail people
+      // zoom in for, and the picture's own resolution is the real limit
+      // (refs #478).
+      const scale = Math.max(1, s);
       let cx = x;
       let cy = y;
 
@@ -101,7 +102,7 @@ export function useZoomPan({
         el.style.willChange = identity ? '' : 'transform';
       }
     },
-    [maxScale],
+    [],
   );
 
   const syncState = useCallback(() => {
@@ -121,13 +122,13 @@ export function useZoomPan({
     const container = containerRef.current;
     if (!container) return;
     const { width, height } = container.getBoundingClientRect();
-    const newScale = Math.min(maxScale, cur.scale + ZOOM_STEP);
+    const newScale = cur.scale + ZOOM_STEP;
     const ratio = newScale / cur.scale;
     const cx = width / 2;
     const cy = height / 2;
     applyTransform(newScale, cx - (cx - cur.x) * ratio, cy - (cy - cur.y) * ratio, true);
     syncState();
-  }, [applyTransform, maxScale, syncState]);
+  }, [applyTransform, syncState]);
 
   const zoomOut = useCallback(() => {
     const cur = stateRef.current;
@@ -192,7 +193,7 @@ export function useZoomPan({
         // Scroll up zooms in, scroll down zooms out. Lower bound is 1 (fit) so
         // the wheel never shrinks the image below the container.
         const factor = dirY < 0 ? 1 + WHEEL_STEP : 1 - WHEEL_STEP;
-        const newScale = Math.max(1, Math.min(maxScale, cur.scale * factor));
+        const newScale = Math.max(1, cur.scale * factor);
         if (newScale === cur.scale) return;
         const ratio = newScale / cur.scale;
         applyTransform(newScale, fx - (fx - cur.x) * ratio, fy - (fy - cur.y) * ratio, false);
@@ -273,7 +274,7 @@ export function useZoomPan({
         // while unzoomed, the browser can claim a touch and cancel a pinch
         // half way through, and a half-recognised one used to land on that
         // floor - which is the "it zooms out the moment I touch a feed".
-        scaleBounds: { min: 1, max: maxScale },
+        scaleBounds: { min: 1, max: Infinity },
         // And it takes a real pinch to start one: a stray touch that the
         // browser is about to turn into a scroll should not nudge the zoom.
         threshold: 0.1,

--- a/app/src/lib/zm/zm-constants.ts
+++ b/app/src/lib/zm/zm-constants.ts
@@ -127,6 +127,13 @@ export const ZMS_MODES = {
 export const ZMS_FRAMES_PARAM_MIN_VERSION = '1.37.61';
 
 /**
+ * `scale=` value that asks zms for the monitor's own frame size. Anything
+ * lower is ZoneMinder resizing before it sends, which costs detail the client
+ * cannot get back by magnifying (refs #478).
+ */
+export const ZMS_FULL_SCALE = 100;
+
+/**
  * Monitor `Decoding` value that keeps zmc decoding whether or not anyone is
  * watching. The others ('None', 'Ondemand', 'KeyFrames', 'KeyFrames+Ondemand')
  * decode on demand or not at all. Absent before ZM 1.37.

--- a/app/src/lib/zmninja-ng-constants.ts
+++ b/app/src/lib/zmninja-ng-constants.ts
@@ -79,6 +79,12 @@ export const ZM_INTEGRATION = {
   mjpegEarlyRetryWindowMs: 12000,
   mjpegEarlyRetryDelayMs: 2000,
 
+  // How long a planned restart (the requested scale changed, e.g. the user
+  // zoomed in) may keep showing the frame already on screen while the new
+  // stream connects. Past it the tile admits it is waiting rather than keep
+  // presenting an old picture as a live one.
+  plannedRestartHoldMs: 5000,
+
   // Grace delay before a scheduled CMD_QUIT fires. Lets React StrictMode's
   // dev double-mount cancel the quit instead of killing a stream the
   // surviving mount is still using. See lib/zm/zms-quit.ts.

--- a/app/src/pages/EventDetail.tsx
+++ b/app/src/pages/EventDetail.tsx
@@ -329,7 +329,7 @@ export default function EventDetail() {
   const [showScrollPad, toggleScrollPad] = useScrollPad();
 
   // Pinch-to-zoom and pan for event video/image
-  const zoomPan = useZoomPan({ maxScale: 4 });
+  const zoomPan = useZoomPan();
 
   // Zoom belongs to the frame the user zoomed into, not to the page. Stepping
   // to another event keeps this component mounted (the route element is not

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -157,7 +157,6 @@ export default function MonitorDetail() {
 
   // Pinch-to-zoom and pan (zooms around focal point, pan when zoomed, swipe when not)
   const zoomPan = useZoomPan({
-    maxScale: 4,
     swipeEnabled: !!enabledMonitors && enabledMonitors.length > 1,
     onSwipeLeft,
     onSwipeRight,

--- a/app/src/pages/MonitorDetail.tsx
+++ b/app/src/pages/MonitorDetail.tsx
@@ -459,6 +459,9 @@ export default function MonitorDetail() {
               bypassGo2rtcFailureCache
               muted={isMuted}
               onMutedChange={setMuted}
+              // Zooming asks ZM for the full-size frame; resetting hands the
+              // saving back. Both re-open the stream (refs #478).
+              fullResolution={zoomPan.isZoomed}
             />
             <ZoneOverlay
               zones={zones}

--- a/docs/developer-guide/11-application-lifecycle.rst
+++ b/docs/developer-guide/11-application-lifecycle.rst
@@ -241,7 +241,12 @@ values are given.
    the ``useStreamLifecycle`` hook it composes) monitor their own health. If a
    stream dies, they reconnect with a fresh connection key (``connkey``),
    releasing the dead one with ``ZMS_COMMANDS.cmdQuit`` first so ZMS does not
-   leak the old process.
+   leak the old process. The requested ``scale`` is part of that connection's
+   identity: a running nph-zms keeps sending the size it started at, so
+   changing the scale quits the key and mints a new one rather than re-pointing
+   the ``<img>``. Zooming into a feed does exactly that, asking for
+   ``ZMS_FULL_SCALE`` while zoomed and dropping back to the profile's Stream
+   scale on reset.
 5. **WebSocket Keepalive & Reconnect**: The notification WebSocket
    (``services/notifications.ts``) sends a version-request ping every
    ``wsKeepaliveInterval`` (60s / 120s) to maintain the connection. On

--- a/docs/developer-guide/11-application-lifecycle.rst
+++ b/docs/developer-guide/11-application-lifecycle.rst
@@ -246,7 +246,11 @@ values are given.
    changing the scale quits the key and mints a new one rather than re-pointing
    the ``<img>``. Zooming into a feed does exactly that, asking for
    ``ZMS_FULL_SCALE`` while zoomed and dropping back to the profile's Stream
-   scale on reset.
+   scale on reset. The frame gate in ``useMonitorStream`` holds the picture
+   already on screen across that swap, the same way it does across a snapshot
+   refresh, and gives up after ``plannedRestartHoldMs`` so a restart that never
+   produces a frame stops standing in for a live one. Both the scale change and
+   the CMD_QUIT it triggers are logged.
 5. **WebSocket Keepalive & Reconnect**: The notification WebSocket
    (``services/notifications.ts``) sends a version-request ping every
    ``wsKeepaliveInterval`` (60s / 120s) to maintain the connection. On

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -1848,7 +1848,7 @@ Click-and-hold repeats the action on every button.
 
 .. code:: tsx
 
-   const zoomPan = useZoomPan({ maxScale: 4 });
+   const zoomPan = useZoomPan();
 
    <div ref={zoomPan.ref}>
      <div ref={zoomPan.innerRef}>{/* zoomable content */}</div>

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -80,6 +80,12 @@ Once zoomed in, you can pan the view in several ways:
 
 Press the reset button to return to the full, unzoomed image.
 
+Zoom has no upper limit, but detail does. The app magnifies the picture it was
+sent, so how far you can usefully zoom depends on the resolution that arrives.
+MJPEG streams are scaled down before they leave ZoneMinder: raise **Stream
+scale** under Live Streaming in {doc}`settings` to 100% for the full frame, at
+the cost of bandwidth. Low bandwidth mode halves it again.
+
 #### Per-Monitor Override
 
 You can force MJPEG for individual monitors via the monitor's Settings dialog (Video tab). When Go2RTC is enabled for a monitor, a toggle appears to turn it off for that monitor only. See {doc}`settings` for details.

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -84,8 +84,10 @@ Zoom has no upper limit, and the live view fetches the detail to go with it.
 MJPEG streams are normally scaled down before they leave ZoneMinder (**Stream
 scale** under Live Streaming in {doc}`settings`, 50% by default). As soon as
 you zoom in, the app asks for the monitor's full-size frames instead, and goes
-back to your usual scale when you reset the zoom. The picture stutters for a
-moment each way while the stream restarts.
+back to your usual scale when you reset the zoom. The last frame stays on
+screen while the new stream connects, so the switch is invisible unless the
+replacement takes more than a few seconds, at which point the tile says it is
+connecting rather than keep showing an old picture.
 
 Cameras streaming through Go2RTC already arrive at their own resolution, so
 nothing changes there. Recorded video is unscaled too, so zooming into an event

--- a/docs/user-guide/monitors.md
+++ b/docs/user-guide/monitors.md
@@ -80,11 +80,16 @@ Once zoomed in, you can pan the view in several ways:
 
 Press the reset button to return to the full, unzoomed image.
 
-Zoom has no upper limit, but detail does. The app magnifies the picture it was
-sent, so how far you can usefully zoom depends on the resolution that arrives.
-MJPEG streams are scaled down before they leave ZoneMinder: raise **Stream
-scale** under Live Streaming in {doc}`settings` to 100% for the full frame, at
-the cost of bandwidth. Low bandwidth mode halves it again.
+Zoom has no upper limit, and the live view fetches the detail to go with it.
+MJPEG streams are normally scaled down before they leave ZoneMinder (**Stream
+scale** under Live Streaming in {doc}`settings`, 50% by default). As soon as
+you zoom in, the app asks for the monitor's full-size frames instead, and goes
+back to your usual scale when you reset the zoom. The picture stutters for a
+moment each way while the stream restarts.
+
+Cameras streaming through Go2RTC already arrive at their own resolution, so
+nothing changes there. Recorded video is unscaled too, so zooming into an event
+needs no such switch.
 
 #### Per-Monitor Override
 


### PR DESCRIPTION
Refs #478.

## Acceptance

From the issue:

> it does not look like it can zoom like the old zmninja which could really zoom into detail

> compare the old one to the new one and the new one stops zoom at 400%

> to zoom like the old one

Zoom has no upper stop, and on a live feed the app now fetches the detail to go with it.

## Two commits

**Remove the ceiling.** `useZoomPan` clamped every path to `maxScale`, which all four call sites set to 4. The option is gone, along with the clamp in the transform, the zoom-in step, the wheel handler, and the pinch `scaleBounds` max. The floor stays at fit, which is what keeps a half-recognised pinch from leaving the picture smaller than its frame. Montage keeps its own 3x pinch limit: that gesture scales the tile grid, not a picture.

**Fetch the detail.** MJPEG streams ask ZoneMinder to resize before sending, 50% by default and 25% in low bandwidth mode, so zoom was magnifying the downscaling as much as the picture. Monitor Detail now asks for `scale=100` while the view is zoomed and drops back to the profile's own scale on reset.

## How the re-request works

The scale is part of the stream's identity in `useStreamLifecycle`. A running nph-zms keeps sending the size it started at, so a scale change quits that connkey and mints a fresh one, the same treatment a view-mode flip already gets. Re-pointing the `<img>` alone would leave the old process streaming the old size and orphan its key.

That fixes the Stream scale setting itself as a side effect. Changing it mid-stream previously rewrote the URL while the old process kept running.

## What playback needed

Nothing. ZMS event playback already requests `scale=100`, and MP4/HLS serve the recorded file at its stored resolution, with no scale parameter to raise. Go2RTC live tiles come from the camera's own stream, so the flag is a documented no-op there.

## Verification

- `npm run gates`: 4427 unit tests pass, build clean, three lints clean.
- `node scripts/proven-red.mjs` on both commits: the new tests fail on the pre-change code each time.
- Device passes not run: manual-only. Worth a look on a phone, since each zoom in and reset restarts the MJPEG stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2FRSC7fub7pMeUxSK4MP6