### PR TITLE
Order both language pickers, English first

### DIFF
--- a/.claude/skills/add-language/SKILL.md
+++ b/.claude/skills/add-language/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-language
-description: Use when adding a new interface language (locale) to the app, or when asked to translate the UI into another language. Covers the translation file, the two language pickers, the i18n resources, and the user doc that names the available languages.
+description: Use when adding a new interface language (locale) to the app, or when asked to translate the UI into another language. Covers the translation file, the i18n resources, the plural forms the language needs, and the user doc that names the available languages.
 ---
 
 # Adding a new interface language
 
-The app bundles translations at build time. Adding a locale means touching five
+The app bundles translations at build time. Adding a locale means touching three
 code locations plus two prose locations. Miss any one and the failure is silent:
 i18next falls back to English mid-screen, or the new locale ships with no
 key-parity coverage.
@@ -44,47 +44,48 @@ ls app/src/locales
 
 Use the same string `{Name}` in all of them. Language names are not translated.
 
-## 4. Register the locale in i18n
+## 4. Register the locale
 
-In `app/src/i18n.ts`, add the import alongside the others and the entry in
-`resources`:
+In `app/src/locales/resources.ts`, add the import alongside the others and the
+entry in `LANGUAGE_RESOURCES`:
 
 ```typescript
-import {code}Translation from './locales/{code}/translation.json';
+import {code}Translation from './{code}/translation.json';
 ```
 
 ```typescript
-resources: {
+export const LANGUAGE_RESOURCES = {
   // ...
   {code}: { translation: {code}Translation },
-},
+};
 ```
 
-## 5. Update both language pickers
+Both pickers and i18next read this map, so nothing else registers a locale.
 
-There are two, and they carry separate hardcoded lists:
+## 5. Nothing to do for the pickers
 
-- `app/src/components/settings/AppearanceSection.tsx` — Settings → Appearance.
-  Add a `SelectItem`:
-
-  ```tsx
-  <SelectItem value="{code}" data-testid="settings-language-option-{code}">{t('languages.{code}')}</SelectItem>
-  ```
-
-- `app/src/components/layout/LanguageSwitcher.tsx` — the globe dropdown in the
-  sidebar. Add to the `languages` array:
-
-  ```tsx
-  { code: '{code}', label: t('languages.{code}') },
-  ```
-
-Updating only the first is the common miss: the language works in Settings and
-is absent from the sidebar.
+Both of them, Settings → Appearance and the sidebar globe dropdown, render
+`useLanguageOptions` (`app/src/hooks/useLanguageOptions.ts`), which reads the
+codes registered in step 4 and orders them English first, then by label. The
+order is covered by `app/src/components/layout/__tests__/LanguageSwitcher.test.tsx`,
+which pins the expected sequence, so add the new code there.
 
 ## 6. Update the user doc
 
 `docs/user-guide/settings.md`, Appearance table, Language row, names the
 available languages in English. Add the new one.
+
+## 7. Add the plural forms the language needs
+
+English declares `_one` and `_other`. A language with more plural categories
+needs the rest, or i18next finds no key for those counts and silently renders
+English: Russian showed "2 monitors" until `_few` and `_many` were added. The
+parity test checks every category `Intl.PluralRules` reports for counts up to
+100, so it tells you which keys are missing.
+
+```bash
+node -e "console.log(new Intl.PluralRules('{code}').resolvedOptions().pluralCategories)"
+```
 
 ## Nothing to do for dates, the assistant, or the parity test
 
@@ -119,7 +120,7 @@ change the visible text.
 - [ ] `app/src/locales/{code}/translation.json` created and fully translated
 - [ ] `languages.{code}` added to every translation file under `app/src/locales/`
 - [ ] `app/src/i18n.ts` import and `resources` entry
-- [ ] `app/src/components/settings/AppearanceSection.tsx` `SelectItem`
-- [ ] `app/src/components/layout/LanguageSwitcher.tsx` array entry
+- [ ] expected order updated in `LanguageSwitcher.test.tsx`
+- [ ] plural forms for every category the language needs
 - [ ] `docs/user-guide/settings.md` Language row
 - [ ] `npm test`, `npx tsc -b`, `npm run build`, `npm run test:e2e -- settings.feature`

--- a/AGENTS.project.md
+++ b/AGENTS.project.md
@@ -97,9 +97,9 @@ Gate: review.
 
 ### Localization
 Owns: all user-facing text.
-Path: locale files under `app/src/locales/` (de, en, es, fr, it, zh); every locale updates together; both pickers list every locale.
-Never: hardcoded user-facing strings.
-Gate: `app/src/locales/__tests__/translation-keys.test.ts`; review for hardcoded strings.
+Path: locale files under `app/src/locales/` (de, en, es, fr, it, ru, zh); every locale updates together; both pickers read `useLanguageOptions`, which lists the codes in `app/src/locales/resources.ts` with English first.
+Never: hardcoded user-facing strings; hand-written locale lists in a picker.
+Gate: `app/src/locales/__tests__/translation-keys.test.ts`; `app/src/components/layout/__tests__/LanguageSwitcher.test.tsx` (picker order); review for hardcoded strings.
 
 ### Native
 Owns: everything touching Capacitor or platform APIs.

--- a/app/src/components/layout/LanguageSwitcher.tsx
+++ b/app/src/components/layout/LanguageSwitcher.tsx
@@ -13,19 +13,12 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { cn } from '../../lib/utils';
+import { useLanguageOptions } from '../../hooks/useLanguageOptions';
 
 export function LanguageSwitcher({ collapsed = false }: { collapsed?: boolean }) {
   const { i18n, t } = useTranslation();
 
-  const languages = [
-    { code: 'en', label: t('languages.en') },
-    { code: 'es', label: t('languages.es') },
-    { code: 'fr', label: t('languages.fr') },
-    { code: 'de', label: t('languages.de') },
-    { code: 'it', label: t('languages.it') },
-    { code: 'zh', label: t('languages.zh') },
-    { code: 'ru', label: t('languages.ru') },
-  ];
+  const languages = useLanguageOptions();
 
   return (
     <DropdownMenu>

--- a/app/src/components/layout/__tests__/LanguageSwitcher.test.tsx
+++ b/app/src/components/layout/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Both language pickers list the same order: English first, then the rest by
+ * the name each language uses for itself. The lists used to be hand-written in
+ * two components, so a new locale landed wherever it was appended.
+ *
+ * The dropdown primitives are stubbed to plain elements, as in
+ * profile-switcher.test.tsx: jsdom cannot drive Radix's pointer-capture
+ * sequence, and the order under test is in the item list, not the popover.
+ */
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>,
+}));
+
+import '../../../i18n';
+import { LanguageSwitcher } from '../LanguageSwitcher';
+
+/** English, Deutsch, Español, Français, Italiano, Русский, 中文. */
+const EXPECTED = ['en', 'de', 'es', 'fr', 'it', 'ru', 'zh'];
+
+describe('LanguageSwitcher', () => {
+  it('lists English first, then the other languages by their own name', () => {
+    render(<LanguageSwitcher />);
+
+    const codes = screen
+      .getAllByTestId(/^language-option-/)
+      .map((item) => item.getAttribute('data-testid')?.replace('language-option-', ''));
+
+    expect(codes).toEqual(EXPECTED);
+  });
+});

--- a/app/src/components/settings/AppearanceSection.tsx
+++ b/app/src/components/settings/AppearanceSection.tsx
@@ -28,6 +28,7 @@ import { cn } from '../../lib/utils';
 import { validateFormatString } from '../../lib/format-date-time';
 import { Platform } from '../../lib/platform';
 import { STORAGE_KEYS } from '../../lib/zmninja-ng-constants';
+import { useLanguageOptions } from '../../hooks/useLanguageOptions';
 import type {
   ProfileSettings,
   DateFormatPreset,
@@ -94,6 +95,7 @@ export interface AppearanceSectionProps {
 
 export function AppearanceSection({ settings, update }: AppearanceSectionProps) {
   const { t, i18n } = useTranslation();
+  const languages = useLanguageOptions();
 
   const [customDateDraft, setCustomDateDraft] = useState(settings.customDateFormat);
   const [customTimeDraft, setCustomTimeDraft] = useState(settings.customTimeFormat);
@@ -115,13 +117,15 @@ export function AppearanceSection({ settings, update }: AppearanceSectionProps) 
               <SelectValue placeholder={t('settings.select_language')} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="en" data-testid="settings-language-option-en">{t('languages.en')}</SelectItem>
-              <SelectItem value="es" data-testid="settings-language-option-es">{t('languages.es')}</SelectItem>
-              <SelectItem value="fr" data-testid="settings-language-option-fr">{t('languages.fr')}</SelectItem>
-              <SelectItem value="de" data-testid="settings-language-option-de">{t('languages.de')}</SelectItem>
-              <SelectItem value="it" data-testid="settings-language-option-it">{t('languages.it')}</SelectItem>
-              <SelectItem value="zh" data-testid="settings-language-option-zh">{t('languages.zh')}</SelectItem>
-              <SelectItem value="ru" data-testid="settings-language-option-ru">{t('languages.ru')}</SelectItem>
+              {languages.map((language) => (
+                <SelectItem
+                  key={language.code}
+                  value={language.code}
+                  data-testid={`settings-language-option-${language.code}`}
+                >
+                  {language.label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </SettingsRow>

--- a/app/src/hooks/useLanguageOptions.ts
+++ b/app/src/hooks/useLanguageOptions.ts
@@ -1,0 +1,29 @@
+/**
+ * The language list both pickers render.
+ *
+ * Codes come from the bundled locale map rather than a hand-written array, so
+ * registering a locale in locales/resources.ts is all it takes to offer it in
+ * the sidebar switcher and in Settings. English leads because it is the
+ * fallback locale every reader can retreat to; the rest sort by the name each
+ * language uses for itself, which is the label on screen.
+ */
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LANGUAGE_CODES } from '../locales/resources';
+
+export type LanguageOption = { code: string; label: string };
+
+export function useLanguageOptions(): LanguageOption[] {
+  const { t } = useTranslation();
+
+  return useMemo(() => {
+    const options = LANGUAGE_CODES.map((code) => ({ code, label: t(`languages.${code}`) }));
+    return options.sort((a, b) => {
+      if (a.code === b.code) return 0;
+      if (a.code === 'en') return -1;
+      if (b.code === 'en') return 1;
+      return a.label.localeCompare(b.label);
+    });
+  }, [t]);
+}

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -2,14 +2,8 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-// Import translation files directly for bundling
-import enTranslation from './locales/en/translation.json';
-import deTranslation from './locales/de/translation.json';
-import esTranslation from './locales/es/translation.json';
-import frTranslation from './locales/fr/translation.json';
-import itTranslation from './locales/it/translation.json';
-import zhTranslation from './locales/zh/translation.json';
-import ruTranslation from './locales/ru/translation.json';
+// Translations are bundled rather than fetched; the map lives in locales/resources.ts
+import { LANGUAGE_RESOURCES } from './locales/resources';
 
 i18n
   // detect user language
@@ -23,16 +17,7 @@ i18n
     fallbackLng: 'en',
     debug: import.meta.env.DEV,
 
-    // Bundle translations inline - eliminates HTTP requests
-    resources: {
-      en: { translation: enTranslation },
-      de: { translation: deTranslation },
-      es: { translation: esTranslation },
-      fr: { translation: frTranslation },
-      it: { translation: itTranslation },
-      zh: { translation: zhTranslation },
-      ru: { translation: ruTranslation },
-    },
+    resources: LANGUAGE_RESOURCES,
 
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default

--- a/app/src/locales/resources.ts
+++ b/app/src/locales/resources.ts
@@ -1,0 +1,26 @@
+/**
+ * The bundled locales, in one place so nothing has to re-list them.
+ *
+ * i18n.ts feeds this to i18next, and useLanguageOptions reads the codes for
+ * the two language pickers. Adding a language means adding it here and
+ * nowhere else in the React code.
+ */
+import enTranslation from './en/translation.json';
+import deTranslation from './de/translation.json';
+import esTranslation from './es/translation.json';
+import frTranslation from './fr/translation.json';
+import itTranslation from './it/translation.json';
+import ruTranslation from './ru/translation.json';
+import zhTranslation from './zh/translation.json';
+
+export const LANGUAGE_RESOURCES = {
+  en: { translation: enTranslation },
+  de: { translation: deTranslation },
+  es: { translation: esTranslation },
+  fr: { translation: frTranslation },
+  it: { translation: itTranslation },
+  ru: { translation: ruTranslation },
+  zh: { translation: zhTranslation },
+};
+
+export const LANGUAGE_CODES = Object.keys(LANGUAGE_RESOURCES);

--- a/app/tests/steps/events.steps.ts
+++ b/app/tests/steps/events.steps.ts
@@ -669,9 +669,9 @@ Then('any relative time labels in the list read as a duration', async ({ page })
 
   // Assert the first chip is visible and shows a recognisable relative-time string.
   // Pattern covers Intl.RelativeTimeFormat narrow output ("ago", "vor", "hace", "il y a", "前")
-  // and the app's now translations across all 6 supported languages:
-  // en: "now", de: "jetzt", es: "ahora", fr: "maintenant", it: "ora", zh: "现在".
-  const relativeTimePattern = /(ago|vor|hace|il y a|ora|前|now|jetzt|ahora|maintenant|现在)/i;
+  // and the app's now translations across all 7 supported languages:
+  // en: "now", de: "jetzt", es: "ahora", fr: "maintenant", it: "ora", ru: "сейчас", zh: "现在".
+  const relativeTimePattern = /(ago|vor|hace|il y a|ora|назад|сейчас|前|now|jetzt|ahora|maintenant|现在)/i;
   const firstChip = chips.first();
   await expect(firstChip).toBeVisible();
   const text = await firstChip.innerText();

--- a/docs/developer-guide/10-key-libraries.rst
+++ b/docs/developer-guide/10-key-libraries.rst
@@ -218,9 +218,15 @@ i18next & react-i18next
 
 Translations reach components through ``const { t } = useTranslation()``, and
 the strings live in one JSON file per language under ``src/locales/``. No
-hardcoded user-facing strings, and all six languages (en, de, es, fr, it, zh) are
-updated in the same commit; that is the Localization contract, and
+hardcoded user-facing strings, and all seven languages (en, de, es, fr, it, ru,
+zh) are updated in the same commit; that is the Localization contract, and
 :doc:`09-contributing` explains why a missing key does not look like a bug.
+
+Neither language picker keeps its own list. ``hooks/useLanguageOptions.ts``
+reads the codes in ``locales/resources.ts``, labels each with the name that
+language uses for itself, and returns English first with the rest sorted by
+label. Adding the locale to that map is therefore the only edit a new
+language needs on the React side.
 
 Constants
 ---------

--- a/docs/developer-guide/12-shared-services-and-components.rst
+++ b/docs/developer-guide/12-shared-services-and-components.rst
@@ -1539,7 +1539,7 @@ partial React Query refetch would leave a dead stream dead.
 
 The icon gets ``animate-spin`` while ``isLoading``, and the button is disabled
 while loading or when ``disabled`` is set. ``label`` defaults to the
-``common.refresh`` translation key (present in en, de, es, fr, it, zh) and doubles
+``common.refresh`` translation key (present in en, de, es, fr, it, ru, zh) and doubles
 as the ``title`` and ``aria-label`` when no explicit ``aria-label`` is passed.
 ``showLabel`` (``'always'``, ``'never'``, ``'sm-and-up'``) defaults to
 ``'never'``, so pages render it icon-only. The default ``data-testid`` is
@@ -2014,7 +2014,8 @@ navigation, reorder mode, and user controls live. The mobile menu button sits
 on the left so it matches the side the drawer opens from. ``LanguageSwitcher``
 is a self-contained dropdown in the ``SidebarContent`` footer, next to the
 theme and lock controls, because language is a set-once control that does not
-belong in the header.
+belong in the header. Its entries come from ``useLanguageOptions``, the same
+hook the Settings picker uses, so both list the languages in one order.
 
 Sidebar order is per profile. An edit mode (the pencil icon) lets a user drag
 menu items; the order is saved to ``ProfileSettings.sidebarNavOrder`` as an


### PR DESCRIPTION
## Description

The sidebar globe dropdown and the Settings → Appearance picker each carried their own hand-written list of locales, so a new language landed wherever it was appended and the two lists could drift apart. Russian sat at the bottom of both.

Both pickers now render `useLanguageOptions`, which reads the codes from `app/src/locales/resources.ts` and returns English first, then the rest sorted by the name each language uses for itself: English, Deutsch, Español, Français, Italiano, Русский, 中文.

`resources.ts` is new and holds the bundled-locale map that `i18n.ts` used to declare inline, so one map now feeds both i18next and the pickers.

Docs moved with it: the Localization contract, the i18n section of the key-libraries guide, the shared-components note on the switcher, and the add-language skill, which loses its "update both pickers" step and gains a step on plural forms.

Refs #484

## Acceptance

> Both language pickers list every bundled locale in the same order, English first and the rest by their own name, and adding a locale needs no picker edit.

- [x] Sidebar switcher and Settings picker render the same ordered list
- [x] Order pinned by `LanguageSwitcher.test.tsx`, which fails on the old hand-written order
- [x] Adding a locale means one entry in `locales/resources.ts`

## Checks run

- `npm run gates` — 4444 unit tests, build with `tsc -b`, three blocking lints
- `npm run test:e2e -- settings.feature` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153CxEJqey6xuJVZ3rqKhDG